### PR TITLE
add --caffeinated for tui assistant turns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,6 +223,7 @@ Trigger sensitivity is a concept that guides how proactively the model should ac
 - `--persona <id>[:<level>]`, `-p` - Start with a specific persona and optional reasoning level
 - `--risk <level>`, `-r` - Set initial risk level (`read-only`, `read-write`)
 - `--sandbox` - Run all tool calls inside a session-specific Docker container
+- `--caffeinated` - Keep macOS awake during active assistant turns in TUI mode
 - `--no-agent-context-files` - Disable AGENTS.md injection into the system prompt
 
 These startup flags apply to both interactive TUI mode (`tau`) and headless RPC mode (`tau rpc`).

--- a/README.md
+++ b/README.md
@@ -244,6 +244,16 @@ example config:
 
 note: when `--sandbox` is enabled, `!` commands also run inside the container.
 
+## power management (macOS)
+
+start tau with `--caffeinated` to keep macOS awake while an assistant turn is running:
+
+```sh
+tau --caffeinated
+```
+
+tau uses `caffeinate -i` and only holds the sleep assertion during active assistant turns. it does not keep the display awake, and it does not apply to `tau rpc` mode.
+
 ## personas
 
 tau comes with several built-in personas across different models:

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -8,7 +8,7 @@ start it like this:
 tau rpc --persona gpt-5.2-coder --risk read-only
 ```
 
-you can still use the usual startup flags (`--persona`, `--risk`, `--sandbox`, `--load`, `--no-agent-context-files`, etc). rpc mode uses the same config/persona loading and runtime as TUI mode.
+you can still use the usual startup flags (`--persona`, `--risk`, `--sandbox`, `--load`, `--no-agent-context-files`, etc). rpc mode uses the same config/persona loading and runtime as TUI mode. `--caffeinated` is TUI-only and rejected in rpc mode.
 
 ## transport
 

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -16,6 +16,7 @@ export const CliOptionsSchema = z.object({
   reasoningOverride: ReasoningEffortSchema.optional(),
   riskLevel: RiskLevelSchema.optional(),
   sandbox: z.boolean(),
+  caffeinated: z.boolean(),
   noAgentContextFiles: z.boolean(),
 });
 
@@ -106,6 +107,7 @@ export function parseCliArgs(argv: string[], personas: Persona[]): CliOptions {
   let reasoningOverride: ReasoningEffort | undefined;
   let riskLevel: RiskLevel | undefined;
   let sandbox = false;
+  let caffeinated = false;
   let noAgentContextFiles = false;
 
   for (let i = 0; i < argv.length; i++) {
@@ -135,6 +137,11 @@ export function parseCliArgs(argv: string[], personas: Persona[]): CliOptions {
 
     if (arg === "--sandbox") {
       sandbox = true;
+      continue;
+    }
+
+    if (arg === "--caffeinated") {
+      caffeinated = true;
       continue;
     }
 
@@ -199,6 +206,7 @@ export function parseCliArgs(argv: string[], personas: Persona[]): CliOptions {
     reasoningOverride,
     riskLevel,
     sandbox,
+    caffeinated,
     noAgentContextFiles,
   };
   return CliOptionsSchema.parse(options);
@@ -230,6 +238,7 @@ export function printHelp(personas: Persona[]): void {
       `  --risk, -r <level>            set initial model risk level. levels: ${riskList}.`,
       `                                if not specified, uses defaultRisk from ~/.config/tau/config.json (default: read-only).`,
       "  --sandbox                     run all tool execution inside a session docker container.",
+      "  --caffeinated                 keep macOS awake during active assistant turns in TUI mode.",
       "  --no-agent-context-files      disable AGENTS.md injection into the system prompt.",
       "",
       "subcommands:",

--- a/src/main.ts
+++ b/src/main.ts
@@ -416,6 +416,12 @@ if (cli.help) {
   process.exit(0);
 }
 
+if (isRpcSubcommand && cli.caffeinated) {
+  // eslint-disable-next-line no-console
+  console.error("--caffeinated is only supported in TUI mode.");
+  process.exit(1);
+}
+
 let checkpointPersonaId: string | undefined;
 let checkpointReasoning: ReasoningEffort | undefined;
 let checkpointRiskLevel: Checkpoint["riskLevel"] | undefined;
@@ -561,6 +567,7 @@ const app = new ChatApp({
   noAgentContextFiles: cli.noAgentContextFiles,
   config,
   sandboxEnabled: cli.sandbox,
+  caffeinated: cli.caffeinated,
   toolBackend: sandboxBackend?.backend,
   toolBackendDispose: sandboxBackend?.dispose,
 });

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -29,6 +29,7 @@ export interface ChatAppOptions {
   noAgentContextFiles?: boolean;
   config?: Config;
   sandboxEnabled: boolean;
+  caffeinated?: boolean;
   toolBackend?: ToolExecutionBackend;
   toolBackendDispose?: () => Promise<void> | void;
 }

--- a/src/tui/chat_controller.ts
+++ b/src/tui/chat_controller.ts
@@ -97,6 +97,7 @@ export interface ChatControllerOptions {
   noAgentContextFiles?: boolean;
   config?: Config;
   sandboxEnabled: boolean;
+  caffeinated?: boolean;
   toolBackend?: ToolExecutionBackend;
   toolBackendDispose?: () => Promise<void> | void;
   deps?: CoreDeps;
@@ -162,6 +163,11 @@ type SpeakRecording = {
   maxDurationTimeout?: ReturnType<typeof setTimeout>;
 };
 
+type TurnCaffeinateSession = {
+  abortController: AbortController;
+  completion: Promise<SpawnCaptureResult>;
+};
+
 const RELOAD_PLANS: Record<ReloadScope, ReloadPlan> = {
   "new-session": {
     personas: true,
@@ -193,6 +199,7 @@ const SPEAK_TEMP_FILE_TEMPLATE = "/tmp/tau-speak.XXXXXX";
 const SPEAK_MISTRAL_TRANSCRIBE_MODEL = "voxtral-mini-latest";
 const SPEAK_RECORDING_MIN_BYTES = 1024;
 const SPEAK_RECORDING_MAX_DURATION_MS = 5 * 60 * 1000;
+const CAFFEINATE_COMMAND = "/usr/bin/caffeinate";
 
 export class ChatController {
   private readonly view: ChatView;
@@ -208,6 +215,7 @@ export class ChatController {
   private readonly credentialResolver: CredentialResolver;
   private readonly authPath: string;
   private readonly sandboxEnabled: boolean;
+  private readonly caffeinated: boolean;
   private readonly sandboxRootReal?: string;
   private agentCwd: string;
   private readonly includeAgentContext: boolean;
@@ -252,6 +260,8 @@ export class ChatController {
   private speakRecording?: SpeakRecording;
   private isTranscribingSpeak = false;
   private speakTransition?: Promise<void>;
+  private turnCaffeinate?: TurnCaffeinateSession;
+  private disableCaffeinateForSession = false;
 
   constructor(options: ChatControllerOptions) {
     this.view = options.view;
@@ -272,6 +282,7 @@ export class ChatController {
     this.initialUserMessage = options.initialUserMessage;
     this.config = options.config ?? {};
     this.sandboxEnabled = options.sandboxEnabled;
+    this.caffeinated = options.caffeinated ?? false;
     this.sandboxRootReal = this.sandboxEnabled ? this.resolveSandboxRoot(cwd) : undefined;
     this.agentCwd = resolveAgentCwd({
       cwd,
@@ -475,6 +486,7 @@ export class ChatController {
       await this.speakTransition;
     }
     await this.cancelSpeakCapture();
+    await this.stopTurnCaffeinate();
     if (!this.toolBackendDispose) return;
     await this.toolBackendDispose();
   }
@@ -3192,6 +3204,55 @@ export class ChatController {
     }
   }
 
+  private startTurnCaffeinate(): void {
+    if (!this.caffeinated || this.disableCaffeinateForSession || this.turnCaffeinate) {
+      return;
+    }
+
+    if (this.deps.env.platform() !== "darwin") {
+      this.disableCaffeinateForSession = true;
+      this.view.addSystemMessage("--caffeinated is only supported on macOS.", "warn");
+      return;
+    }
+
+    const abortController = new AbortController();
+    const completion = this.deps.spawn(CAFFEINATE_COMMAND, ["-i"], {
+      detached: true,
+      killProcessGroup: true,
+      signal: abortController.signal,
+      stdio: ["ignore", "ignore", "ignore"],
+    });
+
+    completion.catch(() => {});
+
+    this.turnCaffeinate = {
+      abortController,
+      completion,
+    };
+  }
+
+  private async stopTurnCaffeinate(): Promise<void> {
+    const session = this.turnCaffeinate;
+    if (!session) return;
+
+    this.turnCaffeinate = undefined;
+    if (!session.abortController.signal.aborted) {
+      session.abortController.abort();
+    }
+
+    try {
+      await session.completion;
+    } catch (err) {
+      if (this.disableCaffeinateForSession) {
+        return;
+      }
+      this.disableCaffeinateForSession = true;
+      const error = err as NodeJS.ErrnoException;
+      const details = error.message || "unknown error";
+      this.view.addSystemMessage(`failed to run caffeinate: ${details}`, "warn");
+    }
+  }
+
   // Assistant Turn --------------------------------------------------------------------------------
 
   private async runAssistantTurn(): Promise<void> {
@@ -3200,6 +3261,7 @@ export class ChatController {
     this.startTurnTimer();
     this.assistantState = undefined;
     this.assistantTurnInterruptRequested = false;
+    this.startTurnCaffeinate();
 
     let runResult: ConversationTurnResult = { aborted: false };
 
@@ -3209,6 +3271,7 @@ export class ChatController {
       const message = (err as Error).message || "request failed";
       this.view.addSystemMessage(message, "error");
     } finally {
+      await this.stopTurnCaffeinate();
       const reason = runResult.aborted ? "aborted" : "interrupted";
 
       this.view.finalizeToolUiPending(reason);

--- a/test/chat_controller.test.js
+++ b/test/chat_controller.test.js
@@ -113,8 +113,45 @@ function createController(view, options = {}) {
     bashCommands: options.bashCommands ?? [],
     config: {},
     sandboxEnabled: options.sandboxEnabled ?? false,
+    caffeinated: options.caffeinated ?? false,
     toolBackend: options.toolBackend,
+    noAgentContextFiles: options.noAgentContextFiles ?? false,
+    deps: options.deps,
   });
+}
+
+function createMockDeps(spawn, platform = "darwin") {
+  return {
+    clock: {
+      now: () => Date.now(),
+    },
+    fs: {
+      readFile: () => "",
+      writeFile: () => {},
+      listDir: () => [],
+    },
+    spawn,
+    env: {
+      cwd: () => process.cwd(),
+      home: () => process.env.HOME ?? process.cwd(),
+      platform: () => platform,
+      nodeVersion: () => process.version,
+      env: () => process.env,
+    },
+  };
+}
+
+function createSpawnAbortResult() {
+  return {
+    stdout: "",
+    stderr: "",
+    output: undefined,
+    exitCode: null,
+    captureLimitExceeded: false,
+    timedOut: false,
+    aborted: true,
+    closeSignal: "SIGTERM",
+  };
 }
 
 describe("ChatController event handling", () => {
@@ -210,6 +247,85 @@ describe("ChatController interrupt handling", () => {
     expect(stub.clearToolUiTransientStateCallCount).toBe(1);
     expect(controller.queuedUserMessages).toEqual([]);
     expect(stub.editorTextUpdates.at(-1)).toBe("queued one\n\n---\n\nqueued two");
+  });
+});
+
+describe("ChatController caffeinate", () => {
+  it("starts and stops caffeinate around assistant turns when enabled", async () => {
+    const stub = createStubView();
+    const spawn = vi.fn((_cmd, _args, options = {}) => {
+      return new Promise((resolve) => {
+        options.signal?.addEventListener(
+          "abort",
+          () => {
+            resolve(createSpawnAbortResult());
+          },
+          { once: true },
+        );
+      });
+    });
+    const controller = createController(stub.view, {
+      caffeinated: true,
+      noAgentContextFiles: true,
+      deps: createMockDeps(spawn),
+    });
+    vi.spyOn(controller.runtime, "runTurn").mockResolvedValue({ aborted: false });
+
+    await controller.runAssistantTurn();
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(spawn).toHaveBeenCalledWith(
+      "/usr/bin/caffeinate",
+      ["-i"],
+      expect.objectContaining({
+        detached: true,
+        killProcessGroup: true,
+        stdio: ["ignore", "ignore", "ignore"],
+      }),
+    );
+  });
+
+  it("does not start caffeinate when disabled", async () => {
+    const stub = createStubView();
+    const spawn = vi.fn();
+    const controller = createController(stub.view, {
+      noAgentContextFiles: true,
+      deps: createMockDeps(spawn),
+    });
+    vi.spyOn(controller.runtime, "runTurn").mockResolvedValue({ aborted: false });
+
+    await controller.runAssistantTurn();
+
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it("stops active caffeinate during dispose", async () => {
+    const stub = createStubView();
+    let signal;
+    const spawn = vi.fn((_cmd, _args, options = {}) => {
+      signal = options.signal;
+      return new Promise((resolve) => {
+        options.signal?.addEventListener(
+          "abort",
+          () => {
+            resolve(createSpawnAbortResult());
+          },
+          { once: true },
+        );
+      });
+    });
+    const controller = createController(stub.view, {
+      caffeinated: true,
+      noAgentContextFiles: true,
+      deps: createMockDeps(spawn),
+    });
+
+    controller.startTurnCaffeinate();
+    await controller.dispose();
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(signal.aborted).toBe(true);
+    expect(controller.turnCaffeinate).toBeUndefined();
   });
 });
 

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -12,6 +12,16 @@ describe("cli", () => {
     expect(options.sandbox).toBe(false);
   });
 
+  it("parses --caffeinated", () => {
+    const options = parseCliArgs(["--caffeinated"], []);
+    expect(options.caffeinated).toBe(true);
+  });
+
+  it("defaults caffeinated to false", () => {
+    const options = parseCliArgs([], []);
+    expect(options.caffeinated).toBe(false);
+  });
+
   it("help output includes rpc subcommand", () => {
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
@@ -21,6 +31,7 @@ describe("cli", () => {
       expect(typeof output).toBe("string");
       expect(output).toContain("tau rpc [options]");
       expect(output).toContain("rpc                           run headless stdio RPC mode");
+      expect(output).toContain("--caffeinated");
       expect(output).toContain("in RPC mode, stdin/stdout are reserved for protocol traffic.");
     } finally {
       logSpy.mockRestore();


### PR DESCRIPTION
## summary
- add a new `--caffeinated` startup flag to the CLI and help output
- keep macOS awake only during active assistant turns by running `caffeinate -i` for the turn lifecycle
- reject `--caffeinated` in `tau rpc`, and document the TUI-only scope in README/docs
- add CLI and chat controller tests for parsing, lifecycle start/stop, and dispose cleanup

## verification
- npm run check
- npm test

fixes #80
