### PR TITLE
upgrade pi-ai/pi-tui and gemini 3.1 pro

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,7 +151,7 @@ Prompt/context tag style: use dash-case for XML-like tag names in prompt text (f
 
 ## Personas and subagents
 
-**Built-in**: 8 personas total: Claude Opus 4.6 (chat, coder), GPT-5.2 (chat, coder), GPT-5.3-Codex ChatGPT (coder), GPT-5.2-Codex API (coder), Gemini 3 Pro (chat), Gemini 3 Flash (chat). Built-in personas include the **default** subagent (general-purpose, trigger: explicit) unless it is explicitly disabled. Built-in personas have `skills: "*"` to enable all discovered skills by default. See trigger sensitivity below for how subagent and skill activation is controlled.
+**Built-in**: 8 personas total: Claude Opus 4.6 (chat, coder), GPT-5.2 (chat, coder), GPT-5.3-Codex ChatGPT (coder), GPT-5.2-Codex API (coder), Gemini 3.1 Pro (chat), Gemini 3 Flash (chat). Built-in personas include the **default** subagent (general-purpose, trigger: explicit) unless it is explicitly disabled. Built-in personas have `skills: "*"` to enable all discovered skills by default. See trigger sensitivity below for how subagent and skill activation is controlled.
 
 Personas can be defined at user level (`~/.config/tau/personas/*.md`) and project level (`.tau/personas/*.md`). Both use YAML frontmatter with required fields `id`, `provider`, `model` and optional fields. The persona file name (without `.md`) must match the `id`.
 

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ tau comes with several built-in personas across different models:
 - **GPT-5.2** (OpenAI): chat and coder variants
 - **GPT-5.3-Codex** (OpenAI): coder-only variant for ChatGPT Plus/Pro subscriptions (`gpt-5.3-codex-chatgpt`)
 - **GPT-5.2-Codex** (OpenAI API): coder-only variant for direct API access (`gpt-5.2-codex-api`)
-- **Gemini 3 Pro** and **Gemini 3 Flash** (Google): chat variants only
+- **Gemini 3.1 Pro** and **Gemini 3 Flash** (Google): chat variants only
 
 chat variants are for general-purpose assistance; coder variants are optimized for software engineering. built-in personas include the `default` sub-agent for background tasks unless disabled.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@markusylisiurunen/tau",
       "version": "0.2.60",
       "dependencies": {
-        "@mariozechner/pi-ai": "^0.53.0",
-        "@mariozechner/pi-tui": "^0.53.0",
+        "@mariozechner/pi-ai": "^0.53.1",
+        "@mariozechner/pi-tui": "^0.53.1",
         "@sinclair/typebox": "^0.34.48",
         "chalk": "^5.6.2",
         "file-type": "^21.3.0",
@@ -2056,9 +2056,9 @@
       "license": "MIT"
     },
     "node_modules/@mariozechner/pi-ai": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.53.0.tgz",
-      "integrity": "sha512-f6dIzxLoVlB7TrT18N48oEUKzyoTw/ujB5zLxklFtpgaCVj9TRVf5manpT+2OYFwq3B6KANJ8X3WfDNCiKBEhA==",
+      "version": "0.53.1",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.53.1.tgz",
+      "integrity": "sha512-2XuWg1XigK+0iSsq21nNEQoCnYMsVKhMMNx9kXMrtTJ7YUSflWG9eZ0qU2dfDQ2ccX5lAf9Gx4OszoLrsGkBvA==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.73.0",
@@ -2083,9 +2083,9 @@
       }
     },
     "node_modules/@mariozechner/pi-tui": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.53.0.tgz",
-      "integrity": "sha512-ffma5Xj6DTN8FWA+6jM5tDiFicF/NnyNSwPH0vw2oqkXqlXt1zSSM9FymZIbSjDLW+A/f1zMvAHORhFIeQTBJQ==",
+      "version": "0.53.1",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.53.1.tgz",
+      "integrity": "sha512-Y417vM7cUDaNcSXAh6wH+xKdEU7ltcj7p6xmlz/BvZokKLcEkoKaaMiFC+3Mlrip2j1SJdu7Y1cv/uxYWDF//Q==",
       "license": "MIT",
       "dependencies": {
         "@types/mime-types": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@mariozechner/pi-ai": "^0.53.0",
-    "@mariozechner/pi-tui": "^0.53.0",
+    "@mariozechner/pi-ai": "^0.53.1",
+    "@mariozechner/pi-tui": "^0.53.1",
     "@sinclair/typebox": "^0.34.48",
     "chalk": "^5.6.2",
     "file-type": "^21.3.0",

--- a/src/core/personas.ts
+++ b/src/core/personas.ts
@@ -223,10 +223,10 @@ const PERSONA_SPECS: PersonaSpec[] = [
     settings: { reasoning: "medium" },
   },
   {
-    id: "gemini-3-pro",
-    description: "Gemini 3 Pro",
-    model: getModel("google", "gemini-3-pro-preview"),
-    allowedReasoningLevels: ["low", "high"],
+    id: "gemini-3.1-pro",
+    description: "Gemini 3.1 Pro",
+    model: getModel("google", "gemini-3.1-pro-preview"),
+    allowedReasoningLevels: ["low", "medium", "high"],
     settings: { reasoning: "low" },
   },
   {


### PR DESCRIPTION
- bump `@mariozechner/pi-ai` and `@mariozechner/pi-tui` from `^0.53.0` to `^0.53.1`
- switch builtin Gemini Pro persona to `gemini-3.1-pro-preview`
- allow `low`, `medium`, and `high` reasoning levels for Gemini 3.1 Pro
- update built-in persona docs in `README.md` and `AGENTS.md`

validation:
- `npm run check`
- `npm test`
