### PR TITLE
support .agents/skills discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,7 +189,7 @@ On conflicts, the most specific level wins (built-ins are the base layer).
 - `sandbox.environmentInfo` (optional): Freeform text injected into the system prompt to describe the sandbox environment.
 - **Prompts**: `~/.config/tau/prompts/*.md` and `.tau/prompts/*.md` (discovered by walking up from cwd to home/root; most specific wins on conflicts). Prompt file names (without `.md`) must match their `id`.
 - **Themes**: `~/.config/tau/themes/*.json` and `.tau/themes/*.json` (same discovery rules as prompts/config). Theme values accept `#rgb`, `#rrggbb`, `rgb(r, g, b)`, or `hsl(h, s%, l%)`. Missing palette tokens render as plain text when a theme is selected. Built-in themes auto-adapt to dark/light terminal backgrounds via OSC 11 detection at startup (best effort, dark fallback). Custom themes remain single-variant.
-- **Skills**: `~/.config/tau/skills/` and `.tau/skills/` (discovered by walking up from cwd to home/root). Each skill is a directory containing `SKILL.md` with required YAML frontmatter:
+- **Skills**: `~/.config/tau/skills/` and `~/.agents/skills/` (global, only when cwd is under home), plus `.tau/skills/` and `.agents/skills/` (discovered by walking up from cwd to home/root). Each skill is a directory containing `SKILL.md` with required YAML frontmatter. When `.tau/skills/` and `.agents/skills/` both exist at the same level, `.agents/skills/` wins on name conflicts:
   - `name` (1-64 chars, `a-z0-9-`, must match directory name)
   - `description` (1-1024 chars)
 

--- a/README.md
+++ b/README.md
@@ -627,7 +627,7 @@ the prompt file name (without the `.md` extension) must match the `id`.
 
 ### skills
 
-skills are optional directories discovered at `~/.config/tau/skills/` (only when cwd is under home) and `.tau/skills/` in the cwd ancestry (up to home, or filesystem root if cwd is outside home). each skill is a directory containing `SKILL.md`. tau follows the [agent skills spec](https://agentskills.io/home).
+skills are optional directories discovered at `~/.config/tau/skills/` and `~/.agents/skills/` (global, only when cwd is under home), plus `.tau/skills/` and `.agents/skills/` in the cwd ancestry (up to home, or filesystem root if cwd is outside home). each skill is a directory containing `SKILL.md`. tau follows the [agent skills spec](https://agentskills.io/home). when `.tau/skills/` and `.agents/skills/` both exist at the same level, `.agents/skills/` wins on name conflicts.
 
 `SKILL.md` must start with yaml frontmatter:
 

--- a/src/core/config/content_loader.ts
+++ b/src/core/config/content_loader.ts
@@ -1095,6 +1095,22 @@ function parseSkill(filePath: string, content: string): { skill?: Skill; error?:
   };
 }
 
+function loadSkillsFromDir(dir: string, deps: ConfigDeps): { skills: Skill[]; errors: string[] } {
+  const { entries, errors } = loadMarkdownEntries(dir, deps, listSkillFiles);
+  const skills: Skill[] = [];
+
+  for (const entry of entries) {
+    const result = parseSkill(entry.path, entry.content);
+    if (result.skill) {
+      skills.push(result.skill);
+    } else if (result.error) {
+      errors.push(result.error);
+    }
+  }
+
+  return { skills, errors };
+}
+
 export async function loadUserSkills(args?: {
   deps?: ConfigDeps;
   levels?: ConfigLevel[];
@@ -1112,16 +1128,15 @@ export async function loadUserSkills(args?: {
   if (!globalLevel) {
     return { skills: [], errors: [] };
   }
-  const { entries, errors } = loadMarkdownEntries(globalLevel.skillsDir, deps, listSkillFiles);
-  const skills: Skill[] = [];
 
-  for (const entry of entries) {
-    const result = parseSkill(entry.path, entry.content);
-    if (result.skill) {
-      skills.push(result.skill);
-    } else if (result.error) {
-      errors.push(result.error);
-    }
+  const skills: Skill[] = [];
+  const errors: string[] = [];
+  const skillDirs = [globalLevel.skillsDir, globalLevel.agentsSkillsDir];
+
+  for (const dir of skillDirs) {
+    const result = loadSkillsFromDir(dir, deps);
+    skills.push(...result.skills);
+    errors.push(...result.errors);
   }
 
   return { skills, errors };
@@ -1150,20 +1165,12 @@ export async function loadProjectSkills(args?: {
 
   // Parent-first order, closest directory wins on conflicts.
   for (const level of projectLevels) {
-    const { entries, errors: entryErrors } = loadMarkdownEntries(
-      level.skillsDir,
-      deps,
-      listSkillFiles,
-    );
-    errors.push(...entryErrors);
+    const skillDirs = [level.skillsDir, level.agentsSkillsDir];
 
-    for (const entry of entries) {
-      const result = parseSkill(entry.path, entry.content);
-      if (result.skill) {
-        skills.push(result.skill);
-      } else if (result.error) {
-        errors.push(result.error);
-      }
+    for (const dir of skillDirs) {
+      const result = loadSkillsFromDir(dir, deps);
+      skills.push(...result.skills);
+      errors.push(...result.errors);
     }
   }
 

--- a/src/core/config/paths.ts
+++ b/src/core/config/paths.ts
@@ -10,6 +10,7 @@ export type ConfigLevel = {
   personasDir: string;
   promptsDir: string;
   skillsDir: string;
+  agentsSkillsDir: string;
   themesDir: string;
   scope: ConfigLevelScope;
 };
@@ -24,6 +25,7 @@ function buildLevel(levelRoot: string, configDir: string, scope: ConfigLevelScop
     personasDir: join(dir, "personas"),
     promptsDir: join(dir, "prompts"),
     skillsDir: join(dir, "skills"),
+    agentsSkillsDir: join(root, ".agents", "skills"),
     themesDir: join(dir, "themes"),
     scope,
   };
@@ -57,7 +59,8 @@ export function resolveConfigLevels(deps: ConfigDeps, options?: { cwd?: string }
 
   while (true) {
     const configDir = join(dir, ".tau");
-    if (isDirectory(deps, configDir)) {
+    const agentsSkillsDir = join(dir, ".agents", "skills");
+    if (isDirectory(deps, configDir) || isDirectory(deps, agentsSkillsDir)) {
       projectLevels.push(buildLevel(dir, configDir, "project"));
     }
 

--- a/test/skills_discovery.test.js
+++ b/test/skills_discovery.test.js
@@ -1,0 +1,137 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { loadAllContent, resolveConfigLevels } from "../dist/core/config/index.js";
+
+function createConfigDeps({ cwd, home }) {
+  return {
+    fs: {
+      readFile: (path) => readFileSync(path, "utf-8"),
+      exists: (path) => existsSync(path),
+      listDir: (path) => readdirSync(path),
+      stat: (path) => statSync(path),
+    },
+    env: {
+      getEnv: () => ({}),
+      cwd: () => cwd,
+      home: () => home,
+    },
+  };
+}
+
+function setupFixture() {
+  const home = mkdtempSync(join(tmpdir(), "tau-skills-home-"));
+  const cwd = join(home, "repo", "packages", "app");
+  mkdirSync(cwd, { recursive: true });
+
+  return {
+    home: resolve(home),
+    cwd: resolve(cwd),
+    cleanup: () => {
+      rmSync(home, { recursive: true, force: true });
+    },
+  };
+}
+
+function writeSkill(skillsDir, name, description) {
+  const skillDir = join(skillsDir, name);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(
+    join(skillDir, "SKILL.md"),
+    ["---", `name: ${name}`, `description: ${description}`, "---", ""].join("\n"),
+  );
+}
+
+describe("skills discovery", () => {
+  it("loads project skills from .agents/skills when .tau is absent", async () => {
+    const fx = setupFixture();
+
+    try {
+      const skillsDir = join(fx.cwd, ".agents", "skills");
+      writeSkill(skillsDir, "alpha", "alpha from agents");
+
+      const deps = createConfigDeps({ cwd: fx.cwd, home: fx.home });
+      const { skills, errors } = await loadAllContent({}, { deps, cwd: fx.cwd });
+
+      expect(errors).toEqual([]);
+      expect(skills.map((skill) => skill.name)).toEqual(["alpha"]);
+      expect(skills[0].description).toBe("alpha from agents");
+      expect(skills[0].path).toBe(join(skillsDir, "alpha", "SKILL.md"));
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("traverses .agents/skills up the cwd ancestry", async () => {
+    const fx = setupFixture();
+
+    try {
+      const repoRoot = join(fx.home, "repo");
+      const packageRoot = join(repoRoot, "packages");
+      writeSkill(join(repoRoot, ".agents", "skills"), "root-skill", "from repo root");
+      writeSkill(join(packageRoot, ".agents", "skills"), "pkg-skill", "from package root");
+
+      const deps = createConfigDeps({ cwd: fx.cwd, home: fx.home });
+      const levels = resolveConfigLevels(deps, { cwd: fx.cwd })
+        .filter((level) => level.scope === "project")
+        .map((level) => level.levelRoot);
+      expect(levels).toEqual([repoRoot, packageRoot]);
+
+      const { skills, errors } = await loadAllContent({}, { deps, cwd: fx.cwd });
+      expect(errors).toEqual([]);
+      expect(skills.map((skill) => skill.name)).toEqual(["pkg-skill", "root-skill"]);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("prefers .agents/skills over .tau/skills at the same level", async () => {
+    const fx = setupFixture();
+
+    try {
+      const repoRoot = join(fx.home, "repo");
+      writeSkill(join(repoRoot, ".tau", "skills"), "shared", "from tau");
+      writeSkill(join(repoRoot, ".agents", "skills"), "shared", "from agents");
+
+      const deps = createConfigDeps({ cwd: fx.cwd, home: fx.home });
+      const { skills, errors } = await loadAllContent({}, { deps, cwd: fx.cwd });
+      expect(errors).toEqual([]);
+
+      const shared = skills.find((skill) => skill.name === "shared");
+      expect(shared).toBeTruthy();
+      expect(shared.description).toBe("from agents");
+      expect(shared.path).toBe(join(repoRoot, ".agents", "skills", "shared", "SKILL.md"));
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("loads user skills from ~/.agents/skills", async () => {
+    const fx = setupFixture();
+
+    try {
+      writeSkill(join(fx.home, ".agents", "skills"), "global-agent", "from global agents");
+
+      const deps = createConfigDeps({ cwd: fx.cwd, home: fx.home });
+      const { skills, errors } = await loadAllContent({}, { deps, cwd: fx.cwd });
+      expect(errors).toEqual([]);
+
+      const globalAgent = skills.find((skill) => skill.name === "global-agent");
+      expect(globalAgent).toBeTruthy();
+      expect(globalAgent.description).toBe("from global agents");
+      expect(globalAgent.path).toBe(join(fx.home, ".agents", "skills", "global-agent", "SKILL.md"));
+    } finally {
+      fx.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
- load skills from `.agents/skills` alongside `.tau/skills` at each traversed project level
- include project levels when `.agents/skills` exists even without `.tau`, so ancestry traversal works for `.agents`-only setups
- support `~/.agents/skills` as a global skills source when cwd is under home
- define same-level precedence as `.tau/skills` first, then `.agents/skills`, so `.agents` wins conflicts
- add `test/skills_discovery.test.js` coverage for loading, ancestry traversal, precedence, and global `.agents` skills
- update README and AGENTS.md skills discovery docs

validation:
- npm run check
- npm test

fixes #95
