### PR TITLE
gracefully no-op macos-only speak and caffeinated on linux

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,7 +228,7 @@ Trigger sensitivity is a concept that guides how proactively the model should ac
 - `--persona <id>[:<level>]`, `-p` - Start with a specific persona and optional reasoning level
 - `--risk <level>`, `-r` - Set initial risk level (`read-only`, `read-write`)
 - `--sandbox` - Run all tool calls inside a session-specific Docker container
-- `--caffeinated` - Keep macOS awake during active assistant turns in TUI mode
+- `--caffeinated` - Keep macOS awake during active assistant turns in TUI mode (currently a no-op on Linux)
 - `--no-agent-context-files` - Disable AGENTS.md injection into the system prompt
 
 These startup flags apply to both interactive TUI mode (`tau`) and headless RPC mode (`tau rpc`), except `--caffeinated` (macOS-only TUI flag, rejected in RPC mode).
@@ -248,11 +248,11 @@ The `--debug` flag respects `--persona` and `--no-agent-context-files`, so you c
 - `TAU_ASYNC_AUTH_TOKEN` (env var) - Optional override for daemon-file `authToken` in daemon mode
 - `TAU_CODEX_ACCOUNT` (env var) - Force a specific Codex account by email or account id (same matching as logout); disables failover
 - `PARALLEL_API_KEY` (env var) - Optional override for `apiKeys.parallel` used by `web_search`/`web_fetch`
-- `MISTRAL_API_KEY` (env var) - Optional override for `/speak` microphone transcription
+- `MISTRAL_API_KEY` (env var) - Optional override for `/speak` microphone transcription (macOS only)
 
 ## Commands
 
-- `/help`, `/new`, `/rewind`, `/cd`, `/copy:text`, `/copy:code`, `/checkpoint`, `/reload`, `/speak`
+- `/help`, `/new`, `/rewind`, `/cd`, `/copy:text`, `/copy:code`, `/checkpoint`, `/reload`, `/speak` (macOS only; warns on Linux)
 - `/compact:summary-only`, `/compact:summary-and-last` - Compact history into a single synthetic user summary message (optionally includes last assistant message verbatim when available)
 - `/prune:earliest`, `/prune:largest`, `/prune:smart` - Prune tool results and compact edit call payloads/results
 - `/risk:read-only`, `/risk:read-write`, `/persona:<id>`, `/prompt:<id>`, `/theme:<id>`, `/bash:<id>`

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ for provider keys (`anthropic`, `openai`, `google`), tau checks `~/.config/tau/c
 
 `parallel` is only needed for `web_search`/`web_fetch` usage in sub-agents and can be provided through `apiKeys.parallel` or `PARALLEL_API_KEY` (`PARALLEL_API_KEY` takes precedence).
 
-`/speak` uses `apiKeys.mistral` or `MISTRAL_API_KEY` for transcription (`MISTRAL_API_KEY` takes precedence) and requires `ffmpeg` on your system.
+`/speak` uses `apiKeys.mistral` or `MISTRAL_API_KEY` for transcription (`MISTRAL_API_KEY` takes precedence), requires `ffmpeg` on your system, and is currently supported only on macOS.
 
 ### OpenAI Codex subscription (ChatGPT Plus/Pro)
 
@@ -283,7 +283,7 @@ start tau with `--caffeinated` to keep macOS awake while an assistant turn is ru
 tau --caffeinated
 ```
 
-tau uses `caffeinate -i` and only holds the sleep assertion during active assistant turns. it does not keep the display awake, and it does not apply to `tau rpc` mode.
+tau uses `caffeinate -i` and only holds the sleep assertion during active assistant turns. it does not keep the display awake, and it does not apply to `tau rpc` mode. on Linux, `--caffeinated` is accepted but currently a no-op.
 
 ## personas
 
@@ -384,7 +384,7 @@ tau supports slash commands for common actions:
 | `/copy:code`                | copy just the code blocks                                                       |
 | `/checkpoint`               | save a checkpoint file for loading later                                        |
 | `/reload`                   | reload personas, prompts, skills, themes, bash commands, and AGENTS.md          |
-| `/speak`                    | toggle microphone recording and transcribe into the editor                      |
+| `/speak`                    | toggle microphone recording and transcribe into the editor (macOS only)         |
 | `/cd`                       | change the working directory                                                    |
 | `/compact:summary-only`     | compress history into one synthetic user summary message                        |
 | `/compact:summary-and-last` | compress history and include the last assistant message verbatim when present   |
@@ -406,7 +406,7 @@ the compact commands are manual and useful when conversations get long. they rep
 
 the prune commands drop bash tool results from the active context without summarizing and compact edit call payloads/results. all three accept an optional fraction between `0` and `1` (for example, `/prune:largest 0.4`) and default to `0.25` when omitted. `/prune:smart` also accepts optional guidance text, either after a fraction (for example, `/prune:smart 0.3 keep only repetitive output`) or by itself (for example, `/prune:smart keep build logs`).
 
-`/speak` (or `ctrl+y`) starts microphone recording. while recording, editor typing is disabled, and `ctrl+y` stops recording and starts transcription at the cursor. recording also auto-stops after 5 minutes.
+`/speak` (or `ctrl+y`) starts microphone recording on macOS. while recording, editor typing is disabled, and `ctrl+y` stops recording and starts transcription at the cursor. recording also auto-stops after 5 minutes. on Linux, `/speak` is currently unavailable and tau shows a warning.
 
 `/rewind` opens a picker over prior user messages in the current context. it truncates history from the selected message onward (including the selected message) and prefills the editor with that message so you can retry from there.
 

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -239,7 +239,7 @@ export function printHelp(personas: Persona[]): void {
       `  --risk, -r <level>            set initial model risk level. levels: ${riskList}.`,
       `                                if not specified, uses defaultRisk from ~/.config/tau/config.json (default: read-only).`,
       "  --sandbox                     run all tool execution inside a session docker container.",
-      "  --caffeinated                 keep macOS awake during active assistant turns in TUI mode.",
+      "  --caffeinated                 keep macOS awake during active assistant turns in TUI mode (no-op on Linux).",
       "  --no-agent-context-files      disable AGENTS.md injection into the system prompt.",
       "",
       "subcommands:",

--- a/src/tui/chat_controller.ts
+++ b/src/tui/chat_controller.ts
@@ -1158,7 +1158,7 @@ export class ChatController {
       case "reload":
         return "reload prompts, skills, themes, bash commands, and AGENTS.md";
       case "speak":
-        return "toggle microphone recording and transcribe to editor";
+        return "toggle microphone recording and transcribe to editor (macOS only)";
       case "risk":
         return "set risk level: /risk:read-only or /risk:read-write";
       case "bash":
@@ -1477,6 +1477,11 @@ export class ChatController {
   }
 
   private async startSpeakCapture(): Promise<void> {
+    if (this.deps.env.platform() !== "darwin") {
+      this.view.addSystemMessage("/speak is currently supported only on macOS.", "warn");
+      return;
+    }
+
     const apiKey = getMistralApiKey(this.config, this.deps.env.env());
     if (!apiKey) {
       this.view.addSystemMessage("set MISTRAL_API_KEY or apiKeys.mistral to use /speak", "error");
@@ -3211,7 +3216,6 @@ export class ChatController {
 
     if (this.deps.env.platform() !== "darwin") {
       this.disableCaffeinateForSession = true;
-      this.view.addSystemMessage("--caffeinated is only supported on macOS.", "warn");
       return;
     }
 

--- a/test/chat_controller.test.js
+++ b/test/chat_controller.test.js
@@ -299,6 +299,22 @@ describe("ChatController caffeinate", () => {
     expect(spawn).not.toHaveBeenCalled();
   });
 
+  it("no-ops caffeinate on Linux", async () => {
+    const stub = createStubView();
+    const spawn = vi.fn();
+    const controller = createController(stub.view, {
+      caffeinated: true,
+      noAgentContextFiles: true,
+      deps: createMockDeps(spawn, "linux"),
+    });
+    vi.spyOn(controller.runtime, "runTurn").mockResolvedValue({ aborted: false });
+
+    await controller.runAssistantTurn();
+
+    expect(spawn).not.toHaveBeenCalled();
+    expect(stub.systemMessages).toEqual([]);
+  });
+
   it("stops active caffeinate during dispose", async () => {
     const stub = createStubView();
     let signal;
@@ -403,6 +419,22 @@ describe("ChatController speak capture", () => {
 
     expect(stub.systemMessages).toContainEqual({
       text: "speech recording state change already in progress",
+      kind: "warn",
+    });
+  });
+
+  it("shows a warning and skips recording on Linux", async () => {
+    const stub = createStubView();
+    const spawn = vi.fn();
+    const controller = createController(stub.view, {
+      deps: createMockDeps(spawn, "linux"),
+    });
+
+    await controller.toggleSpeakCapture();
+
+    expect(spawn).not.toHaveBeenCalled();
+    expect(stub.systemMessages).toContainEqual({
+      text: "/speak is currently supported only on macOS.",
       kind: "warn",
     });
   });


### PR DESCRIPTION
- keep `/speak` macOS-only by short-circuiting on non-darwin with a clear warning instead of trying `ffmpeg -f avfoundation`
- keep `--caffeinated` as a Linux no-op (no spawn, no warning), while preserving existing macOS behavior
- update CLI/help/docs context so platform behavior matches runtime behavior
- add chat controller tests for Linux `/speak` warning path and Linux `--caffeinated` no-op path

validation:
- `npm run check`
- `npm test`

context:
- this intentionally does not implement Linux recording/sleep-inhibit parity and keeps those features macOS-only for now
- related: #92
