### PR TITLE
wrap default subagent prompt around inherited main prompt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Tau is pre-v1 and the priority is to reach a clean, stable v1 design. Prefer exp
 - **Async daemon runtime** (`src/core/async/`): Async CLI + daemon stack (`cli.ts`, `cron.ts`, `http_protocol.ts`, `http_server.ts`, `server_config.ts`, `session_manager.ts`, `telegram.ts`, `workspace.ts`)
 - **ToolCatalog** (`src/core/tools/catalog.ts`): Builds the internal tool registry
 - **ToolExecutionBackend** (`src/core/tools/execution_backend.ts`): Execution backend for filesystem/process tools (local host or docker sandbox)
-- **ToolRegistry** (`src/core/tools/registry.ts`): Tool registry type used by ToolCatalog for main-session (bash, write, edit, view_image, spawn_agent, send_input_to_agent, wait_for_agent, terminate_agent) and sub-agent (emit_output plus allowed tools) registries
+- **ToolRegistry** (`src/core/tools/registry.ts`): Tool registry type used by ToolCatalog for main-session (bash, write, edit, view_image, spawn_agent, send_input_to_agent, wait_for_agent, terminate_agent) and sub-agent (configured allowed tools) registries
 - **TUI**: Terminal rendering via `@mariozechner/pi-tui` with components in `src/tui/ui/`
 - **Chat UI models** (`src/tui/ui/chat_message_model.ts`): Typed message models and rendering glue for UI components
 - **Tool output layout** (`src/tui/ui/tool_output.ts`): Shared compact/expanded tool UI layout and header building
@@ -45,7 +45,7 @@ Tau is pre-v1 and the priority is to reach a clean, stable v1 design. Prefer exp
 
 **Data flow**: TUI mode: User input → `ChatApp` → `ChatController.onUserInput()` → `CoreSession.events()` (yields core events) → `ChatController.onEvent()` → `TuiChatView` rendering. RPC mode: NDJSON requests on stdin → RPC server (`src/core/modes/rpc_server.ts`) → `ChatRuntime`/`CoreSession` → NDJSON responses/events on stdout. SDK mode: Node code → `src/sdk/client.ts` → spawned `tau rpc` subprocess over stdin/stdout NDJSON. Async mode: `tau async daemon` → async HTTP server (`src/core/async/http_server.ts`) + session manager (`src/core/async/session_manager.ts`) + optional cron scheduler (`src/core/async/cron.ts`) + optional Telegram long-poll adapter (`src/core/async/telegram.ts`) over `getUpdates`/`getFile`/`sendMessage`.
 
-**Engine events**: `CoreSession.events()` yields `assistant_start`/`partial`/`final` for streaming text, `tool_ui` for tool progress, `tool_result` when tools complete, and `notice` for warnings. Assistant and tool-result events include stable `historyEntryId` values so the UI can correlate rendered rows with session history across rewind operations. Subagent UI updates (spawned, progress, emit_output messages, finished) are emitted as `subagent_ui` on the same core event channel via `CoreSession.onEvent()`, including stable origin correlation metadata for RPC request mapping. The core event protocol lives in `src/core/events/`. Tools can return immediate results or two-phase results (emit start event, run async, emit completion) for progress indication.
+**Engine events**: `CoreSession.events()` yields `assistant_start`/`partial`/`final` for streaming text, `tool_ui` for tool progress, `tool_result` when tools complete, and `notice` for warnings. Assistant and tool-result events include stable `historyEntryId` values so the UI can correlate rendered rows with session history across rewind operations. Subagent UI updates (spawned, progress, optional emit_output messages when enabled, finished) are emitted as `subagent_ui` on the same core event channel via `CoreSession.onEvent()`, including stable origin correlation metadata for RPC request mapping. The core event protocol lives in `src/core/events/`. Tools can return immediate results or two-phase results (emit start event, run async, emit completion) for progress indication.
 
 ## Key modules
 
@@ -120,17 +120,17 @@ Tau is pre-v1 and the priority is to reach a clean, stable v1 design. Prefer exp
 
 ## Tool system
 
-| Tool                  | Purpose                        | Risk requirement                               |
-| --------------------- | ------------------------------ | ---------------------------------------------- |
-| `bash`                | Shell execution                | `read-only` for reads, `read-write` for writes |
-| `write`               | Create/overwrite files         | `read-write`                                   |
-| `edit`                | Replace exact text in files    | `read-write`                                   |
-| `view_image`          | View an image file             | `read-only`                                    |
-| `spawn_agent`         | Start a background subagent    | `read-only` or `read-write`                    |
-| `send_input_to_agent` | Send input to an idle subagent | `read-only` or `read-write`                    |
-| `wait_for_agent`      | Await subagent completion      | `read-only` or `read-write`                    |
-| `terminate_agent`     | Stop a running subagent        | `read-only` or `read-write`                    |
-| `emit_output`         | Subagent-only output to main   | `read-only` or `read-write`                    |
+| Tool                  | Purpose                                                                  | Risk requirement                               |
+| --------------------- | ------------------------------------------------------------------------ | ---------------------------------------------- |
+| `bash`                | Shell execution                                                          | `read-only` for reads, `read-write` for writes |
+| `write`               | Create/overwrite files                                                   | `read-write`                                   |
+| `edit`                | Replace exact text in files                                              | `read-write`                                   |
+| `view_image`          | View an image file                                                       | `read-only`                                    |
+| `spawn_agent`         | Start a background subagent                                              | `read-only` or `read-write`                    |
+| `send_input_to_agent` | Send input to an idle subagent                                           | `read-only` or `read-write`                    |
+| `wait_for_agent`      | Await subagent completion                                                | `read-only` or `read-write`                    |
+| `terminate_agent`     | Stop a running subagent                                                  | `read-only` or `read-write`                    |
+| `emit_output`         | Subagent-only output to main (currently disabled in subagent registries) | `read-only` or `read-write`                    |
 
 Note: read/list/grep tool definitions exist in `src/core/tools`, but ToolCatalog does not register them in the default tool set.
 
@@ -158,7 +158,7 @@ Prompt/context tag style: use dash-case for XML-like tag names in prompt text (f
 - Current preview shapes: bash uses head/tail output plus a status line; write shows up to 16 preview lines with a status line; edit uses a truncated diff preview with counts.
 - Pruned tool results patch existing tool cards by `toolCallId`, preserve headers, replace the body with model-visible pruned content, and prefix status as `✂ pruned · <existing status>` (or `✂ pruned` when no status exists).
 
-**Subagent-only tools**: subagents run with a dedicated tool registry that always includes `emit_output` plus the tools enabled for that subagent (inherited from the main persona or explicitly overridden). Risk level is inherited by default but can be overridden per subagent, including `read-write` even when the main session is `read-only`. `spawn_agent` can optionally set launch model/reasoning via `<provider>/<model>:<effort>` (allowlisted by `launchModels`) and can optionally set `workingDirectory`. When `workingDirectory` is set, the subagent runs from that directory and its prompt context (cwd, AGENTS.md scope, skills block) is rebuilt as if tau was started there. See `src/core/subagents/subagent_engine.ts` and `src/core/tools/spawn_agent.ts`.
+**Subagent-only tools**: subagents run with a dedicated tool registry that includes the tools enabled for that subagent (inherited from the main persona or explicitly overridden). The `emit_output` tool definition remains in the codebase but is currently disabled for subagent registries. Risk level is inherited by default but can be overridden per subagent, including `read-write` even when the main session is `read-only`. The built-in `default` subagent prompt wraps and inherits the main persona system prompt, while enforcing default-subagent rules that take precedence on conflicts. `spawn_agent` can optionally set launch model/reasoning via `<provider>/<model>:<effort>` (allowlisted by `launchModels`) and can optionally set `workingDirectory`. When `workingDirectory` is set, the subagent runs from that directory and its prompt context (cwd, AGENTS.md scope, skills block) is rebuilt as if tau was started there. See `src/core/subagents/subagent_engine.ts` and `src/core/tools/spawn_agent.ts`.
 
 **Subagent limit**: at most 8 subagents may run concurrently.
 

--- a/README.md
+++ b/README.md
@@ -314,9 +314,9 @@ tau --persona opus-4.6-coder
 
 ## sub-agents
 
-some personas can run isolated sub-agents via the `spawn_agent`, `send_input_to_agent`, `wait_for_agent`, and `terminate_agent` tools. sub-agents return their output through the subagent-only `emit_output` tool, which is collected by `wait_for_agent`.
+some personas can run isolated sub-agents via the `spawn_agent`, `send_input_to_agent`, `wait_for_agent`, and `terminate_agent` tools. sub-agents report progress in the subagent panel, and `wait_for_agent` returns their final output when they finish.
 
-the built-in `default` sub-agent is available unless disabled. it inherits the main persona's model, settings, tool access (minus sub-agent management tools), and the session risk level. custom sub-agents can override model, reasoning, tools, and risk level. a sub-agent configured with `riskLevel: read-write` can perform writes even when the main session is `read-only`.
+the built-in `default` sub-agent is available unless disabled. it inherits the main persona's model, settings, tool access (minus sub-agent management tools), risk level, and system prompt. the inherited main prompt is wrapped with default sub-agent-specific rules, and those wrapper rules take precedence on conflicts. custom sub-agents can override model, reasoning, tools, and risk level. a sub-agent configured with `riskLevel: read-write` can perform writes even when the main session is `read-only`.
 
 `spawn_agent` supports an optional launch override string (`model: "<provider>/<model>:<effort>"`) and an optional `workingDirectory`. when `workingDirectory` is set, the sub-agent runs from that directory and its prompt context (cwd, AGENTS.md scope, and skills block) is rebuilt as if tau was started there. launch overrides are allowlisted per subagent. custom subagents can define `launchModels` in persona frontmatter, and the built-in `default` sub-agent uses `subagents.defaultLaunchModels` from config.
 

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "postbuild": "node scripts/copy-starter.js && find dist -name '*.d.ts' ! -path 'dist/sdk/*' -delete",
-    "check": "prettier -w .tau/**/*.md docs/**/*.md starter/**/*.md *.md && biome check --write . && tsc -p tsconfig.json --noEmit",
+    "postbuild": "node scripts/copy-starter.js && node scripts/copy-static-prompts.js && find dist -name '*.d.ts' ! -path 'dist/sdk/*' -delete",
+    "check": "prettier -w .tau/**/*.md docs/**/*.md src/core/static/**/*.md starter/**/*.md *.md && biome check --write . && tsc -p tsconfig.json --noEmit",
     "precheck": "node scripts/generate-version.js && node scripts/generate-themes.js",
     "prebuild": "node scripts/generate-version.js && node scripts/generate-themes.js",
     "start": "node dist/main.js",

--- a/scripts/copy-static-prompts.js
+++ b/scripts/copy-static-prompts.js
@@ -1,0 +1,20 @@
+import { cpSync, existsSync, mkdirSync, rmSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const sourceDir = join(__dirname, "../src/core/static/prompts");
+const targetDir = join(__dirname, "../dist/core/static/prompts");
+
+if (!existsSync(sourceDir)) {
+  throw new Error(`static prompts source directory not found: ${sourceDir}`);
+}
+
+if (existsSync(targetDir)) {
+  rmSync(targetDir, { recursive: true, force: true });
+}
+
+mkdirSync(targetDir, { recursive: true });
+cpSync(sourceDir, targetDir, { recursive: true });
+
+console.log("copied static prompts to dist/core/static/prompts");

--- a/src/core/config/content_loader.ts
+++ b/src/core/config/content_loader.ts
@@ -154,11 +154,13 @@ function parseSubagentTools(toolsRaw: string[] | undefined): {
   for (const name of cleaned) {
     if (seen.has(name)) continue;
     seen.add(name);
+
     if (SUBAGENT_TOOL_NAME_SET.has(name as SubagentToolName)) {
       selected.push(name as SubagentToolName);
-    } else {
-      unknown.push(name);
+      continue;
     }
+
+    unknown.push(name);
   }
 
   if (unknown.length > 0) {

--- a/src/core/runtime/session_prompt_composer.ts
+++ b/src/core/runtime/session_prompt_composer.ts
@@ -56,7 +56,11 @@ export function composeSessionPrompts(args: ComposeSessionPromptsArgs): SessionP
   const subagents = args.persona.subagents;
   if (subagents) {
     for (const [name, config] of Object.entries(subagents)) {
-      const personaSystemPrompt = getSubagentBasePrompt(name, config);
+      const personaSystemPrompt = getSubagentBasePrompt({
+        name,
+        config,
+        mainPersonaSystemPrompt: args.persona.systemPrompt,
+      });
 
       const subagentEnvironmentTag = buildEnvironmentTag({
         riskLevel: config.riskLevel ?? args.riskLevel,

--- a/src/core/static/index.ts
+++ b/src/core/static/index.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const TEMPLATE_PLACEHOLDER_PATTERN = /\{\{([a-zA-Z0-9_]+)\}\}/g;
+
+const STATIC_PROMPT_PATHS = {
+  "default-subagent-wrapper": "./prompts/default-subagent-wrapper.md",
+} as const;
+
+export type StaticPromptId = keyof typeof STATIC_PROMPT_PATHS;
+
+export function getStaticPromptPath(promptId: StaticPromptId): string {
+  return fileURLToPath(new URL(STATIC_PROMPT_PATHS[promptId], import.meta.url));
+}
+
+export function loadStaticPrompt(promptId: StaticPromptId): string {
+  return readFileSync(getStaticPromptPath(promptId), "utf8");
+}
+
+function interpolateTemplate(template: string, values: Record<string, string>): string {
+  const templatePlaceholders = Array.from(template.matchAll(TEMPLATE_PLACEHOLDER_PATTERN))
+    .map((match) => match[1])
+    .filter((key): key is string => typeof key === "string");
+  const uniqueTemplatePlaceholders = new Set(templatePlaceholders);
+
+  const missingPlaceholders = Object.keys(values)
+    .filter((key) => !uniqueTemplatePlaceholders.has(key))
+    .map((key) => `{{${key}}}`);
+  if (missingPlaceholders.length > 0) {
+    throw new Error(`template is missing placeholders: ${missingPlaceholders.join(", ")}`);
+  }
+
+  const unresolvedPlaceholders = Array.from(uniqueTemplatePlaceholders)
+    .filter((key) => !Object.hasOwn(values, key))
+    .map((key) => `{{${key}}}`);
+  if (unresolvedPlaceholders.length > 0) {
+    throw new Error(`template has unresolved placeholders: ${unresolvedPlaceholders.join(", ")}`);
+  }
+
+  return template.replace(TEMPLATE_PLACEHOLDER_PATTERN, (_match, key: string) => values[key] ?? "");
+}
+
+const DEFAULT_SUBAGENT_WRAPPER_PROMPT = loadStaticPrompt("default-subagent-wrapper").trim();
+
+export function loadDefaultSubagentWrapperPrompt(): string {
+  return DEFAULT_SUBAGENT_WRAPPER_PROMPT;
+}
+
+export function renderDefaultSubagentWrapperPrompt(args: {
+  inheritedInstructions: string;
+}): string {
+  return interpolateTemplate(DEFAULT_SUBAGENT_WRAPPER_PROMPT, {
+    inherited_instructions: args.inheritedInstructions.trim(),
+  });
+}

--- a/src/core/static/prompts/default-subagent-wrapper.md
+++ b/src/core/static/prompts/default-subagent-wrapper.md
@@ -1,0 +1,20 @@
+You are a subagent supporting the main agent.
+
+Treat the instructions in <inherited-instructions> as baseline behavior.
+
+If inherited instructions conflict with this wrapper, tool/runtime constraints, or the current task, follow this wrapper and runtime constraints.
+
+<inherited-instructions>
+{{inherited_instructions}}
+</inherited-instructions>
+
+### Rules
+
+Keep the following in mind as you work:
+
+- You may be part of a larger swarm of subagents. Assume other subagents may be modifying this directory at the same time.
+- Never revert, discard, or overwrite changes you did not make.
+- Avoid mutating git operations (for example: reset, stash, checkout -- <file>, restore, rebase, cherry-pick) unless explicitly instructed.
+- Drive the request to completion autonomously whenever possible. Ask follow-up questions only when blocked by missing or ambiguous requirements.
+- If you hit a real blocker, report it clearly to the main agent. Do not try to hack around blockers with brittle or risky workarounds.
+- Your final response is the only information the main agent receives, so ensure it is self-contained and includes all relevant details needed to understand the outcome.

--- a/src/core/subagents/default.ts
+++ b/src/core/subagents/default.ts
@@ -1,24 +1,10 @@
-import { DEFAULT_SUBAGENT_NAME, type SubagentDefinition } from "./types.js";
+import { renderDefaultSubagentWrapperPrompt } from "../static/index.js";
 
-const DEFAULT_SYSTEM_PROMPT = `
-You are "default", a focused sub-agent that supports the main assistant.
+export const DEFAULT_SUBAGENT_DESCRIPTION =
+  "General-purpose sub-agent for background work. Trigger: explicit.";
 
-Your job: use the tools available to you to execute the user's request, then report results back to the main agent.
-
-### Rules
-
-- Use the emit_output tool to send findings back to the main agent. The main agent only receives emit_output messages, so always call it with your final answer before finishing.
-- Follow-up inputs may arrive later, but you cannot ask for clarification or additional input. You must complete the task with the information available.
-- Follow the environment tag for risk and tool constraints.
-
-### Output
-
-Send the final answer via emit_output. After emitting, reply with a brief confirmation like "done".
-Be direct and concise. No meta commentary about your process.
-`.trim();
-
-export const DEFAULT_SUBAGENT_DEFINITION: SubagentDefinition = {
-  name: DEFAULT_SUBAGENT_NAME,
-  description: "General-purpose sub-agent for background work. Trigger: explicit.",
-  systemPrompt: DEFAULT_SYSTEM_PROMPT,
-};
+export function buildDefaultSubagentSystemPrompt(mainPersonaSystemPrompt: string): string {
+  return renderDefaultSubagentWrapperPrompt({
+    inheritedInstructions: mainPersonaSystemPrompt,
+  });
+}

--- a/src/core/subagents/registry.ts
+++ b/src/core/subagents/registry.ts
@@ -7,7 +7,7 @@ import {
   TOOL_NAME_WRITE,
 } from "../tools/tool_names.js";
 import type { Persona, RiskLevel } from "../types.js";
-import { DEFAULT_SUBAGENT_DEFINITION } from "./default.js";
+import { buildDefaultSubagentSystemPrompt, DEFAULT_SUBAGENT_DESCRIPTION } from "./default.js";
 import {
   DEFAULT_SUBAGENT_NAME,
   type SubagentLaunchModel,
@@ -86,16 +86,20 @@ export function resolveSubagentEffectiveSettings(args: {
   };
 }
 
-export function getSubagentBasePrompt(name: string, config: SubagentPersonaConfig): string {
-  if (name === DEFAULT_SUBAGENT_NAME) {
-    return DEFAULT_SUBAGENT_DEFINITION.systemPrompt;
+export function getSubagentBasePrompt(args: {
+  name: string;
+  config: SubagentPersonaConfig;
+  mainPersonaSystemPrompt: string;
+}): string {
+  if (args.name === DEFAULT_SUBAGENT_NAME) {
+    return buildDefaultSubagentSystemPrompt(args.mainPersonaSystemPrompt);
   }
 
-  if (!config.systemPrompt) {
-    throw new Error(`subagent '${name}' is missing a system prompt`);
+  if (!args.config.systemPrompt) {
+    throw new Error(`subagent '${args.name}' is missing a system prompt`);
   }
 
-  return config.systemPrompt;
+  return args.config.systemPrompt;
 }
 
 export function getSubagentDescription(
@@ -104,7 +108,7 @@ export function getSubagentDescription(
 ): string | undefined {
   if (config.description) return config.description;
   if (name === DEFAULT_SUBAGENT_NAME) {
-    return DEFAULT_SUBAGENT_DEFINITION.description;
+    return DEFAULT_SUBAGENT_DESCRIPTION;
   }
   return undefined;
 }

--- a/src/core/subagents/types.ts
+++ b/src/core/subagents/types.ts
@@ -2,7 +2,6 @@ import type { Api, Model } from "@mariozechner/pi-ai";
 import {
   TOOL_NAME_BASH,
   TOOL_NAME_EDIT,
-  TOOL_NAME_EMIT_OUTPUT,
   TOOL_NAME_VIEW_IMAGE,
   TOOL_NAME_WEB_FETCH,
   TOOL_NAME_WEB_SEARCH,
@@ -21,7 +20,6 @@ export const SUBAGENT_TOOL_NAMES = [
   TOOL_NAME_VIEW_IMAGE,
   TOOL_NAME_WEB_SEARCH,
   TOOL_NAME_WEB_FETCH,
-  TOOL_NAME_EMIT_OUTPUT,
 ] as const;
 
 export type SubagentToolName = (typeof SUBAGENT_TOOL_NAMES)[number];
@@ -77,12 +75,6 @@ export type SubagentUiEvent =
   | { type: "subagent_emit_output"; id: string; text: string }
   | { type: "subagent_abort_requested"; id: string }
   | { type: "subagent_finished"; state: SubagentStateSnapshot };
-
-export type SubagentDefinition = {
-  name: SubagentName;
-  description?: string;
-  systemPrompt: string;
-};
 
 export type SubagentRuntimeConfig = {
   name: SubagentName;

--- a/src/core/tools/catalog.ts
+++ b/src/core/tools/catalog.ts
@@ -12,7 +12,6 @@ import { createTerminateAgentToolDefinition } from "./terminate_agent.js";
 import {
   TOOL_NAME_BASH,
   TOOL_NAME_EDIT,
-  TOOL_NAME_EMIT_OUTPUT,
   TOOL_NAME_VIEW_IMAGE,
   TOOL_NAME_WEB_FETCH,
   TOOL_NAME_WEB_SEARCH,
@@ -23,6 +22,8 @@ import { createWaitForAgentToolDefinition } from "./wait_for_agent.js";
 import { createWebFetchToolDefinition } from "./web_fetch.js";
 import { createWebSearchToolDefinition } from "./web_search.js";
 import { createWriteToolDefinition } from "./write.js";
+
+const SUBAGENT_EMIT_OUTPUT_ENABLED = false;
 
 export const ToolCatalog = {
   createRegistry(backend: ToolExecutionBackend): ToolRegistry {
@@ -43,7 +44,9 @@ export const ToolCatalog = {
     config: Config,
     backend: ToolExecutionBackend,
   ): ToolRegistry {
-    const definitions: ToolDefinition[] = [createEmitOutputToolDefinition()];
+    const definitions: ToolDefinition[] = SUBAGENT_EMIT_OUTPUT_ENABLED
+      ? [createEmitOutputToolDefinition()]
+      : [];
     const seen = new Set<string>();
 
     const addTool = (tool: SubagentToolName): void => {
@@ -68,8 +71,6 @@ export const ToolCatalog = {
           break;
         case TOOL_NAME_WEB_FETCH:
           definitions.push(createWebFetchToolDefinition(config));
-          break;
-        case TOOL_NAME_EMIT_OUTPUT:
           break;
       }
     };

--- a/test/chat_runtime.test.js
+++ b/test/chat_runtime.test.js
@@ -130,6 +130,11 @@ describe("ChatRuntime", () => {
     expect(runtime.promptComposition.subagentPrompts.default).toContain(
       '<risk-level level="read-only">',
     );
+    expect(runtime.promptComposition.subagentPrompts.default).toContain("<inherited-instructions>");
+    expect(runtime.promptComposition.subagentPrompts.default).toContain("main system prompt");
+    expect(runtime.promptComposition.subagentPrompts.default).not.toContain(
+      "{{inherited_instructions}}",
+    );
   });
 
   it("rebuilds full system prompts with main and subagent content", () => {
@@ -165,6 +170,8 @@ describe("ChatRuntime", () => {
     expect(composition.baseSystemPrompt).toContain("<datetime>2026-01-01T00:00:00.000Z</datetime>");
 
     expect(composition.subagentPrompts.default).toContain('<risk-level level="read-only">');
+    expect(composition.subagentPrompts.default).toContain("<inherited-instructions>");
+    expect(composition.subagentPrompts.default).toContain("main system prompt");
     expect(composition.subagentPrompts.researcher).toContain("research subagent prompt");
     expect(composition.subagentPrompts.researcher).toContain('<risk-level level="read-write">');
     expect(composition.subagentPrompts.researcher).toContain("<sandbox-info>");

--- a/test/core_runtime.test.js
+++ b/test/core_runtime.test.js
@@ -449,6 +449,12 @@ describe("session prompt composer", () => {
     expect(result.baseSystemPrompt).toContain("<sandbox-info>");
 
     expect(result.subagentPrompts.default).toContain('<risk-level level="read-only">');
+    expect(result.subagentPrompts.default).toContain("<inherited-instructions>");
+    expect(result.subagentPrompts.default).toContain("main system prompt");
+    expect(result.subagentPrompts.default).not.toContain("{{inherited_instructions}}");
+    expect(result.subagentPrompts.default).toContain(
+      "You are a subagent supporting the main agent.",
+    );
     expect(result.subagentPrompts.researcher).toContain("research subagent prompt");
     expect(result.subagentPrompts.researcher).toContain('<risk-level level="read-write">');
     expect(result.subagentPrompts.researcher).toContain("<sandbox-info>");

--- a/test/static_prompts.test.js
+++ b/test/static_prompts.test.js
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  loadDefaultSubagentWrapperPrompt,
+  renderDefaultSubagentWrapperPrompt,
+} from "../dist/core/static/index.js";
+
+describe("static prompts", () => {
+  it("loads default subagent wrapper prompt from disk", () => {
+    expect(loadDefaultSubagentWrapperPrompt()).toContain(
+      "You are a subagent supporting the main agent.",
+    );
+  });
+
+  it("interpolates inherited main prompt into the default subagent wrapper", () => {
+    const prompt = renderDefaultSubagentWrapperPrompt({
+      inheritedInstructions: "main system prompt",
+    });
+
+    expect(prompt).toContain("main system prompt");
+    expect(prompt).not.toContain("{{inherited_instructions}}");
+  });
+
+  it("preserves literal replacement syntax characters", () => {
+    const prompt = renderDefaultSubagentWrapperPrompt({
+      inheritedInstructions: "$& $$ $1",
+    });
+
+    expect(prompt).toContain("$& $$ $1");
+  });
+
+  it("allows placeholder-like text in replacement values", () => {
+    const prompt = renderDefaultSubagentWrapperPrompt({
+      inheritedInstructions: "keep {{this}} literal",
+    });
+
+    expect(prompt).toContain("keep {{this}} literal");
+  });
+});


### PR DESCRIPTION
- make default subagent prompt composition explicit by wrapping inherited main persona system prompt in a dedicated section
- keep full prompt rebuild path unchanged so skills, AGENTS context, sandbox info, and environment tags are resolved from the subagent cwd/risk
- preserve custom subagent behavior, only the built-in `default` subagent gets inherited main-prompt wrapping
- add tests that assert inherited main prompt inclusion in default subagent prompts
- update README.md and AGENTS.md to document default subagent prompt inheritance and precedence rules

fixes #162
