### PR TITLE
suppress quiet message queued and add telegram eyes reaction

### DIFF
--- a/docs/async.md
+++ b/docs/async.md
@@ -146,6 +146,8 @@ Supported DM commands:
 - `/quiet` (for the selected session, default mode, send only the run's final assistant message)
 - plain text sends to the selected session
 
+When a plain-text message is accepted for a session, the adapter tries to add a 👀 reaction to that user message (best effort).
+
 The adapter registers these commands via Telegram's command list so clients can autocomplete them.
 
 Optional allowlists:
@@ -174,7 +176,7 @@ In `/verbose` mode, run updates also include:
 - each successful write call (`wrote file`)
 - each assistant final message for the current run (`assistant message`)
 
-In `/quiet` mode, these streamed updates are suppressed and only the run's final assistant message is sent when the run completes.
+In `/quiet` mode, these streamed updates are suppressed and only the run's final assistant message is sent when the run completes. The immediate `(sessionId) message queued` acknowledgement is also suppressed in quiet mode.
 
 ## persistence model
 

--- a/src/core/async/telegram.ts
+++ b/src/core/async/telegram.ts
@@ -18,6 +18,7 @@ type TelegramUser = {
 };
 
 type TelegramMessage = {
+  message_id?: number;
   chat?: TelegramChat;
   from?: TelegramUser;
   text?: string;
@@ -48,6 +49,7 @@ export type AsyncTelegramApi = {
   }): Promise<TelegramUpdate[]>;
   sendMessage(chatId: number, text: string): Promise<void>;
   setCommands?(commands: TelegramBotCommand[]): Promise<void>;
+  setMessageReaction?(chatId: number, messageId: number): Promise<void>;
 };
 
 export type AsyncTelegramLogLevel = "info" | "warn" | "error";
@@ -87,6 +89,7 @@ type NewCommandResolution =
 const DEFAULT_POLL_INTERVAL_MS = 1000;
 const DEFAULT_REQUEST_TIMEOUT_SECONDS = 30;
 const MAX_COMMAND_PREVIEW_CHARS = 128;
+const MESSAGE_QUEUED_REACTION_EMOJI = "👀";
 const ABORTED = Symbol("aborted");
 
 type SessionVerbosity = "verbose" | "quiet";
@@ -176,6 +179,11 @@ function createGrammyApi(botToken: string): AsyncTelegramApi {
     },
     async setCommands(commands) {
       await api.setMyCommands(commands);
+    },
+    async setMessageReaction(chatId, messageId) {
+      await api.setMessageReaction(chatId, messageId, [
+        { type: "emoji", emoji: MESSAGE_QUEUED_REACTION_EMOJI },
+      ]);
     },
   };
 }
@@ -380,7 +388,7 @@ class AsyncTelegramAdapterImpl {
       return;
     }
 
-    await this.handleMessage(chatId, text);
+    await this.handleMessage(chatId, text, message.message_id);
   }
 
   private isChatAllowed(chatId: number): boolean {
@@ -651,7 +659,11 @@ class AsyncTelegramAdapterImpl {
     await this.reply(chatId, formatSessionHeadline(session.id, `verbosity set to ${verbosity}`));
   }
 
-  private async handleMessage(chatId: number, text: string): Promise<void> {
+  private async handleMessage(
+    chatId: number,
+    text: string,
+    sourceMessageId?: number,
+  ): Promise<void> {
     const session = this.getActiveSession(chatId);
     if (!session) {
       await this.reply(chatId, "no active session. use /new or /use <sessionId>");
@@ -664,7 +676,10 @@ class AsyncTelegramAdapterImpl {
         text,
         this.systemMessage ? { additionalSystemMessage: this.systemMessage } : undefined,
       );
-      await this.reply(chatId, this.formatMessageQueued(session.id));
+      await this.reactToQueuedMessage(chatId, sourceMessageId);
+      if (this.isVerboseSession(session.id)) {
+        await this.reply(chatId, this.formatMessageQueued(session.id));
+      }
     } catch (error) {
       await this.reply(chatId, this.formatManagerError(error));
     }
@@ -892,6 +907,26 @@ class AsyncTelegramAdapterImpl {
 
     for (const chatId of chatIds) {
       void this.reply(chatId, text);
+    }
+  }
+
+  private async reactToQueuedMessage(chatId: number, messageId?: number): Promise<void> {
+    if (!this.api.setMessageReaction) {
+      return;
+    }
+
+    if (typeof messageId !== "number" || !Number.isInteger(messageId) || messageId <= 0) {
+      return;
+    }
+
+    try {
+      await this.api.setMessageReaction(chatId, messageId);
+    } catch (error) {
+      this.log("warn", "failed to set telegram message reaction", {
+        chatId,
+        messageId,
+        cause: error instanceof Error ? error.message : String(error),
+      });
     }
   }
 

--- a/test/async_telegram.test.js
+++ b/test/async_telegram.test.js
@@ -15,6 +15,7 @@ function createApiHarness(updateBatches) {
   const queue = [...updateBatches];
   const sendMessages = [];
   const setCommandsCalls = [];
+  const setMessageReactions = [];
 
   const api = {
     getUpdates: vi.fn(async () => {
@@ -30,12 +31,16 @@ function createApiHarness(updateBatches) {
     setCommands: vi.fn(async (commands) => {
       setCommandsCalls.push(commands);
     }),
+    setMessageReaction: vi.fn(async (chatId, messageId) => {
+      setMessageReactions.push({ chatId, messageId });
+    }),
   };
 
   return {
     api,
     sendMessages,
     setCommandsCalls,
+    setMessageReactions,
   };
 }
 
@@ -258,6 +263,7 @@ describe("async telegram adapter", () => {
         {
           update_id: 1,
           message: {
+            message_id: 501,
             chat: { id: 200, type: "private" },
             from: { id: 7 },
             text: "/new",
@@ -266,6 +272,7 @@ describe("async telegram adapter", () => {
         {
           update_id: 2,
           message: {
+            message_id: 502,
             chat: { id: 200, type: "private" },
             from: { id: 7 },
             text: "follow up",
@@ -321,7 +328,11 @@ describe("async telegram adapter", () => {
 
       expect(
         apiHarness.sendMessages.some((entry) => String(entry.text).includes("(s1) message queued")),
-      ).toBe(true);
+      ).toBe(false);
+      expect(apiHarness.setMessageReactions).toContainEqual({
+        chatId: 200,
+        messageId: 502,
+      });
     } finally {
       await adapter.close();
     }
@@ -1047,6 +1058,73 @@ describe("async telegram adapter", () => {
       expect(
         apiHarness.sendMessages.some((entry) => entry.text.includes("(s2) assistant message")),
       ).toBe(false);
+    } finally {
+      await adapter.close();
+    }
+  });
+
+  it("sends a queued acknowledgement in verbose mode and reacts to user messages", async () => {
+    const apiHarness = createApiHarness([
+      [
+        {
+          update_id: 1,
+          message: {
+            chat: { id: 475, type: "private" },
+            from: { id: 7 },
+            text: "/use s13",
+          },
+        },
+        {
+          update_id: 2,
+          message: {
+            chat: { id: 475, type: "private" },
+            from: { id: 7 },
+            text: "/verbose",
+          },
+        },
+        {
+          update_id: 3,
+          message: {
+            message_id: 777,
+            chat: { id: 475, type: "private" },
+            from: { id: 7 },
+            text: "ship it",
+          },
+        },
+      ],
+    ]);
+
+    const managerHarness = createSessionManagerHarness([
+      {
+        id: "s13",
+        projectId: "demo",
+        state: "waiting-input",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    const adapter = await startAsyncTelegramAdapter({
+      botToken: "token",
+      projects: { demo: { repo: "git@example.com:demo.git" } },
+      sessionManager: managerHarness.manager,
+      api: apiHarness.api,
+      pollIntervalMs: 1,
+      requestTimeoutSeconds: 1,
+    });
+
+    try {
+      await waitFor(() => managerHarness.manager.sendMessage.mock.calls.length === 1);
+      expect(managerHarness.manager.sendMessage).toHaveBeenCalledWith("s13", "ship it", undefined);
+
+      await waitFor(() =>
+        apiHarness.sendMessages.some((entry) => entry.text.includes("(s13) message queued")),
+      );
+
+      expect(apiHarness.setMessageReactions).toContainEqual({
+        chatId: 475,
+        messageId: 777,
+      });
     } finally {
       await adapter.close();
     }


### PR DESCRIPTION
- suppress `(sessionId) message queued` in `/quiet` mode while keeping it in `/verbose`
- add best-effort Telegram message reactions (`👀`) on accepted plain-text user messages
- update async Telegram tests and async docs for the new behavior

Validation:
- npm run check
- npm run build && npx vitest run test/async_telegram.test.js
