### PR TITLE
add telegram verbosity modes

### DIFF
--- a/docs/async.md
+++ b/docs/async.md
@@ -139,6 +139,8 @@ Supported DM commands:
 - `/list`
 - `/status`
 - `/cancel`
+- `/verbose` (default mode, streams run lifecycle + progress updates)
+- `/quiet` (send only the run's final assistant message, no streamed progress)
 - plain text sends to the active session
 
 The adapter registers these commands via Telegram's command list so clients can autocomplete them.
@@ -154,17 +156,19 @@ Lifecycle notifications are sent back to associated chats:
 
 - `session is being prepared` (after `/new`)
 - `session is ready` (when workspace + client are ready)
-- `run started`
-- `run finished`
 - `run failed`
 - `run canceled`
 
-During runs, progress notifications also include:
+In `/verbose` mode (default), run updates also include:
 
+- `run started`
+- `run finished`
 - each bash command (`bash command`)
 - each successful edit call (`edited file`)
 - each successful write call (`wrote file`)
-- the latest assistant final message (`assistant message`)
+- each assistant final message for the current run (`assistant message`)
+
+In `/quiet` mode, these streamed updates are suppressed and only the run's final assistant message is sent when the run completes.
 
 ## persistence model
 
@@ -173,6 +177,6 @@ Async daemon state is in-memory only:
 - session records
 - session logs
 - Telegram chat routing (`chatId -> activeSessionId`)
-- Telegram per-session progress previews (last command + last assistant message)
+- Telegram per-session state (verbosity mode, last command, last assistant message)
 
 Restarting the daemon clears this state. Existing cloned workspaces on disk are not reused as daemon session state.

--- a/src/core/async/telegram.ts
+++ b/src/core/async/telegram.ts
@@ -89,12 +89,16 @@ const DEFAULT_REQUEST_TIMEOUT_SECONDS = 30;
 const MAX_COMMAND_PREVIEW_CHARS = 128;
 const ABORTED = Symbol("aborted");
 
+type SessionVerbosity = "verbose" | "quiet";
+
 const TELEGRAM_COMMANDS: TelegramBotCommand[] = [
   { command: "new", description: "start a new session" },
   { command: "use", description: "switch active session" },
   { command: "list", description: "list sessions" },
   { command: "status", description: "show active session status" },
   { command: "cancel", description: "cancel active session" },
+  { command: "verbose", description: "stream progress updates" },
+  { command: "quiet", description: "only send final assistant message" },
 ];
 
 function splitCommandText(text: string): string[] {
@@ -129,6 +133,7 @@ function truncateText(text: string, maxChars: number): string {
 function describeSession(
   session: AsyncSessionRecord,
   details: {
+    verbosity?: SessionVerbosity;
     lastCommand?: string;
     lastAssistantMessage?: string;
   } = {},
@@ -137,6 +142,7 @@ function describeSession(
     formatSessionHeadline(session.id, "status"),
     `project: ${session.projectId}`,
     `state: ${session.state}`,
+    `verbosity: ${details.verbosity ?? "verbose"}`,
     ...(session.error ? [`error: ${session.error}`] : []),
     ...(details.lastCommand
       ? [`last command: ${truncateText(details.lastCommand, MAX_COMMAND_PREVIEW_CHARS)}`]
@@ -187,8 +193,10 @@ class AsyncTelegramAdapterImpl {
   private readonly abortController = new AbortController();
   private readonly activeSessionsByChat = new Map<number, string>();
   private readonly chatsBySession = new Map<string, Set<number>>();
+  private readonly sessionVerbosityBySession = new Map<string, SessionVerbosity>();
   private readonly lastCommandBySession = new Map<string, string>();
   private readonly lastAssistantMessageBySession = new Map<string, string>();
+  private readonly latestAssistantMessageByRun = new Map<string, string>();
 
   private readonly unsubscribeSessionEvents: () => void;
   private readonly loopPromise: Promise<void>;
@@ -420,7 +428,20 @@ class AsyncTelegramAdapterImpl {
       return;
     }
 
-    await this.reply(chatId, "supported commands: /new, /use, /list, /status, /cancel");
+    if (command === "/verbose") {
+      await this.handleVerbosityCommand(chatId, "verbose");
+      return;
+    }
+
+    if (command === "/quiet") {
+      await this.handleVerbosityCommand(chatId, "quiet");
+      return;
+    }
+
+    await this.reply(
+      chatId,
+      "supported commands: /new, /use, /list, /status, /cancel, /verbose, /quiet",
+    );
   }
 
   private resolveNewCommand(args: string[]): NewCommandResolution {
@@ -491,6 +512,7 @@ class AsyncTelegramAdapterImpl {
       });
 
       this.setActiveSession(chatId, session.id);
+      this.sessionVerbosityBySession.set(session.id, "verbose");
       await this.reply(chatId, this.formatSessionPreparing(session.projectId));
     } catch (error) {
       await this.reply(chatId, this.formatManagerError(error));
@@ -540,6 +562,7 @@ class AsyncTelegramAdapterImpl {
     await this.reply(
       chatId,
       describeSession(session, {
+        verbosity: this.getSessionVerbosity(session.id),
         lastCommand: this.lastCommandBySession.get(session.id),
         lastAssistantMessage: this.lastAssistantMessageBySession.get(session.id),
       }),
@@ -559,6 +582,17 @@ class AsyncTelegramAdapterImpl {
     } catch (error) {
       await this.reply(chatId, this.formatManagerError(error));
     }
+  }
+
+  private async handleVerbosityCommand(chatId: number, verbosity: SessionVerbosity): Promise<void> {
+    const session = this.getActiveSession(chatId);
+    if (!session) {
+      await this.reply(chatId, "no active session. use /new or /use <sessionId>");
+      return;
+    }
+
+    this.sessionVerbosityBySession.set(session.id, verbosity);
+    await this.reply(chatId, formatSessionHeadline(session.id, `verbosity set to ${verbosity}`));
   }
 
   private async handleMessage(chatId: number, text: string): Promise<void> {
@@ -631,6 +665,14 @@ class AsyncTelegramAdapterImpl {
     }
   }
 
+  private getSessionVerbosity(sessionId: string): SessionVerbosity {
+    return this.sessionVerbosityBySession.get(sessionId) ?? "verbose";
+  }
+
+  private isVerboseSession(sessionId: string): boolean {
+    return this.getSessionVerbosity(sessionId) === "verbose";
+  }
+
   private onSessionEvent(event: AsyncSessionManagerEvent): void {
     if (event.type === "session-progress") {
       this.handleSessionProgress(event);
@@ -642,16 +684,21 @@ class AsyncTelegramAdapterImpl {
     }
 
     if (event.state === "running") {
-      this.notifyLifecycle(event.sessionId, event.projectId, "started");
+      this.latestAssistantMessageByRun.delete(event.sessionId);
+      if (this.isVerboseSession(event.sessionId)) {
+        this.notifyLifecycle(event.sessionId, event.projectId, "started");
+      }
       return;
     }
 
     if (event.state === "failed") {
+      this.latestAssistantMessageByRun.delete(event.sessionId);
       this.notifyLifecycle(event.sessionId, event.projectId, "failed");
       return;
     }
 
     if (event.state === "canceled") {
+      this.latestAssistantMessageByRun.delete(event.sessionId);
       this.notifyLifecycle(event.sessionId, event.projectId, "canceled");
       return;
     }
@@ -665,15 +712,30 @@ class AsyncTelegramAdapterImpl {
     }
 
     if (event.state === "waiting-input" && event.previousState === "running") {
-      this.notifyLifecycle(event.sessionId, event.projectId, "finished");
+      if (this.isVerboseSession(event.sessionId)) {
+        this.notifyLifecycle(event.sessionId, event.projectId, "finished");
+        return;
+      }
+
+      const message = this.latestAssistantMessageByRun.get(event.sessionId);
+      this.latestAssistantMessageByRun.delete(event.sessionId);
+      if (message) {
+        this.notifySession(event.sessionId, message);
+      }
     }
   }
 
   private handleSessionProgress(
     event: Extract<AsyncSessionManagerEvent, { type: "session-progress" }>,
   ): void {
+    const isVerbose = this.isVerboseSession(event.sessionId);
+
     if (event.progress.type === "bash-command") {
       this.lastCommandBySession.set(event.sessionId, event.progress.command);
+      if (!isVerbose) {
+        return;
+      }
+
       this.notifySession(
         event.sessionId,
         [
@@ -685,6 +747,10 @@ class AsyncTelegramAdapterImpl {
     }
 
     if (event.progress.type === "edited-file") {
+      if (!isVerbose) {
+        return;
+      }
+
       this.notifySession(
         event.sessionId,
         [formatSessionHeadline(event.sessionId, "edited file"), event.progress.path].join("\n"),
@@ -693,6 +759,10 @@ class AsyncTelegramAdapterImpl {
     }
 
     if (event.progress.type === "wrote-file") {
+      if (!isVerbose) {
+        return;
+      }
+
       this.notifySession(
         event.sessionId,
         [formatSessionHeadline(event.sessionId, "wrote file"), event.progress.path].join("\n"),
@@ -701,6 +771,12 @@ class AsyncTelegramAdapterImpl {
     }
 
     this.lastAssistantMessageBySession.set(event.sessionId, event.progress.text);
+    this.latestAssistantMessageByRun.set(event.sessionId, event.progress.text);
+
+    if (!isVerbose) {
+      return;
+    }
+
     this.notifySession(
       event.sessionId,
       [formatSessionHeadline(event.sessionId, "assistant message"), event.progress.text].join("\n"),

--- a/test/async_telegram.test.js
+++ b/test/async_telegram.test.js
@@ -122,6 +122,8 @@ describe("async telegram adapter", () => {
         { command: "list", description: "list sessions" },
         { command: "status", description: "show active session status" },
         { command: "cancel", description: "cancel active session" },
+        { command: "verbose", description: "stream progress updates" },
+        { command: "quiet", description: "only send final assistant message" },
       ]);
     } finally {
       await adapter.close();
@@ -564,6 +566,211 @@ describe("async telegram adapter", () => {
           apiHarness.sendMessages.some((entry) => entry.text.includes("(s10) wrote file")) &&
           apiHarness.sendMessages.some((entry) => entry.text.includes("(s10) assistant message")),
       );
+    } finally {
+      await adapter.close();
+    }
+  });
+
+  it("supports /quiet and /verbose per session", async () => {
+    const apiHarness = createApiHarness([
+      [
+        {
+          update_id: 1,
+          message: {
+            chat: { id: 460, type: "private" },
+            from: { id: 7 },
+            text: "/use s11",
+          },
+        },
+        {
+          update_id: 2,
+          message: {
+            chat: { id: 460, type: "private" },
+            from: { id: 7 },
+            text: "/quiet",
+          },
+        },
+        {
+          update_id: 3,
+          message: {
+            chat: { id: 460, type: "private" },
+            from: { id: 7 },
+            text: "/status",
+          },
+        },
+        {
+          update_id: 4,
+          message: {
+            chat: { id: 460, type: "private" },
+            from: { id: 7 },
+            text: "/verbose",
+          },
+        },
+        {
+          update_id: 5,
+          message: {
+            chat: { id: 460, type: "private" },
+            from: { id: 7 },
+            text: "/status",
+          },
+        },
+      ],
+    ]);
+
+    const managerHarness = createSessionManagerHarness([
+      {
+        id: "s11",
+        projectId: "demo",
+        state: "waiting-input",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    const adapter = await startAsyncTelegramAdapter({
+      botToken: "token",
+      projects: { demo: { repo: "git@example.com:demo.git" } },
+      sessionManager: managerHarness.manager,
+      api: apiHarness.api,
+      pollIntervalMs: 1,
+      requestTimeoutSeconds: 1,
+    });
+
+    try {
+      await waitFor(() => apiHarness.sendMessages.length >= 5);
+      expect(
+        apiHarness.sendMessages.some((entry) =>
+          entry.text.includes("(s11) verbosity set to quiet"),
+        ),
+      ).toBe(true);
+      expect(apiHarness.sendMessages.some((entry) => entry.text.includes("verbosity: quiet"))).toBe(
+        true,
+      );
+      expect(
+        apiHarness.sendMessages.some((entry) =>
+          entry.text.includes("(s11) verbosity set to verbose"),
+        ),
+      ).toBe(true);
+      expect(
+        apiHarness.sendMessages.some((entry) => entry.text.includes("verbosity: verbose")),
+      ).toBe(true);
+    } finally {
+      await adapter.close();
+    }
+  });
+
+  it("only sends the final assistant message in quiet mode", async () => {
+    const apiHarness = createApiHarness([
+      [
+        {
+          update_id: 1,
+          message: {
+            chat: { id: 470, type: "private" },
+            from: { id: 7 },
+            text: "/use s12",
+          },
+        },
+        {
+          update_id: 2,
+          message: {
+            chat: { id: 470, type: "private" },
+            from: { id: 7 },
+            text: "/quiet",
+          },
+        },
+      ],
+    ]);
+
+    const managerHarness = createSessionManagerHarness([
+      {
+        id: "s12",
+        projectId: "demo",
+        state: "waiting-input",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    const adapter = await startAsyncTelegramAdapter({
+      botToken: "token",
+      projects: { demo: { repo: "git@example.com:demo.git" } },
+      sessionManager: managerHarness.manager,
+      api: apiHarness.api,
+      pollIntervalMs: 1,
+      requestTimeoutSeconds: 1,
+    });
+
+    try {
+      await waitFor(() => apiHarness.sendMessages.length >= 2);
+
+      managerHarness.manager.emit({
+        type: "session-state-changed",
+        sessionId: "s12",
+        projectId: "demo",
+        previousState: "waiting-input",
+        state: "running",
+        updatedAt: "2024-01-01T00:01:00.000Z",
+      });
+
+      managerHarness.manager.emit({
+        type: "session-progress",
+        sessionId: "s12",
+        projectId: "demo",
+        state: "running",
+        timestamp: "2024-01-01T00:02:00.000Z",
+        progress: {
+          type: "bash-command",
+          command: "npm test",
+        },
+      });
+
+      managerHarness.manager.emit({
+        type: "session-progress",
+        sessionId: "s12",
+        projectId: "demo",
+        state: "running",
+        timestamp: "2024-01-01T00:03:00.000Z",
+        progress: {
+          type: "assistant-message",
+          text: "intermediate",
+        },
+      });
+
+      managerHarness.manager.emit({
+        type: "session-progress",
+        sessionId: "s12",
+        projectId: "demo",
+        state: "running",
+        timestamp: "2024-01-01T00:04:00.000Z",
+        progress: {
+          type: "assistant-message",
+          text: "final answer",
+        },
+      });
+
+      managerHarness.manager.emit({
+        type: "session-state-changed",
+        sessionId: "s12",
+        projectId: "demo",
+        previousState: "running",
+        state: "waiting-input",
+        updatedAt: "2024-01-01T00:05:00.000Z",
+      });
+
+      await waitFor(() => apiHarness.sendMessages.some((entry) => entry.text === "final answer"));
+
+      expect(
+        apiHarness.sendMessages.some((entry) => entry.text.includes("(s12) run started")),
+      ).toBe(false);
+      expect(
+        apiHarness.sendMessages.some((entry) => entry.text.includes("(s12) run finished")),
+      ).toBe(false);
+      expect(
+        apiHarness.sendMessages.some((entry) => entry.text.includes("(s12) bash command")),
+      ).toBe(false);
+      expect(
+        apiHarness.sendMessages.some((entry) => entry.text.includes("(s12) assistant message")),
+      ).toBe(false);
     } finally {
       await adapter.close();
     }


### PR DESCRIPTION
- add `/verbose` and `/quiet` telegram commands to control active session verbosity
- keep default behavior as verbose for new and existing sessions
- in quiet mode, suppress lifecycle start/finish + tool progress + intermediate assistant updates, then send only the run's final assistant message on completion
- include session verbosity in `/status` output
- update async telegram docs and extend async telegram adapter tests for command registration, status reporting, and quiet-mode delivery behavior

validation:
- npm run check
- npm test
