### PR TITLE
default telegram to quiet mode

### DIFF
--- a/docs/async.md
+++ b/docs/async.md
@@ -139,8 +139,8 @@ Supported DM commands:
 - `/list`
 - `/status`
 - `/cancel`
-- `/verbose` (default mode, streams run lifecycle + progress updates)
-- `/quiet` (send only the run's final assistant message, no streamed progress)
+- `/verbose` (streams run lifecycle + progress updates)
+- `/quiet` (default mode, send only the run's final assistant message, no streamed progress)
 - plain text sends to the active session
 
 The adapter registers these commands via Telegram's command list so clients can autocomplete them.
@@ -159,7 +159,7 @@ Lifecycle notifications are sent back to associated chats:
 - `run failed`
 - `run canceled`
 
-In `/verbose` mode (default), run updates also include:
+In `/verbose` mode, run updates also include:
 
 - `run started`
 - `run finished`

--- a/src/core/async/telegram.ts
+++ b/src/core/async/telegram.ts
@@ -142,7 +142,7 @@ function describeSession(
     formatSessionHeadline(session.id, "status"),
     `project: ${session.projectId}`,
     `state: ${session.state}`,
-    `verbosity: ${details.verbosity ?? "verbose"}`,
+    `verbosity: ${details.verbosity ?? "quiet"}`,
     ...(session.error ? [`error: ${session.error}`] : []),
     ...(details.lastCommand
       ? [`last command: ${truncateText(details.lastCommand, MAX_COMMAND_PREVIEW_CHARS)}`]
@@ -512,7 +512,7 @@ class AsyncTelegramAdapterImpl {
       });
 
       this.setActiveSession(chatId, session.id);
-      this.sessionVerbosityBySession.set(session.id, "verbose");
+      this.sessionVerbosityBySession.set(session.id, "quiet");
       await this.reply(chatId, this.formatSessionPreparing(session.projectId));
     } catch (error) {
       await this.reply(chatId, this.formatManagerError(error));
@@ -666,7 +666,7 @@ class AsyncTelegramAdapterImpl {
   }
 
   private getSessionVerbosity(sessionId: string): SessionVerbosity {
-    return this.sessionVerbosityBySession.get(sessionId) ?? "verbose";
+    return this.sessionVerbosityBySession.get(sessionId) ?? "quiet";
   }
 
   private isVerboseSession(sessionId: string): boolean {

--- a/test/async_telegram.test.js
+++ b/test/async_telegram.test.js
@@ -405,6 +405,14 @@ describe("async telegram adapter", () => {
             text: "/use s9",
           },
         },
+        {
+          update_id: 2,
+          message: {
+            chat: { id: 400, type: "private" },
+            from: { id: 7 },
+            text: "/verbose",
+          },
+        },
       ],
     ]);
 
@@ -428,7 +436,11 @@ describe("async telegram adapter", () => {
     });
 
     try {
-      await waitFor(() => apiHarness.sendMessages.length >= 1);
+      await waitFor(() =>
+        apiHarness.sendMessages.some((entry) =>
+          entry.text.includes("(s9) verbosity set to verbose"),
+        ),
+      );
 
       managerHarness.manager.emit({
         type: "session-state-changed",
@@ -486,6 +498,14 @@ describe("async telegram adapter", () => {
             text: "/use s10",
           },
         },
+        {
+          update_id: 2,
+          message: {
+            chat: { id: 450, type: "private" },
+            from: { id: 7 },
+            text: "/verbose",
+          },
+        },
       ],
     ]);
 
@@ -509,7 +529,11 @@ describe("async telegram adapter", () => {
     });
 
     try {
-      await waitFor(() => apiHarness.sendMessages.length >= 1);
+      await waitFor(() =>
+        apiHarness.sendMessages.some((entry) =>
+          entry.text.includes("(s10) verbosity set to verbose"),
+        ),
+      );
 
       managerHarness.manager.emit({
         type: "session-progress",


### PR DESCRIPTION
- make new telegram sessions default to quiet verbosity
- update status fallback verbosity display to quiet
- update async telegram tests that rely on streamed updates to opt into /verbose
- update async docs to describe /quiet as the default mode

validation:
- npm run check
- npm test
