### PR TITLE
add /close commands for async telegram sessions

### DIFF
--- a/docs/async.md
+++ b/docs/async.md
@@ -139,6 +139,9 @@ Supported DM commands:
 - `/list`
 - `/status`
 - `/cancel`
+- `/close` (closes the selected session)
+- `/close <sessionId>` (closes a specific session)
+- `/close all` (closes all inactive sessions)
 - `/verbose` (for the selected session, streams run lifecycle + progress updates)
 - `/quiet` (for the selected session, default mode, send only the run's final assistant message)
 - plain text sends to the selected session

--- a/src/core/async/session_manager.ts
+++ b/src/core/async/session_manager.ts
@@ -127,6 +127,8 @@ export type AsyncSessionManager = {
     options?: AsyncSessionSubmitOptions,
   ): Promise<AsyncSessionRecord>;
   cancelSession(sessionId: string): Promise<AsyncSessionRecord>;
+  closeSession(sessionId: string): Promise<AsyncSessionRecord>;
+  closeInactiveSessions(): Promise<AsyncSessionRecord[]>;
   close(): Promise<void>;
   onEvent(listener: (event: AsyncSessionManagerEvent) => void): () => void;
 };
@@ -285,6 +287,24 @@ class AsyncSessionManagerImpl implements AsyncSessionManager {
     this.requestCancellation(entry, "cancel requested");
     await this.stopClient(entry);
     return this.toRecord(entry);
+  }
+
+  async closeSession(sessionId: string): Promise<AsyncSessionRecord> {
+    const entry = this.requireSession(sessionId);
+    return await this.closeEntry(entry, "close requested");
+  }
+
+  async closeInactiveSessions(): Promise<AsyncSessionRecord[]> {
+    const entries = Array.from(this.sessions.values()).filter((entry) =>
+      this.isInactiveState(entry.record.state),
+    );
+
+    const closed: AsyncSessionRecord[] = [];
+    for (const entry of entries) {
+      closed.push(await this.closeEntry(entry, "close requested"));
+    }
+
+    return closed;
   }
 
   async close(): Promise<void> {
@@ -456,6 +476,28 @@ class AsyncSessionManagerImpl implements AsyncSessionManager {
     );
   }
 
+  private async closeEntry(entry: SessionEntry, message: string): Promise<AsyncSessionRecord> {
+    if (this.isActiveState(entry.record.state)) {
+      this.requestCancellation(entry, message);
+    } else {
+      this.log(entry, "info", message);
+    }
+
+    await this.stopClient(entry);
+
+    const pendingWork = [entry.activeSubmit, entry.initializePromise].filter(
+      (promise): promise is Promise<void> => promise !== undefined,
+    );
+
+    if (pendingWork.length > 0) {
+      await Promise.allSettled(pendingWork);
+    }
+
+    const record = this.toRecord(entry);
+    this.deleteEntry(entry.record.id);
+    return record;
+  }
+
   private requestCancellation(entry: SessionEntry, message: string): void {
     entry.cancelRequested = true;
     entry.abortController.abort();
@@ -530,6 +572,20 @@ class AsyncSessionManagerImpl implements AsyncSessionManager {
       state === "running" ||
       state === "waiting-input"
     );
+  }
+
+  private isInactiveState(state: AsyncSessionState): boolean {
+    return !this.isActiveState(state);
+  }
+
+  private deleteEntry(sessionId: string): void {
+    const internalId = this.sessionInternalIds.get(sessionId);
+    if (!internalId) {
+      return;
+    }
+
+    this.sessionInternalIds.delete(sessionId);
+    this.sessions.delete(internalId);
   }
 
   private getEntryBySessionId(sessionId: string): SessionEntry | undefined {

--- a/src/core/async/telegram.ts
+++ b/src/core/async/telegram.ts
@@ -97,6 +97,7 @@ const TELEGRAM_COMMANDS: TelegramBotCommand[] = [
   { command: "list", description: "list sessions" },
   { command: "status", description: "show active session status" },
   { command: "cancel", description: "cancel active session" },
+  { command: "close", description: "close session(s)" },
   { command: "verbose", description: "stream progress updates" },
   { command: "quiet", description: "only send final assistant message" },
 ];
@@ -429,6 +430,11 @@ class AsyncTelegramAdapterImpl {
       return;
     }
 
+    if (command === "/close") {
+      await this.handleClose(chatId, args);
+      return;
+    }
+
     if (command === "/verbose") {
       await this.handleVerbosityCommand(chatId, "verbose");
       return;
@@ -441,7 +447,7 @@ class AsyncTelegramAdapterImpl {
 
     await this.reply(
       chatId,
-      "supported commands: /new, /use, /list, /status, /cancel, /verbose, /quiet",
+      "supported commands: /new, /use, /list, /status, /cancel, /close, /verbose, /quiet",
     );
   }
 
@@ -585,6 +591,55 @@ class AsyncTelegramAdapterImpl {
     }
   }
 
+  private async handleClose(chatId: number, args: string[]): Promise<void> {
+    if (args.length > 1) {
+      await this.reply(chatId, "usage: /close [<sessionId>|all]");
+      return;
+    }
+
+    const target = args[0]?.trim();
+    if (target === "all") {
+      try {
+        const closed = await this.sessionManager.closeInactiveSessions();
+        for (const session of closed) {
+          this.clearClosedSession(session.id);
+        }
+
+        if (closed.length === 0) {
+          await this.reply(chatId, "no inactive sessions to close");
+          return;
+        }
+
+        const label = closed.length === 1 ? "session" : "sessions";
+        await this.reply(
+          chatId,
+          [
+            `closed ${closed.length} inactive ${label}`,
+            closed.map((session) => session.id).join(", "),
+          ].join("\n"),
+        );
+      } catch (error) {
+        await this.reply(chatId, this.formatManagerError(error));
+      }
+
+      return;
+    }
+
+    const sessionId = target ?? this.getActiveSession(chatId)?.id;
+    if (!sessionId) {
+      await this.reply(chatId, "no active session. use /new or /use <sessionId>");
+      return;
+    }
+
+    try {
+      const closed = await this.sessionManager.closeSession(sessionId);
+      this.clearClosedSession(closed.id);
+      await this.reply(chatId, formatSessionHeadline(closed.id, "closed"));
+    } catch (error) {
+      await this.reply(chatId, this.formatManagerError(error));
+    }
+  }
+
   private async handleVerbosityCommand(chatId: number, verbosity: SessionVerbosity): Promise<void> {
     const session = this.getActiveSession(chatId);
     if (!session) {
@@ -673,6 +728,24 @@ class AsyncTelegramAdapterImpl {
     if (chats.size === 0) {
       this.chatsBySession.delete(sessionId);
     }
+  }
+
+  private clearClosedSession(sessionId: string): void {
+    for (const [chatId, activeSessionId] of this.activeSessionsByChat) {
+      if (activeSessionId === sessionId) {
+        this.activeSessionsByChat.delete(chatId);
+      }
+    }
+
+    const chatIds = Array.from(this.chatsBySession.get(sessionId) ?? []);
+    for (const chatId of chatIds) {
+      this.unlinkChatFromSession(chatId, sessionId);
+    }
+
+    this.sessionVerbosityBySession.delete(sessionId);
+    this.lastCommandBySession.delete(sessionId);
+    this.lastAssistantMessageBySession.delete(sessionId);
+    this.latestAssistantMessageByRun.delete(sessionId);
   }
 
   private getSessionVerbosity(sessionId: string): SessionVerbosity {

--- a/test/async_session_manager.test.js
+++ b/test/async_session_manager.test.js
@@ -349,6 +349,68 @@ describe("async session manager", () => {
     expect(logs.some((entry) => entry.message === "cancel requested")).toBe(true);
   });
 
+  it("closes a selected session and removes it from memory", async () => {
+    const clientHarness = createClientHarness();
+
+    const manager = createAsyncSessionManager({
+      projects: {
+        demo: {
+          repo: "git@example.com:demo.git",
+        },
+      },
+      prepareWorkspace: vi.fn(async () => ({ workspacePath: "/tmp/ws/demo" })),
+      createClient: vi.fn(async () => clientHarness.client),
+    });
+
+    const created = await manager.createSession({ projectId: "demo" });
+    await waitFor(() => manager.getSession(created.id)?.state === "waiting-input");
+
+    const closed = await manager.closeSession(created.id);
+    expect(closed).toEqual(expect.objectContaining({ id: created.id, state: "canceled" }));
+    expect(manager.getSession(created.id)).toBeUndefined();
+    expect(manager.listSessions()).toEqual([]);
+    expect(manager.getLogs(created.id)).toBeUndefined();
+    expect(clientHarness.client.interrupt).toHaveBeenCalledTimes(1);
+    expect(clientHarness.client.shutdown).toHaveBeenCalledTimes(1);
+    expect(clientHarness.client.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes only inactive sessions in bulk", async () => {
+    const firstClientHarness = createClientHarness();
+    const secondClientHarness = createClientHarness();
+    const clients = [firstClientHarness.client, secondClientHarness.client];
+
+    const manager = createAsyncSessionManager({
+      projects: {
+        demo: {
+          repo: "git@example.com:demo.git",
+        },
+      },
+      prepareWorkspace: vi.fn(async () => ({ workspacePath: "/tmp/ws/demo" })),
+      createClient: vi.fn(async () => {
+        const next = clients.shift();
+        if (!next) {
+          throw new Error("missing client");
+        }
+        return next;
+      }),
+    });
+
+    const inactive = await manager.createSession({ projectId: "demo" });
+    const active = await manager.createSession({ projectId: "demo" });
+
+    await waitFor(() => manager.getSession(inactive.id)?.state === "waiting-input");
+    await waitFor(() => manager.getSession(active.id)?.state === "waiting-input");
+
+    const canceled = await manager.cancelSession(inactive.id);
+    expect(canceled.state).toBe("canceled");
+
+    const closed = await manager.closeInactiveSessions();
+    expect(closed).toEqual([expect.objectContaining({ id: inactive.id, state: "canceled" })]);
+    expect(manager.getSession(inactive.id)).toBeUndefined();
+    expect(manager.getSession(active.id)).toEqual(expect.objectContaining({ id: active.id }));
+  });
+
   it("closes active sessions and sdk clients during manager shutdown", async () => {
     const clientHarness = createClientHarness();
     clientHarness.client.interrupt = vi.fn(async () => {

--- a/test/async_telegram.test.js
+++ b/test/async_telegram.test.js
@@ -81,6 +81,24 @@ function createSessionManagerHarness(initialSessions = []) {
       session.updatedAt = "2024-01-01T00:02:00.000Z";
       return { ...session };
     }),
+    closeSession: vi.fn(async (sessionId) => {
+      const session = sessions.get(sessionId);
+      if (!session) {
+        throw new Error("missing session");
+      }
+      sessions.delete(sessionId);
+      return { ...session };
+    }),
+    closeInactiveSessions: vi.fn(async () => {
+      const closed = [];
+      for (const [sessionId, session] of sessions) {
+        if (session.state === "canceled" || session.state === "failed") {
+          closed.push({ ...session });
+          sessions.delete(sessionId);
+        }
+      }
+      return closed;
+    }),
     onEvent: vi.fn((listener) => {
       listeners.add(listener);
       return () => {
@@ -122,6 +140,7 @@ describe("async telegram adapter", () => {
         { command: "list", description: "list sessions" },
         { command: "status", description: "show active session status" },
         { command: "cancel", description: "cancel active session" },
+        { command: "close", description: "close session(s)" },
         { command: "verbose", description: "stream progress updates" },
         { command: "quiet", description: "only send final assistant message" },
       ]);
@@ -388,6 +407,165 @@ describe("async telegram adapter", () => {
       expect(managerHarness.manager.cancelSession).toHaveBeenCalledWith("s2");
       expect(
         apiHarness.sendMessages.some((entry) => String(entry.text).includes("(s2) canceled")),
+      ).toBe(true);
+    } finally {
+      await adapter.close();
+    }
+  });
+
+  it("supports /close for the selected session", async () => {
+    const apiHarness = createApiHarness([
+      [
+        {
+          update_id: 1,
+          message: {
+            chat: { id: 310, type: "private" },
+            from: { id: 7 },
+            text: "/use s2",
+          },
+        },
+        {
+          update_id: 2,
+          message: {
+            chat: { id: 310, type: "private" },
+            from: { id: 7 },
+            text: "/close",
+          },
+        },
+      ],
+    ]);
+
+    const managerHarness = createSessionManagerHarness([
+      {
+        id: "s2",
+        projectId: "demo",
+        state: "waiting-input",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    const adapter = await startAsyncTelegramAdapter({
+      botToken: "token",
+      projects: { demo: { repo: "git@example.com:demo.git" } },
+      sessionManager: managerHarness.manager,
+      api: apiHarness.api,
+      pollIntervalMs: 1,
+      requestTimeoutSeconds: 1,
+    });
+
+    try {
+      await waitFor(() => managerHarness.manager.closeSession.mock.calls.length === 1);
+      expect(managerHarness.manager.closeSession).toHaveBeenCalledWith("s2");
+      expect(
+        apiHarness.sendMessages.some((entry) => String(entry.text).includes("(s2) closed")),
+      ).toBe(true);
+    } finally {
+      await adapter.close();
+    }
+  });
+
+  it("supports /close <id>", async () => {
+    const apiHarness = createApiHarness([
+      [
+        {
+          update_id: 1,
+          message: {
+            chat: { id: 320, type: "private" },
+            from: { id: 7 },
+            text: "/close s3",
+          },
+        },
+      ],
+    ]);
+
+    const managerHarness = createSessionManagerHarness([
+      {
+        id: "s3",
+        projectId: "demo",
+        state: "waiting-input",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    const adapter = await startAsyncTelegramAdapter({
+      botToken: "token",
+      projects: { demo: { repo: "git@example.com:demo.git" } },
+      sessionManager: managerHarness.manager,
+      api: apiHarness.api,
+      pollIntervalMs: 1,
+      requestTimeoutSeconds: 1,
+    });
+
+    try {
+      await waitFor(() => managerHarness.manager.closeSession.mock.calls.length === 1);
+      expect(managerHarness.manager.closeSession).toHaveBeenCalledWith("s3");
+      expect(
+        apiHarness.sendMessages.some((entry) => String(entry.text).includes("(s3) closed")),
+      ).toBe(true);
+    } finally {
+      await adapter.close();
+    }
+  });
+
+  it("supports /close all for inactive sessions", async () => {
+    const apiHarness = createApiHarness([
+      [
+        {
+          update_id: 1,
+          message: {
+            chat: { id: 330, type: "private" },
+            from: { id: 7 },
+            text: "/close all",
+          },
+        },
+      ],
+    ]);
+
+    const managerHarness = createSessionManagerHarness([
+      {
+        id: "s1",
+        projectId: "demo",
+        state: "waiting-input",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+      {
+        id: "s2",
+        projectId: "demo",
+        state: "failed",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+      {
+        id: "s3",
+        projectId: "demo",
+        state: "canceled",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    const adapter = await startAsyncTelegramAdapter({
+      botToken: "token",
+      projects: { demo: { repo: "git@example.com:demo.git" } },
+      sessionManager: managerHarness.manager,
+      api: apiHarness.api,
+      pollIntervalMs: 1,
+      requestTimeoutSeconds: 1,
+    });
+
+    try {
+      await waitFor(() => managerHarness.manager.closeInactiveSessions.mock.calls.length === 1);
+      expect(managerHarness.manager.closeInactiveSessions).toHaveBeenCalledTimes(1);
+      expect(
+        apiHarness.sendMessages.some(
+          (entry) =>
+            entry.text.includes("closed 2 inactive sessions") &&
+            entry.text.includes("s2") &&
+            entry.text.includes("s3"),
+        ),
       ).toBe(true);
     } finally {
       await adapter.close();


### PR DESCRIPTION
- add `/close`, `/close <sessionId>`, and `/close all` command handling in the Telegram adapter
- add async session manager APIs to close a single session and bulk-close inactive sessions
- clear Telegram chat/session routing metadata when sessions are closed
- extend async telegram and session manager test coverage for the new close flows
- document the new Telegram commands in `docs/async.md`

fixes #98
