### PR TITLE
remove grammy from telegram adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@sinclair/typebox": "^0.34.48",
         "chalk": "^5.6.2",
         "file-type": "^21.3.0",
-        "grammy": "^1.40.0",
         "sharp": "^0.34.5",
         "strip-ansi": "^7.1.2",
         "yaml": "^2.8.2",
@@ -1566,12 +1565,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@grammyjs/types": {
-      "version": "3.24.0",
-      "resolved": "https://registry.npmjs.org/@grammyjs/types/-/types-3.24.0.tgz",
-      "integrity": "sha512-qQIEs4lN5WqUdr4aT8MeU6UFpMbGYAvcvYSW1A4OO1PABGJQHz/KLON6qvpf+5RxaNDQBxiY2k2otIhg/AG7RQ==",
-      "license": "MIT"
     },
     "node_modules/@img/colour": {
       "version": "1.0.0",
@@ -3390,18 +3383,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -3801,15 +3782,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -4078,41 +4050,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/grammy": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/grammy/-/grammy-1.40.0.tgz",
-      "integrity": "sha512-ssuE7fc1AwqlUxHr931OCVW3fU+oFDjHZGgvIedPKXfTdjXvzP19xifvVGCnPtYVUig1Kz+gwxe4A9M5WdkT4Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@grammyjs/types": "3.24.0",
-        "abort-controller": "^3.0.0",
-        "debug": "^4.4.3",
-        "node-fetch": "^2.7.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || >=14.13.1"
-      }
-    },
-    "node_modules/grammy/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/gtoken": {
@@ -5091,12 +5028,6 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
     "node_modules/ts-algebra": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
@@ -5310,22 +5241,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@sinclair/typebox": "^0.34.48",
     "chalk": "^5.6.2",
     "file-type": "^21.3.0",
-    "grammy": "^1.40.0",
     "sharp": "^0.34.5",
     "strip-ansi": "^7.1.2",
     "yaml": "^2.8.2",

--- a/src/core/async/telegram.ts
+++ b/src/core/async/telegram.ts
@@ -1,7 +1,6 @@
 import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, extname, join } from "node:path";
-import { Api } from "grammy";
 import type { AsyncProjectConfig } from "../config/schema.js";
 import { transcribeMistralAudio } from "../utils/mistral_transcription.js";
 import { isRecord } from "../utils/type_guards.js";
@@ -72,12 +71,7 @@ type TelegramUpdate = {
   callback_query?: TelegramCallbackQuery;
 };
 
-type TelegramAllowedUpdates =
-  NonNullable<Parameters<Api["getUpdates"]>[0]> extends {
-    allowed_updates?: infer T;
-  }
-    ? NonNullable<T>
-    : readonly string[];
+type TelegramAllowedUpdates = readonly string[];
 
 type TelegramBotCommand = {
   command: string;
@@ -476,12 +470,48 @@ function formatSessionHeadline(sessionId: string, label: string): string {
   return `(${sessionId}) ${label}`;
 }
 
-function createGrammyApi(botToken: string): AsyncTelegramApi {
-  const api = new Api(botToken);
+function createTelegramApi(botToken: string): AsyncTelegramApi {
+  const apiUrl = `https://api.telegram.org/bot${botToken}`;
+
+  async function callTelegramMethod<T>(
+    method: string,
+    payload: Record<string, unknown>,
+  ): Promise<T> {
+    const response = await fetch(`${apiUrl}/${method}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const detail = (await response.text()).trim();
+      throw new Error(detail || `telegram ${method} failed: HTTP ${response.status}`);
+    }
+
+    let data: unknown;
+    try {
+      data = await response.json();
+    } catch {
+      throw new Error(`telegram ${method} returned invalid JSON`);
+    }
+
+    if (!isRecord(data)) {
+      throw new Error(`telegram ${method} returned an invalid response payload`);
+    }
+
+    if (data.ok !== true) {
+      const detail = typeof data.description === "string" ? data.description.trim() : "";
+      throw new Error(detail || `telegram ${method} request failed`);
+    }
+
+    return data.result as T;
+  }
 
   return {
     async getUpdates(args) {
-      const updates = await api.getUpdates({
+      const updates = await callTelegramMethod<TelegramUpdate[]>("getUpdates", {
         offset: args.offset,
         timeout: args.timeoutSeconds,
         allowed_updates: args.allowedUpdates,
@@ -490,12 +520,16 @@ function createGrammyApi(botToken: string): AsyncTelegramApi {
       return updates;
     },
     async sendMessage(chatId, text, options) {
-      await api.sendMessage(chatId, text, {
+      await callTelegramMethod("sendMessage", {
+        chat_id: chatId,
+        text,
         ...(options?.replyMarkup ? { reply_markup: options.replyMarkup } : {}),
       });
     },
     async downloadFile(fileId) {
-      const file = await api.getFile(fileId);
+      const file = await callTelegramMethod<{ file_path?: string }>("getFile", {
+        file_id: fileId,
+      });
       const filePath = file.file_path?.trim();
       if (!filePath) {
         throw new Error("telegram file path is missing");
@@ -511,15 +545,20 @@ function createGrammyApi(botToken: string): AsyncTelegramApi {
       return Buffer.from(bytes);
     },
     async setCommands(commands) {
-      await api.setMyCommands(commands);
+      await callTelegramMethod("setMyCommands", {
+        commands,
+      });
     },
     async setMessageReaction(chatId, messageId) {
-      await api.setMessageReaction(chatId, messageId, [
-        { type: "emoji", emoji: MESSAGE_QUEUED_REACTION_EMOJI },
-      ]);
+      await callTelegramMethod("setMessageReaction", {
+        chat_id: chatId,
+        message_id: messageId,
+        reaction: [{ type: "emoji", emoji: MESSAGE_QUEUED_REACTION_EMOJI }],
+      });
     },
     async answerCallbackQuery(callbackQueryId, text) {
-      await api.answerCallbackQuery(callbackQueryId, {
+      await callTelegramMethod("answerCallbackQuery", {
+        callback_query_id: callbackQueryId,
         ...(text ? { text } : {}),
       });
     },
@@ -573,7 +612,7 @@ class AsyncTelegramAdapterImpl {
     this.requestTimeoutSeconds = options.requestTimeoutSeconds ?? DEFAULT_REQUEST_TIMEOUT_SECONDS;
     this.mistralApiKey = options.mistralApiKey?.trim() || undefined;
     this.sessionManager = options.sessionManager;
-    this.api = options.api ?? createGrammyApi(options.botToken);
+    this.api = options.api ?? createTelegramApi(options.botToken);
     this.fetchImpl = options.fetchImpl;
     this.onLog = options.onLog;
 


### PR DESCRIPTION
- replace grammy with direct telegram bot api calls via fetch in async telegram adapter
- remove grammy dependency to eliminate the deprecated punycode warning path
- verified with npm run check and npm test

fixes #152
