### PR TITLE
default custom personas to all skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,7 +156,7 @@ Personas can be defined at user level (`~/.config/tau/personas/*.md`) and projec
 - `label`, `description`: metadata
 - `reasoning`: default reasoning effort level
 - `allowedReasoningLevels`: list of reasoning levels shown in the UI
-- `skills`: list of enabled skill names (matched by `name` in skill frontmatter), or `"*"` to enable all discovered skills
+- `skills`: list of enabled skill names (matched by `name` in skill frontmatter), or `"*"` to enable all discovered skills. if omitted on custom personas, defaults to `"*"`; set `skills: []` to disable skills completely.
 - `subagents`: optional map of subagent definitions. The built-in `default` subagent is implicitly enabled unless `default: false` is provided. Custom subagents must be defined as `{ systemPrompt, description?, provider+model?, reasoning?, tools?, riskLevel?, launchModels? }` with lowercase-dash names (max 64 chars). `launchModels` values are allowlisted launch overrides in `<provider>/<model>:<effort>` format. The `default` subagent cannot be overridden.
 - `tools`: list of tool names to enable for this persona. allowed: `bash`, `write`, `edit`, `view_image`, `spawn_agent`, `send_input_to_agent`, `wait_for_agent`, `terminate_agent`. if omitted, defaults to `bash`, `write`, `edit`, `view_image` (and subagent tools when subagents are enabled). risk levels still apply.
 

--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ optional frontmatter fields:
 - `extends`: inherit optional fields from a built-in persona id (for example `gpt-5.2-coder`). `provider` and `model` are still required. if the markdown body is empty, the base persona's system prompt is used.
 - `reasoning`: one of `none`, `minimal`, `low`, `medium`, `high`, `xhigh`
 - `allowedReasoningLevels`: list of reasoning levels shown in the ui
-- `skills`: list of enabled skill names (matched by `name` in skill frontmatter), or `"*"` to enable all discovered skills
+- `skills`: list of enabled skill names (matched by `name` in skill frontmatter), or `"*"` to enable all discovered skills. if omitted, custom personas default to `"*"`. set `skills: []` to disable skills completely.
 - `subagents`: optional map of subagent definitions. the built-in `default` sub-agent is implicit unless `default: false` is provided. custom subagents must include `systemPrompt` and may include `description`, `provider`+`model`, `reasoning`, `tools`, `riskLevel`, and `launchModels` (when specifying a model, `provider` and `model` must be provided together). names must be lowercase with dashes (max 64 chars). `launchModels` entries must use `<provider>/<model>:<effort>` and are used to allowlist launch-time `spawn_agent` overrides. example:
   ```yaml
   subagents:
@@ -642,7 +642,7 @@ skills are optional directories discovered at `~/.config/tau/skills/` and `~/.ag
 
 optional fields: `license`, `compatibility` (<=500 chars), `metadata` (string map), `allowed-tools` (validated, currently ignored by tau).
 
-enable skills per persona with the `skills` frontmatter field. you can list specific skill names (matched by `name` in skill frontmatter), or use `"*"` to enable all discovered skills. all built-in personas have `skills: "*"` by default. if a project skill conflicts with a user skill by name, the project skill wins. tau injects an index of enabled skills into the system prompt containing only each skill's `name`, `description`, and absolute file path.
+enable skills per persona with the `skills` frontmatter field. you can list specific skill names (matched by `name` in skill frontmatter), use `"*"` to enable all discovered skills, or set `skills: []` to disable skills completely. built-in personas and custom personas with omitted `skills` default to `skills: "*"`. if a project skill conflicts with a user skill by name, the project skill wins. tau injects an index of enabled skills into the system prompt containing only each skill's `name`, `description`, and absolute file path.
 
 use `/reload` to pick up changes to personas, prompts, skills, themes, bash commands, and AGENTS.md without restarting.
 

--- a/src/core/config/content_loader.ts
+++ b/src/core/config/content_loader.ts
@@ -626,8 +626,12 @@ function parsePersona(
   }
 
   let skills: string[] | "*" | undefined;
-  if (skillsRaw === undefined && basePersona?.skills !== undefined) {
-    skills = Array.isArray(basePersona.skills) ? [...basePersona.skills] : basePersona.skills;
+  if (skillsRaw === undefined) {
+    if (basePersona?.skills !== undefined) {
+      skills = Array.isArray(basePersona.skills) ? [...basePersona.skills] : basePersona.skills;
+    } else {
+      skills = "*";
+    }
   } else {
     const skillsParsed = skillsSchema.safeParse(skillsRaw);
 
@@ -638,10 +642,9 @@ function parsePersona(
         skills = "*";
       } else if (typeof val === "string") {
         const trimmed = val.trim();
-        skills = trimmed ? [trimmed] : undefined;
+        skills = trimmed ? [trimmed] : [];
       } else if (Array.isArray(val)) {
-        const trimmed = val.map((s) => s.trim()).filter(Boolean);
-        skills = trimmed.length > 0 ? trimmed : undefined;
+        skills = val.map((s) => s.trim()).filter(Boolean);
       }
     } else if (skillsRaw !== undefined) {
       if (Array.isArray(skillsRaw)) {
@@ -734,7 +737,7 @@ function parsePersona(
     ...(finalDescription && { description: finalDescription }),
     ...(finalAllowedReasoningLevels ? { allowedReasoningLevels: finalAllowedReasoningLevels } : {}),
     ...(finalSubagents && { subagents: finalSubagents }),
-    ...(skills && { skills }),
+    ...(skills !== undefined ? { skills } : {}),
     source,
   };
 

--- a/test/persona_extends.test.js
+++ b/test/persona_extends.test.js
@@ -74,6 +74,7 @@ describe("custom personas", () => {
 
       expect(clone.model.provider).toBe("anthropic");
       expect(clone.systemPrompt).toBe(base.systemPrompt);
+      expect(clone.skills).toEqual(base.skills);
 
       expect(clone.tools.map((t) => t.name)).toEqual(base.tools.map((t) => t.name));
 
@@ -116,6 +117,71 @@ describe("custom personas", () => {
 
       expect(personas.map((p) => p.id)).toEqual(["gpt-5.2-chat"]);
       expect(personas[0].source).toBe("user");
+      expect(personas[0].skills).toBe("*");
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("allows disabling skills for custom personas with an empty list", async () => {
+    const fx = setupFixture();
+
+    try {
+      mkdirSync(join(fx.home, ".config", "tau", "personas"), { recursive: true });
+      writeFileSync(
+        join(fx.home, ".config", "tau", "personas", "no-skills.md"),
+        [
+          "---",
+          "id: no-skills",
+          "provider: anthropic",
+          "model: claude-haiku-4-5",
+          "skills: []",
+          "---",
+          "custom prompt",
+          "",
+        ].join("\n"),
+      );
+
+      const deps = createConfigDeps({ cwd: fx.cwd, home: fx.home });
+      const { personas, errors } = await loadAllContent({}, { deps, cwd: fx.cwd });
+      expect(errors).toEqual([]);
+
+      const persona = personas.find((p) => p.id === "no-skills");
+      expect(persona).toBeTruthy();
+      expect(persona.skills).toEqual([]);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("supports selecting a subset of skills for custom personas", async () => {
+    const fx = setupFixture();
+
+    try {
+      mkdirSync(join(fx.home, ".config", "tau", "personas"), { recursive: true });
+      writeFileSync(
+        join(fx.home, ".config", "tau", "personas", "subset-skills.md"),
+        [
+          "---",
+          "id: subset-skills",
+          "provider: anthropic",
+          "model: claude-haiku-4-5",
+          "skills:",
+          "  - alpha",
+          "  - beta",
+          "---",
+          "custom prompt",
+          "",
+        ].join("\n"),
+      );
+
+      const deps = createConfigDeps({ cwd: fx.cwd, home: fx.home });
+      const { personas, errors } = await loadAllContent({}, { deps, cwd: fx.cwd });
+      expect(errors).toEqual([]);
+
+      const persona = personas.find((p) => p.id === "subset-skills");
+      expect(persona).toBeTruthy();
+      expect(persona.skills).toEqual(["alpha", "beta"]);
     } finally {
       fx.cleanup();
     }


### PR DESCRIPTION
- default custom personas to `skills: "*"` when `skills` is omitted
- keep `skills` configurable: `skills: []` disables skills, and explicit lists keep subset behavior
- update persona loading tests and persona docs (README + AGENTS)

## verification
- npm test
- npm run check

fixes #123
