### PR TITLE
add per-model system notices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,7 +167,7 @@ On conflicts, the most specific level wins (built-ins are the base layer).
 
 ## Configuration
 
-- **Global**: `~/.config/tau/config.json` (API keys, `defaultPersona`, `defaultRisk`, `disableBuiltinPersonas`, `disableBuiltinThemes`, `defaultTheme`, `bashCommands`, `agentContextFiles`, `sandbox`, `async`). This level is only included when cwd is inside home.
+- **Global**: `~/.config/tau/config.json` (API keys, `defaultPersona`, `defaultRisk`, `disableBuiltinPersonas`, `disableBuiltinThemes`, `defaultTheme`, `bashCommands`, `agentContextFiles`, `sandbox`, `subagents`, `modelSystemNotices`, `async`). This level is only included when cwd is inside home.
   - `apiKeys.parallel` (optional): Parallel API key for `web_search`/`web_fetch` usage in subagents.
   - `apiKeys.mistral` (optional): Mistral API key for `/speak` and Telegram audio transcription.
   - `defaultPersona` (optional): String ID of the persona to use by default when starting the app. Overridden by `--persona` flag.
@@ -177,10 +177,11 @@ On conflicts, the most specific level wins (built-ins are the base layer).
   - `disableBuiltinThemes` (optional): If true, tau will not load built-in themes, only entries from disk.
   - `defaultTheme` (optional): Theme id to load from built-in themes, `.tau/themes/<id>.json`, or `~/.config/tau/themes/<id>.json`. Defaults to `gold`.
   - `subagents.defaultLaunchModels` (optional): Allowlisted `spawn_agent` launch overrides for the built-in `default` subagent (`<provider>/<model>:<effort>` entries).
+  - `modelSystemNotices` (optional): Map of `<provider>/<model>` to notice text. Tau prepends the notice as a `<system>` block before each user message sent to that model (main session and subagents).
   - `async.client` (optional): Async client config (`defaultTarget`, `defaultProjectId`, `targets.<id>.url`, `targets.<id>.token`, `targets.<id>.timeoutMs`).
   - daemon-side async settings are loaded from a separate JSON file passed via `tau async daemon --config-file <path>` (`host`, `port`, `authToken`, `maxSessions`, `telegram` (single bot object or map by bot id, with optional `allowedProjectIds`; sessions are bot-scoped), `cron` (including `cron.jobsDir`), `projects`, `workspaceRoot`, `systemMessage`, and project fields like `workingDirectory`, `description`, `bootstrapCommands`, and `backgroundBootstrapCommands`). On daemon startup, Tau removes existing entries under configured async workspace roots (`workspaceRoot` plus any per-project overrides) before adapters start, and the Telegram adapter prunes stale `tau-telegram-attachments-*` directories under the system temp directory. Assume zero or one async daemon process per host; concurrent daemons are unsupported.
 
-- **Config levels**: `.tau/config.json` files are discovered from cwd up to home (or filesystem root if cwd is outside home). The global level is included only when cwd is under home. Scalars use most-specific wins; `apiKeys`, `sandbox`, and `async.client` merge per field; `bashCommands` merge by `id` and run from the config level root (directory containing `.tau`, or home for the global config); `agentContextFiles` are additive.
+- **Config levels**: `.tau/config.json` files are discovered from cwd up to home (or filesystem root if cwd is outside home). The global level is included only when cwd is under home. Scalars use most-specific wins; `apiKeys`, `sandbox`, `modelSystemNotices`, and `async.client` merge per field; `bashCommands` merge by `id` and run from the config level root (directory containing `.tau`, or home for the global config); `agentContextFiles` are additive.
 - **Project Context**: `AGENTS.md` (searched from current directory up to home/root), plus optional additional `AGENTS.md` files configured via `agentContextFiles` in config (paths resolved relative to the directory containing `.tau/`, or relative to home for the global config when it is in scope). Entries are only included when their directory is an ancestor or descendant of the current working directory; sibling paths are ignored.
 - **Bash commands**: `bashCommands` entries in any in-scope config file (`{ "bashCommands": [{ "id", "cmd", "description?" }] }`). Each command runs with cwd set to the config level root (same root used to resolve `agentContextFiles`).
 

--- a/README.md
+++ b/README.md
@@ -465,6 +465,9 @@ settings merge from least-specific to most-specific.
       "openai/gpt-5.2:high",
       "anthropic/claude-haiku-4-5:low"
     ]
+  },
+  "modelSystemNotices": {
+    "openai-codex/gpt-5.3-codex": "avoid apply_patch heredocs, use tau tools directly"
   }
 }
 ```
@@ -476,6 +479,8 @@ the `defaultRisk` field sets the initial risk level (`read-only` or `read-write`
 the `defaultTheme` field sets the theme id to load at startup. if not specified, it defaults to `gold`.
 
 the `subagents.defaultLaunchModels` field configures allowed `spawn_agent` launch overrides for the built-in `default` sub-agent. values must use `<provider>/<model>:<effort>`.
+
+the `modelSystemNotices` field maps `<provider>/<model>` to a notice string. when a message is sent to that model, tau prepends the notice as a `<system>...</system>` block before the user content. this applies to main-session user messages and sub-agent prompts, regardless of persona id.
 
 if `disableBuiltinPersonas` is set to `true`, tau will not load built-in personas. if `disableBuiltinThemes` is set to `true`, tau will not load built-in themes. only entries from `~/.config/tau/` and `.tau/` will be available for those categories. you can also set these flags in any `.tau/config.json`; the most specific value wins.
 

--- a/src/core/config/schema.ts
+++ b/src/core/config/schema.ts
@@ -1,7 +1,8 @@
 import { resolve } from "node:path";
-import type { KnownProvider } from "@mariozechner/pi-ai";
+import { getModels, getProviders, type KnownProvider } from "@mariozechner/pi-ai";
 import { parseSubagentLaunchModelList } from "../subagents/launch_model.js";
 import { type RiskLevel, RiskLevelSchema } from "../types.js";
+import { normalizeModelNoticeKey, parseModelNoticeKey } from "../utils/model_notices.js";
 import { isRecord } from "../utils/type_guards.js";
 import type { BashCommand } from "./bash_commands.js";
 import { parseBashCommands } from "./bash_commands.js";
@@ -30,6 +31,7 @@ export interface Config {
   subagents?: {
     defaultLaunchModels?: string[];
   };
+  modelSystemNotices?: Record<string, string>;
   async?: AsyncConfig;
 }
 
@@ -211,6 +213,12 @@ function validateConfigData(raw: unknown, sourceLabel: string): ConfigDiagnostic
   }
   errors.push(...subagentsResult.errors);
 
+  const modelSystemNoticesResult = parseModelSystemNotices(data.modelSystemNotices, sourceLabel);
+  if (modelSystemNoticesResult.notices) {
+    config.modelSystemNotices = modelSystemNoticesResult.notices;
+  }
+  errors.push(...modelSystemNoticesResult.errors);
+
   const asyncResult = parseAsyncConfig(data.async, sourceLabel);
   if (asyncResult.config) {
     config.async = asyncResult.config;
@@ -364,6 +372,73 @@ function parseSubagentsConfig(
   }
 
   return { config, errors };
+}
+
+function parseModelNoticeTarget(rawKey: string): { normalizedKey?: string; error?: string } {
+  const parsedKey = parseModelNoticeKey(rawKey);
+  if (!parsedKey) {
+    return { error: "must use keys in format '<provider>/<model>'" };
+  }
+
+  const provider = parsedKey.provider as KnownProvider;
+  if (!getProviders().includes(provider)) {
+    return { error: `unknown provider '${parsedKey.provider}'` };
+  }
+
+  const model = getModels(provider).find(
+    (candidate) => candidate.id.toLowerCase() === parsedKey.modelId.toLowerCase(),
+  );
+  if (!model) {
+    return {
+      error: `unknown model '${parsedKey.provider}/${parsedKey.modelId}'`,
+    };
+  }
+
+  return {
+    normalizedKey: normalizeModelNoticeKey(provider, model.id),
+  };
+}
+
+function parseModelSystemNotices(
+  raw: unknown,
+  sourceLabel: string,
+): { notices?: Record<string, string>; errors: string[] } {
+  if (raw === undefined) {
+    return { errors: [] };
+  }
+
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return { errors: [`${sourceLabel}: 'modelSystemNotices' must be an object.`] };
+  }
+
+  const data = raw as Record<string, unknown>;
+  const notices: Record<string, string> = {};
+  const errors: string[] = [];
+
+  for (const [rawKey, rawValue] of Object.entries(data)) {
+    const parsedKey = parseModelNoticeTarget(rawKey);
+    if (parsedKey.error || !parsedKey.normalizedKey) {
+      errors.push(
+        `${sourceLabel}: modelSystemNotices.${rawKey} ${parsedKey.error ?? "is invalid"}.`,
+      );
+      continue;
+    }
+
+    if (typeof rawValue !== "string" || !rawValue.trim()) {
+      errors.push(
+        `${sourceLabel}: modelSystemNotices.${rawKey} must be a non-empty string notice.`,
+      );
+      continue;
+    }
+
+    notices[parsedKey.normalizedKey] = rawValue.trim();
+  }
+
+  if (Object.keys(notices).length === 0) {
+    return { errors };
+  }
+
+  return { notices, errors };
 }
 
 function isPositiveInteger(value: unknown): value is number {
@@ -604,6 +679,20 @@ function mergeSubagentsConfig(
   return merged;
 }
 
+function mergeModelSystemNotices(
+  target: Config["modelSystemNotices"] | undefined,
+  overlay: Config["modelSystemNotices"] | undefined,
+): Config["modelSystemNotices"] | undefined {
+  if (!target && !overlay) {
+    return undefined;
+  }
+
+  return {
+    ...(target ?? {}),
+    ...(overlay ?? {}),
+  };
+}
+
 function mergeAsyncClientTarget(
   target: AsyncClientTargetConfig | undefined,
   overlay: AsyncClientTargetConfig | undefined,
@@ -723,6 +812,7 @@ function mergeConfigLevels(levels: ConfigLevel[], configs: Config[]): Config {
   let apiKeys: Config["apiKeys"] | undefined;
   let sandbox: SandboxConfig | undefined;
   let subagents: Config["subagents"] | undefined;
+  let modelSystemNotices: Config["modelSystemNotices"] | undefined;
   let asyncConfig: AsyncConfig | undefined;
   const bashCommands = new Map<string, BashCommand>();
   const agentContextFiles: string[] = [];
@@ -734,6 +824,7 @@ function mergeConfigLevels(levels: ConfigLevel[], configs: Config[]): Config {
     apiKeys = mergeApiKeys(apiKeys, config.apiKeys);
     sandbox = mergeSandboxConfig(sandbox, config.sandbox);
     subagents = mergeSubagentsConfig(subagents, config.subagents);
+    modelSystemNotices = mergeModelSystemNotices(modelSystemNotices, config.modelSystemNotices);
     asyncConfig = mergeAsyncConfig(
       asyncConfig,
       config.async ? resolveAsyncConfig(level, config.async) : undefined,
@@ -780,6 +871,10 @@ function mergeConfigLevels(levels: ConfigLevel[], configs: Config[]): Config {
 
   if (subagents && Object.keys(subagents).length > 0) {
     merged.subagents = subagents;
+  }
+
+  if (modelSystemNotices && Object.keys(modelSystemNotices).length > 0) {
+    merged.modelSystemNotices = modelSystemNotices;
   }
 
   if (asyncConfig && Object.keys(asyncConfig).length > 0) {

--- a/src/core/session/session_engine.ts
+++ b/src/core/session/session_engine.ts
@@ -22,6 +22,7 @@ import { appendUsageLogEntry, getUsageCostTotal, getUsageTotals } from "../usage
 import { shouldAutoRetry } from "../utils/auto_retry.js";
 import { CODEX_ORIGINATOR, CODEX_USER_AGENT } from "../utils/codex.js";
 import { extractAssistantText } from "../utils/messages.js";
+import { prependModelNotice, resolveModelNotice } from "../utils/model_notices.js";
 import { streamModel } from "../utils/model_stream.js";
 import type { TauStreamOptions } from "../utils/streaming_settings.js";
 import { parseStreamingSettings } from "../utils/streaming_settings.js";
@@ -181,10 +182,15 @@ export class SessionEngine {
   }
 
   addUserText(textForModel: string, options?: { historyEntryId?: string }): string {
+    const textWithModelNotice = prependModelNotice(
+      textForModel,
+      resolveModelNotice(this.config, this.persona.model),
+    );
+
     return this.addMessage(
       {
         role: "user",
-        content: [{ type: "text", text: textForModel }],
+        content: [{ type: "text", text: textWithModelNotice }],
         timestamp: this.deps.clock.now(),
       },
       options,

--- a/src/core/subagents/subagent_engine.ts
+++ b/src/core/subagents/subagent_engine.ts
@@ -24,6 +24,7 @@ import { appendUsageLogEntry, getUsageCostTotal, getUsageTotals } from "../usage
 import { shouldAutoRetry } from "../utils/auto_retry.js";
 import { CODEX_ORIGINATOR, CODEX_USER_AGENT } from "../utils/codex.js";
 import { extractAssistantText } from "../utils/messages.js";
+import { prependModelNotice, resolveModelNotice } from "../utils/model_notices.js";
 import type { TauStreamOptions } from "../utils/streaming_settings.js";
 import { parseStreamingSettings } from "../utils/streaming_settings.js";
 import {
@@ -116,9 +117,13 @@ export async function runSubagent(options: {
   const allowedTools = runtimeConfig.tools;
   const toolRegistry = buildToolRegistryForAllowedTools(allowedTools, config, backend);
   const messages = options.messages ?? [];
+  const promptWithModelNotice = prependModelNotice(
+    prompt,
+    resolveModelNotice(config, runtimeConfig.model),
+  );
   messages.push({
     role: "user",
-    content: [{ type: "text", text: prompt }],
+    content: [{ type: "text", text: promptWithModelNotice }],
     timestamp: Date.now(),
   });
 

--- a/src/core/utils/model_notices.ts
+++ b/src/core/utils/model_notices.ts
@@ -1,0 +1,62 @@
+import type { Api, Model } from "@mariozechner/pi-ai";
+import type { Config } from "../config/index.js";
+
+export function normalizeModelNoticeKey(provider: string, modelId: string): string {
+  return `${provider.trim().toLowerCase()}/${modelId.trim().toLowerCase()}`;
+}
+
+export function parseModelNoticeKey(raw: string):
+  | {
+      provider: string;
+      modelId: string;
+    }
+  | undefined {
+  const value = raw.trim();
+  if (!value) {
+    return undefined;
+  }
+
+  const separator = value.indexOf("/");
+  if (separator <= 0 || separator !== value.lastIndexOf("/") || separator >= value.length - 1) {
+    return undefined;
+  }
+
+  const provider = value.slice(0, separator).trim().toLowerCase();
+  const modelId = value.slice(separator + 1).trim();
+  if (!provider || !modelId) {
+    return undefined;
+  }
+
+  return {
+    provider,
+    modelId,
+  };
+}
+
+export function resolveModelNotice(
+  config: Config | undefined,
+  model: Model<Api>,
+): string | undefined {
+  const notices = config?.modelSystemNotices;
+  if (!notices) {
+    return undefined;
+  }
+
+  const notice = notices[normalizeModelNoticeKey(model.provider, model.id)];
+  const trimmed = notice?.trim();
+  return trimmed || undefined;
+}
+
+export function prependModelNotice(text: string, notice?: string): string {
+  const trimmedNotice = notice?.trim();
+  if (!trimmedNotice) {
+    return text;
+  }
+
+  const systemNotice = `<system>${trimmedNotice.replaceAll("</system>", "<\\/system>")}</system>`;
+  if (!text.trim()) {
+    return systemNotice;
+  }
+
+  return `${systemNotice}\n\n${text}`;
+}

--- a/test/config_layers.test.js
+++ b/test/config_layers.test.js
@@ -119,6 +119,10 @@ describe("loadConfig", () => {
           subagents: {
             defaultLaunchModels: ["anthropic/claude-haiku-4-5:low"],
           },
+          modelSystemNotices: {
+            "openai/gpt-5.2": "global codex notice",
+            "anthropic/claude-sonnet-4-5": "global anthropic notice",
+          },
         }),
       );
 
@@ -135,6 +139,9 @@ describe("loadConfig", () => {
           agentContextFiles: ["docs/AGENTS.md"],
           subagents: {
             defaultLaunchModels: ["openai/gpt-5.2:high"],
+          },
+          modelSystemNotices: {
+            "openai/gpt-5.2": "repo codex notice",
           },
         }),
       );
@@ -181,6 +188,10 @@ describe("loadConfig", () => {
       ]);
       expect(config.subagents).toEqual({
         defaultLaunchModels: ["openai/gpt-5.2:high"],
+      });
+      expect(config.modelSystemNotices).toEqual({
+        "openai/gpt-5.2": "repo codex notice",
+        "anthropic/claude-sonnet-4-5": "global anthropic notice",
       });
     } finally {
       fx.cleanup();
@@ -285,6 +296,39 @@ describe("loadConfig", () => {
       expect(result.errors.some((error) => error.includes("subagents.defaultLaunchModels"))).toBe(
         true,
       );
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("validates modelSystemNotices keys and values", () => {
+    const fx = setupFixture();
+
+    try {
+      mkdirSync(join(fx.repo, ".tau"), { recursive: true });
+      writeFileSync(
+        join(fx.repo, ".tau", "config.json"),
+        JSON.stringify({
+          modelSystemNotices: {
+            "openai/gpt-5.2": "always use tau tools",
+            "openai/does-not-exist": "unknown model",
+            "not-a-model-key": "bad key",
+            "anthropic/claude-sonnet-4-5": "   ",
+          },
+        }),
+      );
+
+      const deps = createConfigDeps({
+        cwd: fx.repo,
+        home: fx.home,
+        env: {},
+      });
+
+      const result = loadConfigWithDiagnostics(fx.repo, deps);
+      expect(result.config.modelSystemNotices).toEqual({
+        "openai/gpt-5.2": "always use tau tools",
+      });
+      expect(result.errors.some((error) => error.includes("modelSystemNotices"))).toBe(true);
     } finally {
       fx.cleanup();
     }

--- a/test/core_runtime.test.js
+++ b/test/core_runtime.test.js
@@ -169,6 +169,73 @@ describe("core session rewind APIs", () => {
   });
 });
 
+describe("core session model notices", () => {
+  function getUserText(session, index) {
+    const message = session.history[index];
+    if (message?.role !== "user") {
+      return "";
+    }
+
+    const textBlock = message.content.find((block) => block.type === "text");
+    return textBlock?.text ?? "";
+  }
+
+  it("prepends configured model notice to user messages", () => {
+    const backend = createLocalToolExecutionBackend();
+    const toolRegistry = ToolCatalog.createRegistry(backend);
+    const persona = personas.find((entry) => entry.model.provider === "openai");
+    expect(persona).toBeDefined();
+
+    const session = new CoreSession({
+      persona,
+      systemPrompt: "system",
+      subagentPrompts: {},
+      riskLevel: "read-only",
+      toolRegistry,
+      config: {
+        modelSystemNotices: {
+          [`${persona.model.provider}/${persona.model.id}`]: "always use tau tools",
+        },
+      },
+    });
+
+    session.addUserText("hello");
+
+    expect(getUserText(session, 0)).toBe("<system>always use tau tools</system>\n\nhello");
+    expect(session.listRewindCandidates().map((candidate) => candidate.text)).toEqual(["hello"]);
+  });
+
+  it("switches notice based on current persona model", () => {
+    const backend = createLocalToolExecutionBackend();
+    const toolRegistry = ToolCatalog.createRegistry(backend);
+    const openaiPersona = personas.find((entry) => entry.model.provider === "openai");
+    const anthropicPersona = personas.find((entry) => entry.model.provider === "anthropic");
+    expect(openaiPersona).toBeDefined();
+    expect(anthropicPersona).toBeDefined();
+
+    const session = new CoreSession({
+      persona: openaiPersona,
+      systemPrompt: "system",
+      subagentPrompts: {},
+      riskLevel: "read-only",
+      toolRegistry,
+      config: {
+        modelSystemNotices: {
+          [`${openaiPersona.model.provider}/${openaiPersona.model.id}`]: "openai notice",
+          [`${anthropicPersona.model.provider}/${anthropicPersona.model.id}`]: "anthropic notice",
+        },
+      },
+    });
+
+    session.addUserText("message one");
+    session.setPersona(anthropicPersona, "system two", {});
+    session.addUserText("message two");
+
+    expect(getUserText(session, 0)).toBe("<system>openai notice</system>\n\nmessage one");
+    expect(getUserText(session, 1)).toBe("<system>anthropic notice</system>\n\nmessage two");
+  });
+});
+
 describe("context builder", () => {
   it("renders environment and project context blocks", () => {
     const tag = buildEnvironmentTag({

--- a/test/subagent_engine.test.js
+++ b/test/subagent_engine.test.js
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import { personas } from "../dist/core/personas.js";
+
+const { capturedUserMessages, runModelSubturnMock, runToolCallsMock } = vi.hoisted(() => ({
+  capturedUserMessages: [],
+  runModelSubturnMock: vi.fn(),
+  runToolCallsMock: vi.fn(),
+}));
+
+vi.mock("../dist/core/session/runner.js", () => ({
+  runModelSubturn: runModelSubturnMock,
+  runToolCalls: runToolCallsMock,
+}));
+
+vi.mock("../dist/core/usage/logs.js", () => ({
+  appendUsageLogEntry: vi.fn(),
+  getUsageCostTotal: (usage) => usage?.cost?.total ?? 0,
+  getUsageTotals: (usage) => usage,
+}));
+
+import { runSubagent } from "../dist/core/subagents/subagent_engine.js";
+
+function createAssistantMessage(model) {
+  return {
+    role: "assistant",
+    api: "anthropic-messages",
+    provider: model.provider,
+    model: model.id,
+    stopReason: "stop",
+    timestamp: Date.now(),
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    content: [{ type: "text", text: "done" }],
+  };
+}
+
+describe("subagent engine model notices", () => {
+  it("prepends configured model notices to subagent user prompts", async () => {
+    capturedUserMessages.length = 0;
+
+    const persona = personas.find((entry) => entry.model.provider === "anthropic");
+    expect(persona).toBeDefined();
+
+    runModelSubturnMock.mockImplementationOnce(async function* ({ context }) {
+      const userMessage = context.messages.find((message) => message.role === "user");
+      const textBlock = userMessage?.content.find((block) => block.type === "text");
+      capturedUserMessages.push(textBlock?.text ?? "");
+      return createAssistantMessage(persona.model);
+    });
+
+    const result = await runSubagent({
+      runtimeConfig: {
+        name: "default",
+        systemPrompt: "subagent system",
+        model: persona.model,
+        tools: [],
+        riskLevel: "read-only",
+      },
+      prompt: "collect findings",
+      config: {
+        modelSystemNotices: {
+          [`${persona.model.provider}/${persona.model.id}`]: "subagent notice",
+        },
+      },
+      signal: new AbortController().signal,
+    });
+
+    expect(result.finalText).toBe("done");
+    expect(capturedUserMessages).toEqual(["<system>subagent notice</system>\n\ncollect findings"]);
+  });
+});


### PR DESCRIPTION
- add `modelSystemNotices` to config loading with `<provider>/<model>` validation and per-key merge across config layers
- prepend configured notices as `<system>` blocks for every user message sent through the main session
- apply the same notice injection for subagent prompts based on the effective subagent model (including launch overrides)
- add coverage for config parsing/merge, session notice behavior, and subagent prompt injection
- update README.md and AGENTS.md config docs

fixes #159
