### PR TITLE
fix codex failover with stale usage cache

### DIFF
--- a/src/core/auth/providers/openai_codex.ts
+++ b/src/core/auth/providers/openai_codex.ts
@@ -127,25 +127,19 @@ export class OpenAICodexAdapter implements AuthProviderAdapter {
       usage: account.usage,
     }));
 
-    const usableCandidates = candidates.filter((candidate) => isUsageUsable(candidate.usage, now));
-    if (usableCandidates.length === 0) {
-      return undefined;
-    }
+    candidates.sort((a, b) => compareAccountPriority(a, b, now));
 
-    usableCandidates.sort((a, b) => compareAccountPriority(a, b, now));
-
-    for (const candidate of usableCandidates) {
+    for (const candidate of candidates) {
       const apiKey = await this.getApiKeyForAccount(authStorage, candidate.account.accountId);
       if (!apiKey) {
         continue;
       }
 
       let usage = candidate.usage;
-      if (shouldRefreshUsage(usage, now)) {
+      if (shouldRefreshUsage(usage, now) || !isUsageUsable(usage, now)) {
         const refreshed = await this.getUsageSnapshot(authStorage, candidate.account, {
           apiKey,
-          refreshIfExpired: true,
-          refreshIfMissing: true,
+          forceRefresh: true,
         });
         usage = refreshed ?? usage;
       }

--- a/test/auth_storage.test.js
+++ b/test/auth_storage.test.js
@@ -1,7 +1,7 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@mariozechner/pi-ai", async (importOriginal) => {
   const actual = await importOriginal();
@@ -28,6 +28,10 @@ function createTempAuthPath() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 describe("AuthStorage", () => {
@@ -134,6 +138,125 @@ describe("CredentialResolver", () => {
       const account = saved.providers["openai-codex"].accounts[0];
       expect(account.access).toBe("new-access");
       expect(account.refresh).toBe("new-refresh");
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("refreshes exhausted codex accounts before deciding failover candidates", async () => {
+    const fx = createTempAuthPath();
+    try {
+      writeFileSync(
+        fx.authPath,
+        JSON.stringify(
+          {
+            providers: {
+              "openai-codex": {
+                accounts: [
+                  {
+                    type: "oauth",
+                    accountId: "acct-exhausted",
+                    providerAccountId: "provider-exhausted",
+                    access: "access-exhausted",
+                    refresh: "refresh-exhausted",
+                    expires: 0,
+                    usage: {
+                      windows: [
+                        {
+                          name: "primary",
+                          usedPercent: 100,
+                          resetAt: 4102444800,
+                          windowSeconds: 3600,
+                        },
+                      ],
+                    },
+                  },
+                  {
+                    type: "oauth",
+                    accountId: "acct-next",
+                    providerAccountId: "provider-next",
+                    access: "access-next",
+                    refresh: "refresh-next",
+                    expires: 0,
+                    usage: {
+                      windows: [
+                        {
+                          name: "primary",
+                          usedPercent: 100,
+                          resetAt: 4102444800,
+                          windowSeconds: 3600,
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          },
+          null,
+          2,
+        ),
+      );
+
+      getOAuthApiKey.mockImplementation(async (_provider, providers) => {
+        const account = providers["openai-codex"];
+        if (account.refresh === "refresh-exhausted") {
+          return {
+            apiKey: "api-exhausted",
+            newCredentials: {
+              access: account.access,
+              refresh: account.refresh,
+              expires: account.expires,
+              accountId: account.accountId,
+            },
+          };
+        }
+
+        return {
+          apiKey: "api-next",
+          newCredentials: {
+            access: account.access,
+            refresh: account.refresh,
+            expires: account.expires,
+            accountId: account.accountId,
+          },
+        };
+      });
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (_url, init) => {
+          const rawHeaders = init?.headers;
+          const accountId =
+            rawHeaders instanceof Headers
+              ? rawHeaders.get("ChatGPT-Account-Id")
+              : rawHeaders && typeof rawHeaders === "object"
+                ? rawHeaders["ChatGPT-Account-Id"]
+                : undefined;
+          const usedPercent = accountId === "provider-next" ? 12 : 100;
+          return {
+            ok: true,
+            json: async () => ({
+              rate_limit: {
+                primary_window: {
+                  used_percent: usedPercent,
+                  reset_at: 4102444800,
+                  limit_window_seconds: 3600,
+                },
+              },
+            }),
+          };
+        }),
+      );
+
+      const storage = new AuthStorage(fx.authPath);
+      const resolver = createCredentialResolver({
+        authStorage: storage,
+        getConfig: () => ({}),
+      });
+
+      const apiKey = await resolver.getApiKey("openai-codex", { sessionId: "session-1" });
+      expect(apiKey).toBe("api-next");
     } finally {
       fx.cleanup();
     }


### PR DESCRIPTION
- stop filtering codex accounts by cached usability before refresh in account selection
- force-refresh usage for candidates that are expired, missing, or currently marked unusable before final usability check
- add a regression test covering stale exhausted cache data so failover still selects a healthy account

## validation
- npm run check
- npm test

fixes #165
