### PR TITLE
add subagent follow-up inputs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Terminal-based AI chat client with tool execution, streaming responses, and risk
 - **Mode adapters** (`src/core/modes/`): ModeAdapter interface and RPC stub for alternate front-ends
 - **ToolCatalog** (`src/core/tools/catalog.ts`): Builds the internal tool registry
 - **ToolExecutionBackend** (`src/core/tools/execution_backend.ts`): Execution backend for filesystem/process tools (local host or docker sandbox)
-- **ToolRegistry** (`src/core/tools/registry.ts`): Tool registry type used by ToolCatalog for main-session (bash, write, edit, spawn_agent, wait_for_agent, terminate_agent) and sub-agent (emit_output plus allowed tools) registries
+- **ToolRegistry** (`src/core/tools/registry.ts`): Tool registry type used by ToolCatalog for main-session (bash, write, edit, spawn_agent, send_input_to_agent, wait_for_agent, terminate_agent) and sub-agent (emit_output plus allowed tools) registries
 - **TUI**: Terminal rendering via `@mariozechner/pi-tui` with components in `src/tui/ui/`
 - **Chat UI models** (`src/tui/ui/chat_message_model.ts`): Typed message models and rendering glue for UI components
 - **Tool output layout** (`src/tui/ui/tool_output.ts`): Shared compact/expanded tool UI layout and header building
@@ -54,7 +54,7 @@ Terminal-based AI chat client with tool execution, streaming responses, and risk
   - `auth/codex_prompt.ts` - Codex system prompt handling
   - `events/` - Core event protocol types and serialization
   - `session/` - Turn processing, streaming, and tool dispatch
-  - `tools/` - Tool definitions (bash, write, edit, spawn_agent, wait_for_agent, terminate_agent, emit_output, web_search, web_fetch) plus read/list/grep helpers not wired into the default registry
+  - `tools/` - Tool definitions (bash, write, edit, spawn_agent, send_input_to_agent, wait_for_agent, terminate_agent, emit_output, web_search, web_fetch) plus read/list/grep helpers not wired into the default registry
   - `tools/execution_backend.ts` - Local and sandbox tool backends
   - `tools/sandbox/docker_sandbox.ts` - Docker sandbox runner
   - `subagents/` - Default subagent prompt and runner
@@ -91,15 +91,16 @@ Terminal-based AI chat client with tool execution, streaming responses, and risk
 
 ## Tool system
 
-| Tool              | Purpose                      | Risk requirement                               |
-| ----------------- | ---------------------------- | ---------------------------------------------- |
-| `bash`            | Shell execution              | `read-only` for reads, `read-write` for writes |
-| `write`           | Create/overwrite files       | `read-write`                                   |
-| `edit`            | Replace exact text in files  | `read-write`                                   |
-| `spawn_agent`     | Start a background subagent  | `read-only` or `read-write`                    |
-| `wait_for_agent`  | Await subagent completion    | `read-only` or `read-write`                    |
-| `terminate_agent` | Stop a running subagent      | `read-only` or `read-write`                    |
-| `emit_output`     | Subagent-only output to main | `read-only` or `read-write`                    |
+| Tool                 | Purpose                        | Risk requirement                               |
+| -------------------- | ------------------------------ | ---------------------------------------------- |
+| `bash`               | Shell execution                | `read-only` for reads, `read-write` for writes |
+| `write`              | Create/overwrite files         | `read-write`                                   |
+| `edit`               | Replace exact text in files    | `read-write`                                   |
+| `spawn_agent`        | Start a background subagent    | `read-only` or `read-write`                    |
+| `send_input_to_agent` | Send input to an idle subagent | `read-only` or `read-write`                    |
+| `wait_for_agent`     | Await subagent completion      | `read-only` or `read-write`                    |
+| `terminate_agent`    | Stop a running subagent        | `read-only` or `read-write`                    |
+| `emit_output`        | Subagent-only output to main   | `read-only` or `read-write`                    |
 
 Note: read/list/grep tool definitions exist in `src/core/tools`, but ToolCatalog does not register them in the default tool set.
 
@@ -139,7 +140,7 @@ Personas can be defined at user level (`~/.config/tau/personas/*.md`) and projec
 - `allowedReasoningLevels`: list of reasoning levels shown in the UI
 - `skills`: list of enabled skill names (matched by `name` in skill frontmatter), or `"*"` to enable all discovered skills
 - `subagents`: optional map of subagent definitions. The built-in `default` subagent is implicitly enabled unless `default: false` is provided. Custom subagents must be defined as `{ systemPrompt, description?, provider+model?, reasoning?, tools?, riskLevel? }` with lowercase-dash names (max 64 chars). The `default` subagent cannot be overridden.
-- `tools`: list of tool names to enable for this persona. allowed: `bash`, `write`, `edit`, `spawn_agent`, `wait_for_agent`, `terminate_agent`. if omitted, defaults to `bash`, `write`, `edit` (and subagent tools when subagents are enabled). risk levels still apply.
+- `tools`: list of tool names to enable for this persona. allowed: `bash`, `write`, `edit`, `spawn_agent`, `send_input_to_agent`, `wait_for_agent`, `terminate_agent`. if omitted, defaults to `bash`, `write`, `edit` (and subagent tools when subagents are enabled). risk levels still apply.
 
 On conflicts, the most specific level wins (built-ins are the base layer).
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ tau --persona opus-4.5-coder
 
 ## sub-agents
 
-some personas can run isolated sub-agents via the `spawn_agent`, `wait_for_agent`, and `terminate_agent` tools. sub-agents return their output through the subagent-only `emit_output` tool, which is collected by `wait_for_agent`.
+some personas can run isolated sub-agents via the `spawn_agent`, `send_input_to_agent`, `wait_for_agent`, and `terminate_agent` tools. sub-agents return their output through the subagent-only `emit_output` tool, which is collected by `wait_for_agent`.
 
 the built-in `default` sub-agent is available unless disabled. it inherits the main persona's model, settings, tool access (minus sub-agent management tools), and the session risk level. custom sub-agents can override model, reasoning, tools, and risk level. a sub-agent configured with `riskLevel: read-write` can perform writes even when the main session is `read-only`.
 
@@ -422,7 +422,7 @@ optional frontmatter fields:
       tools: [web_search, web_fetch, bash]
       riskLevel: read-only
   ```
-- `tools`: list of tool names to enable for this persona. allowed: `bash`, `write`, `edit`, `spawn_agent`, `wait_for_agent`, `terminate_agent`. if omitted, defaults to `bash`, `write`, `edit` (and subagent tools when subagents are enabled). risk levels still apply.
+- `tools`: list of tool names to enable for this persona. allowed: `bash`, `write`, `edit`, `spawn_agent`, `send_input_to_agent`, `wait_for_agent`, `terminate_agent`. if omitted, defaults to `bash`, `write`, `edit` (and subagent tools when subagents are enabled). risk levels still apply.
 
 the markdown body becomes the system prompt.
 

--- a/src/core/config/content_loader.ts
+++ b/src/core/config/content_loader.ts
@@ -13,6 +13,7 @@ import type {
 import { DEFAULT_SUBAGENT_NAME } from "../subagents/types.js";
 import { BASH_TOOL } from "../tools/bash.js";
 import { EDIT_TOOL } from "../tools/edit.js";
+import { SEND_INPUT_TO_AGENT_TOOL } from "../tools/send_input_to_agent.js";
 import { SPAWN_AGENT_TOOL } from "../tools/spawn_agent.js";
 import { TERMINATE_AGENT_TOOL } from "../tools/terminate_agent.js";
 import { WAIT_FOR_AGENT_TOOL } from "../tools/wait_for_agent.js";
@@ -528,12 +529,18 @@ const PERSONA_TOOL_DEFINITIONS = new Map([
   ["write", WRITE_TOOL],
   ["edit", EDIT_TOOL],
   ["spawn_agent", SPAWN_AGENT_TOOL],
+  ["send_input_to_agent", SEND_INPUT_TO_AGENT_TOOL],
   ["wait_for_agent", WAIT_FOR_AGENT_TOOL],
   ["terminate_agent", TERMINATE_AGENT_TOOL],
 ]);
 
 const DEFAULT_PERSONA_TOOLS = [BASH_TOOL, WRITE_TOOL, EDIT_TOOL];
-const DEFAULT_SUBAGENT_TOOLS = [SPAWN_AGENT_TOOL, WAIT_FOR_AGENT_TOOL, TERMINATE_AGENT_TOOL];
+const DEFAULT_SUBAGENT_TOOLS = [
+  SPAWN_AGENT_TOOL,
+  SEND_INPUT_TO_AGENT_TOOL,
+  WAIT_FOR_AGENT_TOOL,
+  TERMINATE_AGENT_TOOL,
+];
 
 function parsePersona(
   file: string,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -64,6 +64,7 @@ export { createGrepToolDefinition } from "./tools/grep.js";
 export { createListToolDefinition } from "./tools/list.js";
 export { createReadToolDefinition } from "./tools/read.js";
 export { ToolRegistry } from "./tools/registry.js";
+export { createSendInputToAgentToolDefinition } from "./tools/send_input_to_agent.js";
 export { createSpawnAgentToolDefinition } from "./tools/spawn_agent.js";
 export { createTerminateAgentToolDefinition } from "./tools/terminate_agent.js";
 export { createWaitForAgentToolDefinition } from "./tools/wait_for_agent.js";

--- a/src/core/personas.ts
+++ b/src/core/personas.ts
@@ -2,6 +2,7 @@ import { getModel } from "@mariozechner/pi-ai";
 import { DEFAULT_SUBAGENT_NAME, type SubagentConfigMap } from "./subagents/types.js";
 import { BASH_TOOL } from "./tools/bash.js";
 import { EDIT_TOOL } from "./tools/edit.js";
+import { SEND_INPUT_TO_AGENT_TOOL } from "./tools/send_input_to_agent.js";
 import { SPAWN_AGENT_TOOL } from "./tools/spawn_agent.js";
 import { TERMINATE_AGENT_TOOL } from "./tools/terminate_agent.js";
 import { WAIT_FOR_AGENT_TOOL } from "./tools/wait_for_agent.js";
@@ -71,7 +72,7 @@ The user may refer to files by typing \`@file:\` followed by a path relative to 
 
 The user may refer to skills by typing \`@skill:\` followed by a skill name (e.g., \`@skill:skill-name\`). The \`@skill:\` prefix indicates a skill reference. When you see this notation, follow the skill guidelines and open its \`SKILL.md\` if needed.
 
-The user may tag subagents by typing \`@agent:\` followed by a subagent name (e.g., \`@agent:default\`). Tags identify the intended subagent for a task but do not automatically spawn a subagent. Use \`spawn_agent\` explicitly when needed.
+The user may tag subagents by typing \`@agent:\` followed by a subagent name (e.g., \`@agent:default\`). Tags identify the intended subagent for a task but do not automatically spawn a subagent. Use \`spawn_agent\` to start a subagent, and \`send_input_to_agent\` for follow-up inputs once it is idle.
 `.trim();
 
 const BLOCK_FILE_EDIT_GUIDELINES = `
@@ -247,6 +248,7 @@ const VARIANT_CONFIG: Record<Variant, { suffix: string; systemPrompt: string }> 
 const BASE_TOOLS: NonNullable<Persona["tools"]> = [BASH_TOOL, WRITE_TOOL, EDIT_TOOL];
 const SUBAGENT_TOOLS: NonNullable<Persona["tools"]> = [
   SPAWN_AGENT_TOOL,
+  SEND_INPUT_TO_AGENT_TOOL,
   WAIT_FOR_AGENT_TOOL,
   TERMINATE_AGENT_TOOL,
 ];

--- a/src/core/subagents/control_plane.ts
+++ b/src/core/subagents/control_plane.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import type { Message } from "@mariozechner/pi-ai";
 import type { Config } from "../config/index.js";
 import type { ToolExecutionBackend } from "../tools/execution_backend.js";
 import type { ToolDispatchContext } from "../tools/registry.js";
@@ -33,6 +34,10 @@ export type SubagentResult = {
 
 export type SubagentSpawnResult = { ok: true; id: string } | { ok: false; reason: string };
 
+export type SubagentSendInputResult =
+  | { ok: true; id: string; name: SubagentName; title: string }
+  | { ok: false; reason: string };
+
 type SubagentLogEntry = {
   kind: "progress" | "output";
   text: string;
@@ -42,10 +47,15 @@ type SubagentRecord = {
   id: string;
   name: SubagentName;
   title: string;
+  runtimeConfig: SubagentRuntimeConfig;
+  messages: Message[];
   status: SubagentStatus;
   costTotal: number;
   turns: number;
   toolCalls: number;
+  costOffset: number;
+  turnsOffset: number;
+  toolCallsOffset: number;
   startedAt: number;
   finishedAt?: number;
   abortRequested: boolean;
@@ -135,73 +145,67 @@ export class SubagentControlPlane {
 
     const { runtimeConfig, prompt, title, config, authPath, backend, personaId } = options;
     const id = randomUUID();
-    const controller = new AbortController();
-    const startedAt = Date.now();
 
     const record: SubagentRecord = {
       id,
       name: runtimeConfig.name,
       title,
+      runtimeConfig,
+      messages: [],
       status: "running",
       costTotal: 0,
       turns: 0,
       toolCalls: 0,
-      startedAt,
+      costOffset: 0,
+      turnsOffset: 0,
+      toolCallsOffset: 0,
+      startedAt: Date.now(),
       abortRequested: false,
       progress: [],
       outputs: [],
-      controller,
+      controller: new AbortController(),
       completion: Promise.resolve(undefined as never),
     };
 
     this.records.set(id, record);
-    this.emit({ type: "subagent_spawned", state: this.toSnapshot(record) });
-
-    const subagentContext: ToolDispatchContext["subagentContext"] = {
-      id,
-      name: runtimeConfig.name,
-      title,
-      controlPlane: this,
-    };
-
-    record.completion = runSubagent({
-      runtimeConfig,
-      prompt,
-      config,
-      authPath,
-      backend,
-      signal: controller.signal,
-      sessionId: id,
-      personaId,
-      subagentContext,
-      onProgress: (event) => this.recordProgress(id, event),
-      onToolUiEvent: (event) => this.recordToolUiEvent(id, event),
-    })
-      .then((result) => {
-        record.status = "success";
-        record.costTotal = result.costTotal;
-        record.turns = result.turns;
-        record.toolCalls = result.toolCalls;
-        record.finalText = result.finalText;
-        record.finishedAt = Date.now();
-        if (this.records.get(id) === record) {
-          this.emit({ type: "subagent_finished", state: this.toSnapshot(record) });
-        }
-        return record;
-      })
-      .catch((error) => {
-        const message = error instanceof Error ? error.message : String(error);
-        const wasAborted = record.controller.signal.aborted || record.abortRequested;
-        record.status = wasAborted ? "aborted" : "error";
-        record.error = wasAborted ? undefined : message;
-        record.finishedAt = Date.now();
-        if (this.records.get(id) === record) {
-          this.emit({ type: "subagent_finished", state: this.toSnapshot(record) });
-        }
-        return record;
-      });
+    this.startRun({ record, prompt, config, authPath, backend, personaId });
 
     return { ok: true, id };
+  }
+
+  sendInput(options: {
+    id: string;
+    prompt: string;
+    config: Config;
+    authPath?: string;
+    backend: ToolExecutionBackend;
+    personaId?: string;
+  }): SubagentSendInputResult {
+    const { id, prompt, config, authPath, backend, personaId } = options;
+    const record = this.records.get(id);
+    if (!record) {
+      return { ok: false, reason: `unknown subagent id: ${id}` };
+    }
+
+    if (record.status === "running") {
+      return {
+        ok: false,
+        reason: `subagent ${id} is already running. wait for it to finish before sending input.`,
+      };
+    }
+
+    if (this.getActiveCount() >= MAX_ACTIVE_SUBAGENTS) {
+      return {
+        ok: false,
+        reason:
+          `subagent limit reached (max ${MAX_ACTIVE_SUBAGENTS} active). ` +
+          "wait for existing agents to finish.",
+      };
+    }
+
+    this.startRun({ record, prompt, config, authPath, backend, personaId });
+
+    return { ok: true, id: record.id, name: record.name, title: record.title };
   }
 
   recordEmitOutput(id: string, text: string): void {
@@ -248,6 +252,77 @@ export class SubagentControlPlane {
     return record ? this.toSnapshot(record) : undefined;
   }
 
+  private startRun(options: {
+    record: SubagentRecord;
+    prompt: string;
+    config: Config;
+    authPath?: string;
+    backend: ToolExecutionBackend;
+    personaId?: string;
+  }): void {
+    const { record, prompt, config, authPath, backend, personaId } = options;
+
+    record.status = "running";
+    record.startedAt = Date.now();
+    record.finishedAt = undefined;
+    record.abortRequested = false;
+    record.progress = [];
+    record.outputs = [];
+    record.error = undefined;
+    record.finalText = undefined;
+    record.controller = new AbortController();
+    record.costOffset = record.costTotal;
+    record.turnsOffset = record.turns;
+    record.toolCallsOffset = record.toolCalls;
+
+    const subagentContext: ToolDispatchContext["subagentContext"] = {
+      id: record.id,
+      name: record.name,
+      title: record.title,
+      controlPlane: this,
+    };
+
+    this.emit({ type: "subagent_spawned", state: this.toSnapshot(record) });
+
+    record.completion = runSubagent({
+      runtimeConfig: record.runtimeConfig,
+      prompt,
+      config,
+      authPath,
+      backend,
+      signal: record.controller.signal,
+      sessionId: record.id,
+      personaId,
+      subagentContext,
+      messages: record.messages,
+      onProgress: (event) => this.recordProgress(record.id, event),
+      onToolUiEvent: (event) => this.recordToolUiEvent(record.id, event),
+    })
+      .then((result) => {
+        record.status = "success";
+        record.costTotal = record.costOffset + result.costTotal;
+        record.turns = record.turnsOffset + result.turns;
+        record.toolCalls = record.toolCallsOffset + result.toolCalls;
+        record.finalText = result.finalText;
+        record.finishedAt = Date.now();
+        if (this.records.get(record.id) === record) {
+          this.emit({ type: "subagent_finished", state: this.toSnapshot(record) });
+        }
+        return record;
+      })
+      .catch((error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        const wasAborted = record.controller.signal.aborted || record.abortRequested;
+        record.status = wasAborted ? "aborted" : "error";
+        record.error = wasAborted ? undefined : message;
+        record.finishedAt = Date.now();
+        if (this.records.get(record.id) === record) {
+          this.emit({ type: "subagent_finished", state: this.toSnapshot(record) });
+        }
+        return record;
+      });
+  }
+
   private async waitForRecord(id: string): Promise<SubagentRecord> {
     const record = this.records.get(id);
     if (!record) {
@@ -263,9 +338,9 @@ export class SubagentControlPlane {
     const record = this.records.get(id);
     if (!record) return;
 
-    record.costTotal = event.costTotal;
-    record.turns = event.turns;
-    record.toolCalls = event.toolCalls;
+    record.costTotal = record.costOffset + event.costTotal;
+    record.turns = record.turnsOffset + event.turns;
+    record.toolCalls = record.toolCallsOffset + event.toolCalls;
 
     const text = event.text.trim();
     if (text) {
@@ -289,9 +364,9 @@ export class SubagentControlPlane {
     const record = this.records.get(id);
     if (!record) return;
 
-    record.costTotal = event.costTotal;
-    record.turns = event.turns;
-    record.toolCalls = event.toolCalls;
+    record.costTotal = record.costOffset + event.costTotal;
+    record.turns = record.turnsOffset + event.turns;
+    record.toolCalls = record.toolCallsOffset + event.toolCalls;
 
     const text = formatToolUiEventForProgress(event.uiEvent) ?? "";
     if (text) {

--- a/src/core/subagents/default.ts
+++ b/src/core/subagents/default.ts
@@ -8,7 +8,7 @@ Your job: use the tools available to you to execute the user's request, then rep
 ### Rules
 
 - Use the emit_output tool to send findings back to the main agent. The main agent only receives emit_output messages, so always call it with your final answer before finishing.
-- This is a non-interactive session. You cannot ask for clarification or additional input. You must complete the task with the information available.
+- Follow-up inputs may arrive later, but you cannot ask for clarification or additional input. You must complete the task with the information available.
 - Follow the environment tag for risk and tool constraints.
 
 ### Output

--- a/src/core/subagents/subagent_engine.ts
+++ b/src/core/subagents/subagent_engine.ts
@@ -77,6 +77,7 @@ export async function runSubagent(options: {
   config: Config;
   authPath?: string;
   backend?: ToolExecutionBackend;
+  messages?: Message[];
   signal: AbortSignal;
   onProgress?: (event: SubagentProgressEvent) => void;
   onToolUiEvent?: (event: SubagentToolUiEvent) => void;
@@ -108,13 +109,12 @@ export async function runSubagent(options: {
   const backend = options.backend ?? createLocalToolExecutionBackend();
   const allowedTools = runtimeConfig.tools;
   const toolRegistry = buildToolRegistryForAllowedTools(allowedTools, config, backend);
-  const messages: Message[] = [
-    {
-      role: "user",
-      content: [{ type: "text", text: prompt }],
-      timestamp: Date.now(),
-    },
-  ];
+  const messages = options.messages ?? [];
+  messages.push({
+    role: "user",
+    content: [{ type: "text", text: prompt }],
+    timestamp: Date.now(),
+  });
 
   let costTotal = 0;
   let turns = 0;

--- a/src/core/tools/catalog.ts
+++ b/src/core/tools/catalog.ts
@@ -6,6 +6,7 @@ import { createEmitOutputToolDefinition } from "./emit_output.js";
 import type { ToolExecutionBackend } from "./execution_backend.js";
 import type { ToolDefinition } from "./registry.js";
 import { ToolRegistry } from "./registry.js";
+import { createSendInputToAgentToolDefinition } from "./send_input_to_agent.js";
 import { createSpawnAgentToolDefinition } from "./spawn_agent.js";
 import { createTerminateAgentToolDefinition } from "./terminate_agent.js";
 import { createWaitForAgentToolDefinition } from "./wait_for_agent.js";
@@ -20,6 +21,7 @@ export const ToolCatalog = {
       createWriteToolDefinition(backend),
       createEditToolDefinition(backend),
       createSpawnAgentToolDefinition(backend),
+      createSendInputToAgentToolDefinition(backend),
       createWaitForAgentToolDefinition(),
       createTerminateAgentToolDefinition(),
     ]);

--- a/src/core/tools/registry.ts
+++ b/src/core/tools/registry.ts
@@ -52,6 +52,31 @@ export type ToolUiEvent =
       reason: string;
     }
   | {
+      type: "send_input_to_agent_started";
+      toolCallId: string;
+      agentId: string;
+      name: string;
+      title: string;
+    }
+  | {
+      type: "send_input_to_agent_finished";
+      toolCallId: string;
+      agentId: string;
+      name: string;
+      title: string;
+      status: "success" | "error";
+      message?: string;
+      uiText?: ToolUiText;
+    }
+  | {
+      type: "send_input_to_agent_blocked";
+      toolCallId: string;
+      agentId?: string;
+      name?: string;
+      title: string;
+      reason: string;
+    }
+  | {
       type: "wait_for_agent_started";
       toolCallId: string;
       agentIds: string[];

--- a/src/core/tools/send_input_to_agent.ts
+++ b/src/core/tools/send_input_to_agent.ts
@@ -1,0 +1,181 @@
+import type { Tool, ToolCall, ToolResultMessage } from "@mariozechner/pi-ai";
+import { Type } from "@sinclair/typebox";
+import { z } from "zod";
+import type { SubagentStateSnapshot } from "../subagents/types.js";
+import type { RiskLevel } from "../types.js";
+import { createToolError, createToolResult } from "../utils/messages.js";
+import type { ToolExecutionBackend } from "./execution_backend.js";
+import type {
+  ToolDefinition,
+  ToolDispatchContext,
+  ToolDispatchResult,
+  ToolDispatchResultWithPhases,
+  ToolUiEvent,
+} from "./registry.js";
+import { buildSubagentUiText } from "./subagent_ui.js";
+
+const SEND_INPUT_TO_AGENT_DESCRIPTION = [
+  "Send a follow-up prompt to an existing subagent.",
+  "The subagent must be idle before you can send another input.",
+].join(" ");
+
+const SEND_INPUT_TO_AGENT_ID_DESCRIPTION = "Subagent id to send input to.";
+
+const SEND_INPUT_TO_AGENT_PROMPT_DESCRIPTION = [
+  "The prompt to send to the subagent.",
+  "Include all necessary context and instructions for the next run.",
+].join(" ");
+
+export const SEND_INPUT_TO_AGENT_TOOL: Tool = {
+  name: "send_input_to_agent",
+  description: SEND_INPUT_TO_AGENT_DESCRIPTION,
+  parameters: Type.Object(
+    {
+      id: Type.String({ description: SEND_INPUT_TO_AGENT_ID_DESCRIPTION }),
+      prompt: Type.String({ description: SEND_INPUT_TO_AGENT_PROMPT_DESCRIPTION }),
+    },
+    { additionalProperties: false },
+  ),
+};
+
+const sendInputArgsSchema = z.object({
+  id: z.string().trim().catch(""),
+  prompt: z.string().trim().catch(""),
+});
+
+function parseSendInputArgs(raw: unknown): { id: string; prompt: string } {
+  const parsed = sendInputArgsSchema.safeParse(raw);
+  return parsed.success ? parsed.data : { id: "", prompt: "" };
+}
+
+function formatSendInputToolResult(args: { id: string; name: string; title: string }): string {
+  return [`id: ${args.id}`, `name: ${args.name}`, `title: ${args.title}`, "status: running"].join(
+    "\n",
+  );
+}
+
+function resolveSnapshotTarget(snapshot?: SubagentStateSnapshot, agentId?: string) {
+  const name = snapshot?.name ?? "";
+  const title = snapshot?.title ?? agentId ?? "(subagent)";
+  return { name, title };
+}
+
+export function createSendInputToAgentToolDefinition(
+  backend: ToolExecutionBackend,
+): ToolDefinition {
+  return {
+    schema: SEND_INPUT_TO_AGENT_TOOL,
+    async dispatch(
+      toolCall: ToolCall,
+      _riskLevel: RiskLevel,
+      signal?: AbortSignal,
+      context?: ToolDispatchContext,
+    ): Promise<ToolDispatchResult | ToolDispatchResultWithPhases> {
+      const { id, prompt } = parseSendInputArgs(toolCall.arguments);
+
+      const blocked = (
+        reason: string,
+        details?: { id?: string; name?: string; title?: string },
+      ) => {
+        const toolResult = createToolError(toolCall, reason);
+        const uiEvent: ToolUiEvent = {
+          type: "send_input_to_agent_blocked",
+          toolCallId: toolCall.id,
+          agentId: details?.id ?? (id || undefined),
+          name: details?.name ?? undefined,
+          title: details?.title ?? (id || "(subagent)"),
+          reason,
+        };
+        return { kind: "single", toolResult, uiEvent } satisfies ToolDispatchResult;
+      };
+
+      if (!id || !prompt) {
+        const missing = [!id ? "id" : undefined, !prompt ? "prompt" : undefined]
+          .filter(Boolean)
+          .join(", ");
+        return blocked(`missing required parameter(s): ${missing}.`, {
+          id: id || undefined,
+          title: id || "(subagent)",
+        });
+      }
+
+      const controlPlane = context?.subagentControlPlane;
+      if (!controlPlane) {
+        return blocked("subagent control plane is not available.", { id });
+      }
+
+      const snapshot = controlPlane.getSnapshot(id);
+      if (!snapshot) {
+        return blocked(`unknown subagent id: ${id}`, { id, title: id });
+      }
+
+      const target = resolveSnapshotTarget(snapshot, id);
+
+      return {
+        kind: "phased",
+        startedUiEvent: {
+          type: "send_input_to_agent_started",
+          toolCallId: toolCall.id,
+          agentId: id,
+          name: target.name,
+          title: target.title,
+        },
+        run: (async (): Promise<ToolDispatchResult> => {
+          if (signal?.aborted) {
+            const toolResult = createToolError(toolCall, "send_input_to_agent aborted");
+            const uiEvent: ToolUiEvent = {
+              type: "send_input_to_agent_finished",
+              toolCallId: toolCall.id,
+              agentId: id,
+              name: target.name,
+              title: target.title,
+              status: "error",
+              message: "aborted",
+            };
+            return { kind: "single", toolResult, uiEvent };
+          }
+
+          const sendResult = controlPlane.sendInput({
+            id,
+            prompt,
+            config: context?.config ?? {},
+            authPath: context?.authPath,
+            backend,
+            personaId: context?.persona?.id,
+          });
+
+          if (!sendResult.ok) {
+            const toolResult = createToolError(toolCall, sendResult.reason);
+            const uiEvent: ToolUiEvent = {
+              type: "send_input_to_agent_blocked",
+              toolCallId: toolCall.id,
+              agentId: id,
+              name: target.name,
+              title: target.title,
+              reason: sendResult.reason,
+            };
+            return { kind: "single", toolResult, uiEvent };
+          }
+
+          const resultText = formatSendInputToolResult(sendResult);
+          const toolResult: ToolResultMessage = createToolResult(toolCall, resultText, false);
+          const uiText = buildSubagentUiText({
+            output: prompt,
+            statusText: `${sendResult.name} · ${sendResult.id}`,
+            maxOutputLines: 16,
+          });
+          const uiEvent: ToolUiEvent = {
+            type: "send_input_to_agent_finished",
+            toolCallId: toolCall.id,
+            agentId: sendResult.id,
+            name: sendResult.name,
+            title: sendResult.title,
+            status: "success",
+            uiText,
+          };
+          return { kind: "single", toolResult, uiEvent };
+        })(),
+      };
+    },
+  };
+}

--- a/src/tui/tool_ui_router.ts
+++ b/src/tui/tool_ui_router.ts
@@ -12,6 +12,12 @@ type RunningSubagentTool =
       title: string;
     }
   | {
+      kind: "send_input_to_agent";
+      agentId: string;
+      name: string;
+      title: string;
+    }
+  | {
       kind: "wait_for_agent";
       agentIds: string[];
     }
@@ -119,6 +125,36 @@ export class ToolUiRouter {
     }
 
     if (uiEvent.type === "spawn_agent_blocked") {
+      if (this.runningSubagentTools.has(uiEvent.toolCallId)) {
+        this.chatContainer.replaceMessage(uiEvent.toolCallId, { type: "tool", event: uiEvent });
+      } else {
+        this.chatContainer.addMessage({ type: "tool", event: uiEvent }, uiEvent.toolCallId);
+      }
+      this.runningSubagentTools.delete(uiEvent.toolCallId);
+      this.requestRender();
+      return;
+    }
+
+    if (uiEvent.type === "send_input_to_agent_started") {
+      this.chatContainer.addMessage({ type: "tool", event: uiEvent }, uiEvent.toolCallId);
+      this.runningSubagentTools.set(uiEvent.toolCallId, {
+        kind: "send_input_to_agent",
+        agentId: uiEvent.agentId,
+        name: uiEvent.name,
+        title: uiEvent.title,
+      });
+      this.requestRender();
+      return;
+    }
+
+    if (uiEvent.type === "send_input_to_agent_finished") {
+      this.chatContainer.replaceMessage(uiEvent.toolCallId, { type: "tool", event: uiEvent });
+      this.runningSubagentTools.delete(uiEvent.toolCallId);
+      this.requestRender();
+      return;
+    }
+
+    if (uiEvent.type === "send_input_to_agent_blocked") {
       if (this.runningSubagentTools.has(uiEvent.toolCallId)) {
         this.chatContainer.replaceMessage(uiEvent.toolCallId, { type: "tool", event: uiEvent });
       } else {
@@ -239,6 +275,18 @@ export class ToolUiRouter {
       return {
         type: "spawn_agent_finished",
         toolCallId,
+        name: running.name,
+        title: running.title,
+        status: "error",
+        message: reason,
+      };
+    }
+
+    if (running.kind === "send_input_to_agent") {
+      return {
+        type: "send_input_to_agent_finished",
+        toolCallId,
+        agentId: running.agentId,
         name: running.name,
         title: running.title,
         status: "error",

--- a/src/tui/ui/tool_ui_registry.ts
+++ b/src/tui/ui/tool_ui_registry.ts
@@ -290,6 +290,50 @@ export function createToolUiRegistry(): ToolUiRegistry {
     });
   });
 
+  registry.register("send_input_to_agent_started", (event, context) => {
+    const uiEvent = event as Extract<ToolUiEvent, { type: "send_input_to_agent_started" }>;
+    const title = formatSubagentTitle(uiEvent.title ?? uiEvent.agentId);
+    return buildSubagentRunningView({
+      theme: context.theme,
+      label: "sending",
+      title,
+    });
+  });
+
+  registry.register("send_input_to_agent_finished", (event, context) => {
+    const uiEvent = event as Extract<ToolUiEvent, { type: "send_input_to_agent_finished" }>;
+    const title = formatSubagentTitle(uiEvent.title ?? uiEvent.agentId);
+    if (!uiEvent.uiText) {
+      return buildSimpleToolFinishedView({
+        theme: context.theme,
+        label: "send input",
+        target: title,
+        status: uiEvent.status,
+        message: uiEvent.message,
+      });
+    }
+    return buildSubagentFinishedView({
+      theme: context.theme,
+      label: "sent input",
+      failureLabel: "send failed",
+      title,
+      status: uiEvent.status,
+      uiText: uiEvent.uiText,
+    });
+  });
+
+  registry.register("send_input_to_agent_blocked", (event, context) => {
+    const uiEvent = event as Extract<ToolUiEvent, { type: "send_input_to_agent_blocked" }>;
+    const title = formatSubagentTitle(uiEvent.title ?? uiEvent.agentId ?? uiEvent.name);
+    return buildSimpleToolFinishedView({
+      theme: context.theme,
+      label: "send input",
+      target: title,
+      status: "error",
+      message: uiEvent.reason,
+    });
+  });
+
   registry.register("wait_for_agent_started", (event, context) => {
     const uiEvent = event as Extract<ToolUiEvent, { type: "wait_for_agent_started" }>;
     const title = formatAgentIdList(uiEvent.agentIds);

--- a/test/tool_ui_registry.test.js
+++ b/test/tool_ui_registry.test.js
@@ -90,6 +90,27 @@ describe("ToolUiRegistry", () => {
     expect(spawnFinished).toContain("spawned");
     expect(spawnFinished).toContain("agent-1");
 
+    const sendStarted = renderEvent(registry, theme, {
+      type: "send_input_to_agent_started",
+      toolCallId: "si1",
+      agentId: "agent-1",
+      name: "explore",
+      title: "scan repo",
+    });
+    expect(sendStarted).toContain("sending");
+
+    const sendFinished = renderEvent(registry, theme, {
+      type: "send_input_to_agent_finished",
+      toolCallId: "si1",
+      agentId: "agent-1",
+      name: "explore",
+      title: "scan repo",
+      status: "success",
+      uiText: makeUiText("    follow-up", "    (explore · agent-1)", "follow-up"),
+    });
+    expect(sendFinished).toContain("sent input");
+    expect(sendFinished).toContain("agent-1");
+
     const waitStarted = renderEvent(registry, theme, {
       type: "wait_for_agent_started",
       toolCallId: "w1",


### PR DESCRIPTION
- persist subagent history across runs and allow sending follow-up prompts
- add send_input_to_agent tool with ui handling and docs/tests updates

fixes #39
