### PR TITLE
refactor tool ui router lifecycle handling

### DIFF
--- a/src/tui/tool_ui_router.ts
+++ b/src/tui/tool_ui_router.ts
@@ -34,6 +34,36 @@ type RunningSubagentTool =
 
 type ToolUiEventWithToolCallId = Extract<ToolUiEvent, { toolCallId: string }>;
 type ToolPrunedEvent = Extract<ToolUiEvent, { type: "tool_pruned" }>;
+type NonPrunedToolUiEvent = Exclude<ToolUiEventWithToolCallId, ToolPrunedEvent>;
+
+type ToolUiEventType = ToolUiEvent["type"];
+type BashTerminalEventType = "bash_execution" | "bash_aborted" | "bash_blocked";
+type SubagentTerminalEventType =
+  | "spawn_agent_finished"
+  | "spawn_agent_blocked"
+  | "send_input_to_agent_finished"
+  | "send_input_to_agent_blocked"
+  | "wait_for_agent_finished"
+  | "wait_for_agent_blocked"
+  | "terminate_agent_finished"
+  | "terminate_agent_blocked";
+
+const BASH_TERMINAL_EVENT_TYPES = new Set<BashTerminalEventType>([
+  "bash_execution",
+  "bash_aborted",
+  "bash_blocked",
+]);
+
+const SUBAGENT_TERMINAL_EVENT_TYPES = new Set<SubagentTerminalEventType>([
+  "spawn_agent_finished",
+  "spawn_agent_blocked",
+  "send_input_to_agent_finished",
+  "send_input_to_agent_blocked",
+  "wait_for_agent_finished",
+  "wait_for_agent_blocked",
+  "terminate_agent_finished",
+  "terminate_agent_blocked",
+]);
 
 const PRUNED_STATUS_PREFIX = "✂ pruned";
 
@@ -91,178 +121,83 @@ export class ToolUiRouter {
       return;
     }
 
-    if (uiEvent.type === "bash_started") {
-      this.upsertToolMessage(uiEvent);
-      this.runningBashComponents.set(uiEvent.toolCallId, { command: uiEvent.command });
-      this.requestRender();
+    this.upsertToolMessage(uiEvent);
+    this.updateRunningToolState(uiEvent);
+    this.requestRender();
+  }
+
+  private updateRunningToolState(uiEvent: NonPrunedToolUiEvent): void {
+    const bashComponent = this.toRunningBashComponent(uiEvent);
+    if (bashComponent) {
+      this.runningBashComponents.set(uiEvent.toolCallId, bashComponent);
       return;
     }
 
-    if (uiEvent.type === "bash_execution") {
-      this.upsertToolMessage(uiEvent);
+    if (this.isBashTerminalType(uiEvent.type)) {
       this.runningBashComponents.delete(uiEvent.toolCallId);
-      this.requestRender();
       return;
     }
 
-    if (uiEvent.type === "bash_aborted") {
-      this.upsertToolMessage(uiEvent);
-      this.runningBashComponents.delete(uiEvent.toolCallId);
-      this.requestRender();
+    const subagentTool = this.toRunningSubagentTool(uiEvent);
+    if (subagentTool) {
+      this.runningSubagentTools.set(uiEvent.toolCallId, subagentTool);
       return;
     }
 
-    if (uiEvent.type === "bash_blocked") {
-      this.upsertToolMessage(uiEvent);
-      this.runningBashComponents.delete(uiEvent.toolCallId);
-      this.requestRender();
-      return;
+    if (this.isSubagentTerminalType(uiEvent.type)) {
+      this.runningSubagentTools.delete(uiEvent.toolCallId);
+    }
+  }
+
+  private toRunningBashComponent(uiEvent: NonPrunedToolUiEvent): RunningBashComponent | null {
+    if (uiEvent.type !== "bash_started") {
+      return null;
     }
 
+    return { command: uiEvent.command };
+  }
+
+  private toRunningSubagentTool(uiEvent: NonPrunedToolUiEvent): RunningSubagentTool | null {
     if (uiEvent.type === "spawn_agent_started") {
-      this.upsertToolMessage(uiEvent);
-      this.runningSubagentTools.set(uiEvent.toolCallId, {
+      return {
         kind: TOOL_NAME_SPAWN_AGENT,
         name: uiEvent.name,
         title: uiEvent.headerTarget ?? uiEvent.title,
-      });
-      this.requestRender();
-      return;
-    }
-
-    if (uiEvent.type === "spawn_agent_finished") {
-      this.upsertToolMessage(uiEvent);
-      this.runningSubagentTools.delete(uiEvent.toolCallId);
-      this.requestRender();
-      return;
-    }
-
-    if (uiEvent.type === "spawn_agent_blocked") {
-      this.upsertToolMessage(uiEvent);
-      this.runningSubagentTools.delete(uiEvent.toolCallId);
-      this.requestRender();
-      return;
+      };
     }
 
     if (uiEvent.type === "send_input_to_agent_started") {
-      this.upsertToolMessage(uiEvent);
-      this.runningSubagentTools.set(uiEvent.toolCallId, {
+      return {
         kind: TOOL_NAME_SEND_INPUT_TO_AGENT,
         agentId: uiEvent.agentId,
         name: uiEvent.name,
         title: uiEvent.headerTarget ?? uiEvent.title,
-      });
-      this.requestRender();
-      return;
-    }
-
-    if (uiEvent.type === "send_input_to_agent_finished") {
-      this.upsertToolMessage(uiEvent);
-      this.runningSubagentTools.delete(uiEvent.toolCallId);
-      this.requestRender();
-      return;
-    }
-
-    if (uiEvent.type === "send_input_to_agent_blocked") {
-      this.upsertToolMessage(uiEvent);
-      this.runningSubagentTools.delete(uiEvent.toolCallId);
-      this.requestRender();
-      return;
+      };
     }
 
     if (uiEvent.type === "wait_for_agent_started") {
-      this.upsertToolMessage(uiEvent);
-      this.runningSubagentTools.set(uiEvent.toolCallId, {
+      return {
         kind: TOOL_NAME_WAIT_FOR_AGENT,
         agentIds: uiEvent.agentIds,
-      });
-      this.requestRender();
-      return;
-    }
-
-    if (uiEvent.type === "wait_for_agent_finished") {
-      this.upsertToolMessage(uiEvent);
-      this.runningSubagentTools.delete(uiEvent.toolCallId);
-      this.requestRender();
-      return;
-    }
-
-    if (uiEvent.type === "wait_for_agent_blocked") {
-      this.upsertToolMessage(uiEvent);
-      this.runningSubagentTools.delete(uiEvent.toolCallId);
-      this.requestRender();
-      return;
+      };
     }
 
     if (uiEvent.type === "terminate_agent_started") {
-      this.upsertToolMessage(uiEvent);
-      this.runningSubagentTools.set(uiEvent.toolCallId, {
+      return {
         kind: TOOL_NAME_TERMINATE_AGENT,
         agentId: uiEvent.agentId,
-      });
-      this.requestRender();
-      return;
+      };
     }
 
-    if (uiEvent.type === "terminate_agent_finished") {
-      this.upsertToolMessage(uiEvent);
-      this.runningSubagentTools.delete(uiEvent.toolCallId);
-      this.requestRender();
-      return;
-    }
+    return null;
+  }
 
-    if (uiEvent.type === "terminate_agent_blocked") {
-      this.upsertToolMessage(uiEvent);
-      this.runningSubagentTools.delete(uiEvent.toolCallId);
-      this.requestRender();
-      return;
-    }
+  private isBashTerminalType(type: ToolUiEventType): type is BashTerminalEventType {
+    return BASH_TERMINAL_EVENT_TYPES.has(type as BashTerminalEventType);
+  }
 
-    if (
-      uiEvent.type === "write_success" ||
-      uiEvent.type === "write_blocked" ||
-      uiEvent.type === "edit_success" ||
-      uiEvent.type === "edit_blocked" ||
-      uiEvent.type === "read_success" ||
-      uiEvent.type === "read_blocked" ||
-      uiEvent.type === "view_image_success" ||
-      uiEvent.type === "view_image_blocked" ||
-      uiEvent.type === "list_success" ||
-      uiEvent.type === "list_blocked"
-    ) {
-      this.upsertToolMessage(uiEvent);
-      this.requestRender();
-      return;
-    }
-
-    if (uiEvent.type === "grep_started") {
-      this.upsertToolMessage(uiEvent);
-      this.requestRender();
-      return;
-    }
-
-    if (uiEvent.type === "grep_finished") {
-      this.upsertToolMessage(uiEvent);
-      this.requestRender();
-      return;
-    }
-
-    if (uiEvent.type === "grep_blocked") {
-      this.upsertToolMessage(uiEvent);
-      this.requestRender();
-      return;
-    }
-
-    if (uiEvent.type === "web_search_started" || uiEvent.type === "web_fetch_started") {
-      this.upsertToolMessage(uiEvent);
-      this.requestRender();
-      return;
-    }
-
-    if (uiEvent.type === "web_search_finished" || uiEvent.type === "web_fetch_finished") {
-      this.upsertToolMessage(uiEvent);
-      this.requestRender();
-    }
+  private isSubagentTerminalType(type: ToolUiEventType): type is SubagentTerminalEventType {
+    return SUBAGENT_TERMINAL_EVENT_TYPES.has(type as SubagentTerminalEventType);
   }
 
   private upsertToolMessage(uiEvent: ToolUiEventWithToolCallId): void {

--- a/test/tool_ui_router.test.js
+++ b/test/tool_ui_router.test.js
@@ -42,6 +42,48 @@ function createHarness() {
   };
 }
 
+function getRunningBashMap(router) {
+  return router.runningBashComponents;
+}
+
+function getRunningSubagentMap(router) {
+  return router.runningSubagentTools;
+}
+
+function getLatestEventsMap(router) {
+  return router.latestToolEventsById;
+}
+
+function findLatestReplacedEvent(replaced, id) {
+  return replaced.findLast((entry) => entry.id === id)?.model.event;
+}
+
+function bashExecutionEvent(toolCallId, command) {
+  return {
+    type: "bash_execution",
+    toolCallId,
+    command,
+    exitCode: 0,
+    truncationInfo: {
+      output: "ok",
+      rawOutput: "ok",
+      model: {
+        truncated: false,
+        totalLines: 1,
+        outputLines: 1,
+        totalBytes: 2,
+        outputBytes: 2,
+      },
+      captureTruncated: false,
+    },
+    uiText: {
+      previewLines: [{ text: "ok" }],
+      statusLine: "exit 0",
+      fullLines: [{ text: "ok" }],
+    },
+  };
+}
+
 describe("ToolUiRouter prune mutations", () => {
   it("patches existing tool cards by toolCallId and preserves the base event type", () => {
     const harness = createHarness();
@@ -182,5 +224,253 @@ describe("ToolUiRouter prune mutations", () => {
     expect(harness.added).toHaveLength(2);
     expect(harness.added.at(-1)).toMatchObject({ id: "write-1" });
     expect(harness.replaced).toHaveLength(0);
+  });
+});
+
+describe("ToolUiRouter lifecycle tracking", () => {
+  it("tracks and untracks bash for execution and blocked lifecycles", () => {
+    const harness = createHarness();
+
+    harness.router.handle({
+      type: "bash_started",
+      toolCallId: "bash-exec",
+      command: "echo one",
+    });
+    expect(getRunningBashMap(harness.router).has("bash-exec")).toBe(true);
+
+    harness.router.handle(bashExecutionEvent("bash-exec", "echo one"));
+    expect(getRunningBashMap(harness.router).has("bash-exec")).toBe(false);
+
+    harness.router.handle({
+      type: "bash_started",
+      toolCallId: "bash-blocked",
+      command: "echo two",
+    });
+    expect(getRunningBashMap(harness.router).has("bash-blocked")).toBe(true);
+
+    harness.router.handle({
+      type: "bash_blocked",
+      toolCallId: "bash-blocked",
+      command: "echo two",
+      reason: "blocked",
+    });
+    expect(getRunningBashMap(harness.router).has("bash-blocked")).toBe(false);
+    expect(harness.renders).toBe(4);
+  });
+
+  it("tracks subagent lifecycle transitions for start, finish, and blocked events", () => {
+    const harness = createHarness();
+
+    const cases = [
+      {
+        started: {
+          type: "spawn_agent_started",
+          toolCallId: "spawn-finish",
+          name: "default",
+          title: "spawn default",
+        },
+        terminal: {
+          type: "spawn_agent_finished",
+          toolCallId: "spawn-finish",
+          name: "default",
+          title: "spawn default",
+          status: "success",
+          message: "done",
+        },
+        blockedStarted: {
+          type: "spawn_agent_started",
+          toolCallId: "spawn-blocked",
+          name: "default",
+          title: "spawn blocked",
+        },
+        blocked: {
+          type: "spawn_agent_blocked",
+          toolCallId: "spawn-blocked",
+          title: "spawn blocked",
+          reason: "blocked",
+        },
+      },
+      {
+        started: {
+          type: "send_input_to_agent_started",
+          toolCallId: "send-finish",
+          agentId: "agent-1",
+          name: "default",
+          title: "send input",
+        },
+        terminal: {
+          type: "send_input_to_agent_finished",
+          toolCallId: "send-finish",
+          agentId: "agent-1",
+          name: "default",
+          title: "send input",
+          status: "success",
+          message: "sent",
+        },
+        blockedStarted: {
+          type: "send_input_to_agent_started",
+          toolCallId: "send-blocked",
+          agentId: "agent-1",
+          name: "default",
+          title: "send blocked",
+        },
+        blocked: {
+          type: "send_input_to_agent_blocked",
+          toolCallId: "send-blocked",
+          title: "send blocked",
+          reason: "blocked",
+        },
+      },
+      {
+        started: {
+          type: "wait_for_agent_started",
+          toolCallId: "wait-finish",
+          agentIds: ["agent-1", "agent-2"],
+        },
+        terminal: {
+          type: "wait_for_agent_finished",
+          toolCallId: "wait-finish",
+          agentIds: ["agent-1", "agent-2"],
+          status: "success",
+          message: "ready",
+        },
+        blockedStarted: {
+          type: "wait_for_agent_started",
+          toolCallId: "wait-blocked",
+          agentIds: ["agent-3"],
+        },
+        blocked: {
+          type: "wait_for_agent_blocked",
+          toolCallId: "wait-blocked",
+          reason: "blocked",
+        },
+      },
+      {
+        started: {
+          type: "terminate_agent_started",
+          toolCallId: "terminate-finish",
+          agentId: "agent-4",
+        },
+        terminal: {
+          type: "terminate_agent_finished",
+          toolCallId: "terminate-finish",
+          agentId: "agent-4",
+          status: "success",
+          message: "terminated",
+        },
+        blockedStarted: {
+          type: "terminate_agent_started",
+          toolCallId: "terminate-blocked",
+          agentId: "agent-5",
+        },
+        blocked: {
+          type: "terminate_agent_blocked",
+          toolCallId: "terminate-blocked",
+          reason: "blocked",
+        },
+      },
+    ];
+
+    for (const entry of cases) {
+      harness.router.handle(entry.started);
+      expect(getRunningSubagentMap(harness.router).has(entry.started.toolCallId)).toBe(true);
+
+      harness.router.handle(entry.terminal);
+      expect(getRunningSubagentMap(harness.router).has(entry.started.toolCallId)).toBe(false);
+
+      harness.router.handle(entry.blockedStarted);
+      expect(getRunningSubagentMap(harness.router).has(entry.blockedStarted.toolCallId)).toBe(true);
+
+      harness.router.handle(entry.blocked);
+      expect(getRunningSubagentMap(harness.router).has(entry.blockedStarted.toolCallId)).toBe(
+        false,
+      );
+    }
+  });
+
+  it("finalizes pending bash and subagent entries with aborted reason", () => {
+    const harness = createHarness();
+
+    harness.router.handle({
+      type: "bash_started",
+      toolCallId: "bash-pending",
+      command: "echo pending",
+    });
+    harness.router.handle({
+      type: "spawn_agent_started",
+      toolCallId: "spawn-pending",
+      name: "default",
+      title: "spawn pending",
+    });
+
+    harness.router.finalizePending("aborted");
+
+    const bashEvent = findLatestReplacedEvent(harness.replaced, "bash-pending");
+    expect(bashEvent.type).toBe("bash_aborted");
+    expect(bashEvent.reason).toBe("aborted");
+
+    const subagentEvent = findLatestReplacedEvent(harness.replaced, "spawn-pending");
+    expect(subagentEvent.type).toBe("spawn_agent_finished");
+    expect(subagentEvent.status).toBe("error");
+    expect(subagentEvent.message).toBe("aborted");
+  });
+
+  it("finalizes pending bash and subagent entries with interrupted reason", () => {
+    const harness = createHarness();
+
+    harness.router.handle({
+      type: "bash_started",
+      toolCallId: "bash-pending-int",
+      command: "echo pending int",
+    });
+    harness.router.handle({
+      type: "wait_for_agent_started",
+      toolCallId: "wait-pending-int",
+      agentIds: ["agent-1", "agent-2"],
+    });
+
+    harness.router.finalizePending("interrupted");
+
+    const bashEvent = findLatestReplacedEvent(harness.replaced, "bash-pending-int");
+    expect(bashEvent.type).toBe("bash_aborted");
+    expect(bashEvent.reason).toBe("interrupted");
+
+    const subagentEvent = findLatestReplacedEvent(harness.replaced, "wait-pending-int");
+    expect(subagentEvent.type).toBe("wait_for_agent_finished");
+    expect(subagentEvent.status).toBe("error");
+    expect(subagentEvent.message).toBe("interrupted");
+  });
+
+  it("clears transient maps and resetSession clears all cached tool state", () => {
+    const harness = createHarness();
+
+    harness.router.handle({
+      type: "bash_started",
+      toolCallId: "bash-1",
+      command: "echo one",
+    });
+    harness.router.handle({
+      type: "send_input_to_agent_started",
+      toolCallId: "send-1",
+      agentId: "agent-1",
+      name: "default",
+      title: "send one",
+    });
+
+    expect(getRunningBashMap(harness.router).size).toBe(1);
+    expect(getRunningSubagentMap(harness.router).size).toBe(1);
+    expect(getLatestEventsMap(harness.router).size).toBe(2);
+
+    harness.router.clearTransientState();
+
+    expect(getRunningBashMap(harness.router).size).toBe(0);
+    expect(getRunningSubagentMap(harness.router).size).toBe(0);
+    expect(getLatestEventsMap(harness.router).size).toBe(2);
+
+    harness.router.resetSession();
+
+    expect(getRunningBashMap(harness.router).size).toBe(0);
+    expect(getRunningSubagentMap(harness.router).size).toBe(0);
+    expect(getLatestEventsMap(harness.router).size).toBe(0);
   });
 });


### PR DESCRIPTION
- simplify `ToolUiRouter.handle` to a grouped dispatch flow that always upserts and renders for non-prune events
- centralize bash/subagent running-state tracking and terminal cleanup in dedicated lifecycle helpers
- keep prune mutation and finalize behavior intact while expanding lifecycle coverage in `test/tool_ui_router.test.js`

validation:
- npm run check
- npm run build
- npm exec vitest run test/tool_ui_router.test.js
