### PR TITLE
show subagent model in UI when explicitly set

### DIFF
--- a/src/core/subagents/control_plane.ts
+++ b/src/core/subagents/control_plane.ts
@@ -47,6 +47,7 @@ type SubagentRecord = {
   id: string;
   name: SubagentName;
   title: string;
+  modelLabel?: string;
   runtimeConfig: SubagentRuntimeConfig;
   messages: Message[];
   status: SubagentStatus;
@@ -129,6 +130,7 @@ export class SubagentControlPlane {
     runtimeConfig: SubagentRuntimeConfig;
     prompt: string;
     title: string;
+    modelLabel?: string;
     config: Config;
     authPath?: string;
     backend: ToolExecutionBackend;
@@ -143,13 +145,15 @@ export class SubagentControlPlane {
       };
     }
 
-    const { runtimeConfig, prompt, title, config, authPath, backend, personaId } = options;
+    const { runtimeConfig, prompt, title, modelLabel, config, authPath, backend, personaId } =
+      options;
     const id = randomUUID();
 
     const record: SubagentRecord = {
       id,
       name: runtimeConfig.name,
       title,
+      modelLabel,
       runtimeConfig,
       messages: [],
       status: "running",
@@ -391,6 +395,7 @@ export class SubagentControlPlane {
       id: record.id,
       name: record.name,
       title: record.title,
+      modelLabel: record.modelLabel,
       status: record.status,
       costTotal: record.costTotal,
       turns: record.turns,

--- a/src/core/subagents/types.ts
+++ b/src/core/subagents/types.ts
@@ -53,6 +53,7 @@ export type SubagentStateSnapshot = {
   name: SubagentName;
   title: string;
   status: SubagentStatus;
+  modelLabel?: string;
   costTotal: number;
   turns: number;
   toolCalls: number;

--- a/src/core/tools/spawn_agent.ts
+++ b/src/core/tools/spawn_agent.ts
@@ -223,6 +223,11 @@ export function createSpawnAgentToolDefinition(backend: ToolExecutionBackend): T
         });
       }
 
+      const modelLabel =
+        effectiveSettings.model !== persona.model
+          ? `${effectiveSettings.model.provider}/${effectiveSettings.model.id}:${effectiveSettings.settings?.reasoning ?? "none"}`
+          : undefined;
+
       return {
         kind: "phased",
         startedUiEvent: {
@@ -251,6 +256,7 @@ export function createSpawnAgentToolDefinition(backend: ToolExecutionBackend): T
             runtimeConfig,
             prompt,
             title,
+            modelLabel,
             config: context.config ?? {},
             authPath: context.authPath,
             backend,
@@ -276,10 +282,11 @@ export function createSpawnAgentToolDefinition(backend: ToolExecutionBackend): T
             title,
           });
 
+          const statusParts = [name, modelLabel, spawnResult.id].filter(Boolean);
           const toolResult: ToolResultMessage = createToolResult(toolCall, resultText, false);
           const uiText = buildSubagentUiText({
             output: prompt,
-            statusText: `${name} · ${spawnResult.id}`,
+            statusText: statusParts.join(" · "),
             maxOutputLines: 16,
             fullText: resultText,
           });


### PR DESCRIPTION
when a subagent's effective model differs from the main persona model (via persona config or launch model override), display the model label in the tool output card headers and the subagent panel header.

the label uses `provider:model_id` format and appears:
- in the subagent panel header as muted text after the title
- in spawn_agent tool card headers as a tail segment

fixes #86
