### PR TITLE
fix telegram session multiplexing

### DIFF
--- a/docs/async.md
+++ b/docs/async.md
@@ -139,9 +139,9 @@ Supported DM commands:
 - `/list`
 - `/status`
 - `/cancel`
-- `/verbose` (streams run lifecycle + progress updates)
-- `/quiet` (default mode, send only the run's final assistant message, no streamed progress)
-- plain text sends to the active session
+- `/verbose` (for the selected session, streams run lifecycle + progress updates)
+- `/quiet` (for the selected session, default mode, send only the run's final assistant message)
+- plain text sends to the selected session
 
 The adapter registers these commands via Telegram's command list so clients can autocomplete them.
 
@@ -151,6 +151,9 @@ Optional allowlists:
 - `allowedChatIds`
 
 If provided, both must match for a DM to be processed.
+
+Telegram keeps one selected session per chat for command and plain-text input routing, but it continues
+streaming events for every session that has been selected in that chat.
 
 Lifecycle notifications are sent back to associated chats:
 
@@ -176,7 +179,8 @@ Async daemon state is in-memory only:
 
 - session records
 - session logs
-- Telegram chat routing (`chatId -> activeSessionId`)
+- Telegram chat routing (selected session per chat)
+- Telegram chat-to-session associations for multiplexed event streaming
 - Telegram per-session state (verbosity mode, last command, last assistant message)
 
 Restarting the daemon clears this state. Existing cloned workspaces on disk are not reused as daemon session state.

--- a/src/core/async/telegram.ts
+++ b/src/core/async/telegram.ts
@@ -192,6 +192,7 @@ class AsyncTelegramAdapterImpl {
   private readonly onLog?: (entry: AsyncTelegramLogEntry) => void;
   private readonly abortController = new AbortController();
   private readonly activeSessionsByChat = new Map<number, string>();
+  private readonly sessionsByChat = new Map<number, Set<string>>();
   private readonly chatsBySession = new Map<string, Set<number>>();
   private readonly sessionVerbosityBySession = new Map<string, SessionVerbosity>();
   private readonly lastCommandBySession = new Map<string, string>();
@@ -630,20 +631,8 @@ class AsyncTelegramAdapterImpl {
   }
 
   private setActiveSession(chatId: number, sessionId: string): void {
-    const currentSessionId = this.activeSessionsByChat.get(chatId);
-    if (currentSessionId && currentSessionId !== sessionId) {
-      const currentChats = this.chatsBySession.get(currentSessionId);
-      currentChats?.delete(chatId);
-      if (currentChats && currentChats.size === 0) {
-        this.chatsBySession.delete(currentSessionId);
-      }
-    }
-
     this.activeSessionsByChat.set(chatId, sessionId);
-
-    const chats = this.chatsBySession.get(sessionId) ?? new Set<number>();
-    chats.add(chatId);
-    this.chatsBySession.set(sessionId, chats);
+    this.linkChatToSession(chatId, sessionId);
   }
 
   private clearActiveSession(chatId: number): void {
@@ -653,6 +642,27 @@ class AsyncTelegramAdapterImpl {
     }
 
     this.activeSessionsByChat.delete(chatId);
+    this.unlinkChatFromSession(chatId, sessionId);
+  }
+
+  private linkChatToSession(chatId: number, sessionId: string): void {
+    const sessions = this.sessionsByChat.get(chatId) ?? new Set<string>();
+    sessions.add(sessionId);
+    this.sessionsByChat.set(chatId, sessions);
+
+    const chats = this.chatsBySession.get(sessionId) ?? new Set<number>();
+    chats.add(chatId);
+    this.chatsBySession.set(sessionId, chats);
+  }
+
+  private unlinkChatFromSession(chatId: number, sessionId: string): void {
+    const sessions = this.sessionsByChat.get(chatId);
+    if (sessions) {
+      sessions.delete(sessionId);
+      if (sessions.size === 0) {
+        this.sessionsByChat.delete(chatId);
+      }
+    }
 
     const chats = this.chatsBySession.get(sessionId);
     if (!chats) {

--- a/test/async_telegram.test.js
+++ b/test/async_telegram.test.js
@@ -683,6 +683,197 @@ describe("async telegram adapter", () => {
     }
   });
 
+  it("keeps forwarding session events after /new switches the selected session", async () => {
+    const apiHarness = createApiHarness([
+      [
+        {
+          update_id: 1,
+          message: {
+            chat: { id: 465, type: "private" },
+            from: { id: 7 },
+            text: "/new",
+          },
+        },
+        {
+          update_id: 2,
+          message: {
+            chat: { id: 465, type: "private" },
+            from: { id: 7 },
+            text: "/verbose",
+          },
+        },
+        {
+          update_id: 3,
+          message: {
+            chat: { id: 465, type: "private" },
+            from: { id: 7 },
+            text: "/new",
+          },
+        },
+      ],
+    ]);
+
+    const managerHarness = createSessionManagerHarness();
+
+    const adapter = await startAsyncTelegramAdapter({
+      botToken: "token",
+      projects: { demo: { repo: "git@example.com:demo.git" } },
+      sessionManager: managerHarness.manager,
+      api: apiHarness.api,
+      pollIntervalMs: 1,
+      requestTimeoutSeconds: 1,
+    });
+
+    try {
+      await waitFor(() => managerHarness.manager.createSession.mock.calls.length === 2);
+
+      managerHarness.manager.emit({
+        type: "session-progress",
+        sessionId: "s1",
+        projectId: "demo",
+        state: "running",
+        timestamp: "2024-01-01T00:01:00.000Z",
+        progress: {
+          type: "assistant-message",
+          text: "first session update",
+        },
+      });
+
+      await waitFor(() =>
+        apiHarness.sendMessages.some((entry) => entry.text.includes("(s1) assistant message")),
+      );
+
+      expect(
+        apiHarness.sendMessages.some((entry) => entry.text.includes("(s1) assistant message")),
+      ).toBe(true);
+    } finally {
+      await adapter.close();
+    }
+  });
+
+  it("scopes /quiet and /verbose to the selected session while multiplexing", async () => {
+    const apiHarness = createApiHarness([
+      [
+        {
+          update_id: 1,
+          message: {
+            chat: { id: 466, type: "private" },
+            from: { id: 7 },
+            text: "/use s1",
+          },
+        },
+        {
+          update_id: 2,
+          message: {
+            chat: { id: 466, type: "private" },
+            from: { id: 7 },
+            text: "/verbose",
+          },
+        },
+        {
+          update_id: 3,
+          message: {
+            chat: { id: 466, type: "private" },
+            from: { id: 7 },
+            text: "/use s2",
+          },
+        },
+        {
+          update_id: 4,
+          message: {
+            chat: { id: 466, type: "private" },
+            from: { id: 7 },
+            text: "/quiet",
+          },
+        },
+      ],
+    ]);
+
+    const managerHarness = createSessionManagerHarness([
+      {
+        id: "s1",
+        projectId: "demo",
+        state: "waiting-input",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+      {
+        id: "s2",
+        projectId: "demo",
+        state: "waiting-input",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    const adapter = await startAsyncTelegramAdapter({
+      botToken: "token",
+      projects: { demo: { repo: "git@example.com:demo.git" } },
+      sessionManager: managerHarness.manager,
+      api: apiHarness.api,
+      pollIntervalMs: 1,
+      requestTimeoutSeconds: 1,
+    });
+
+    try {
+      await waitFor(() => apiHarness.sendMessages.length >= 4);
+
+      managerHarness.manager.emit({
+        type: "session-progress",
+        sessionId: "s1",
+        projectId: "demo",
+        state: "running",
+        timestamp: "2024-01-01T00:01:00.000Z",
+        progress: {
+          type: "assistant-message",
+          text: "update from s1",
+        },
+      });
+
+      managerHarness.manager.emit({
+        type: "session-state-changed",
+        sessionId: "s2",
+        projectId: "demo",
+        previousState: "waiting-input",
+        state: "running",
+        updatedAt: "2024-01-01T00:02:00.000Z",
+      });
+
+      managerHarness.manager.emit({
+        type: "session-progress",
+        sessionId: "s2",
+        projectId: "demo",
+        state: "running",
+        timestamp: "2024-01-01T00:03:00.000Z",
+        progress: {
+          type: "assistant-message",
+          text: "final from s2",
+        },
+      });
+
+      managerHarness.manager.emit({
+        type: "session-state-changed",
+        sessionId: "s2",
+        projectId: "demo",
+        previousState: "running",
+        state: "waiting-input",
+        updatedAt: "2024-01-01T00:04:00.000Z",
+      });
+
+      await waitFor(
+        () =>
+          apiHarness.sendMessages.some((entry) => entry.text.includes("(s1) assistant message")) &&
+          apiHarness.sendMessages.some((entry) => entry.text === "final from s2"),
+      );
+
+      expect(
+        apiHarness.sendMessages.some((entry) => entry.text.includes("(s2) assistant message")),
+      ).toBe(false);
+    } finally {
+      await adapter.close();
+    }
+  });
+
   it("only sends the final assistant message in quiet mode", async () => {
     const apiHarness = createApiHarness([
       [


### PR DESCRIPTION
- keep chat-to-session links when switching the selected session, so Telegram continues receiving events from earlier sessions
- keep `/verbose` and `/quiet` scoped to the currently selected session while event streaming stays multiplexed
- add regression coverage for `/new` switching and mixed per-session verbosity, and update async docs

fixes #97
