### PR TITLE
fix tui ellipsis color

### DIFF
--- a/src/tui/ui/components/one_line_segments.ts
+++ b/src/tui/ui/components/one_line_segments.ts
@@ -32,6 +32,118 @@ export function truncateFromEndByWidth(text: string, maxCols: number): string {
   return `${out}${ellipsis}`;
 }
 
+export function truncateFromEndByWidthPreserveAnsi(text: string, maxCols: number): string {
+  if (!text.includes("\x1b")) {
+    return truncateFromEndByWidth(text, maxCols);
+  }
+
+  if (maxCols <= 0) return "";
+  if (visibleWidth(text) <= maxCols) return text;
+  if (maxCols === 1) return "…";
+
+  const ellipsis = "…";
+  const targetCols = Math.max(0, maxCols - visibleWidth(ellipsis));
+  if (targetCols <= 0) return ellipsis;
+
+  const parts = splitAnsiParts(text);
+
+  let out = "";
+  let outCols = 0;
+
+  outer: for (const part of parts) {
+    if (part.type === "ansi") {
+      out += part.value;
+      continue;
+    }
+
+    for (const g of iterateGraphemes(part.value)) {
+      const gCols = visibleWidth(g);
+      if (outCols + gCols > targetCols) break outer;
+      out += g;
+      outCols += gCols;
+    }
+  }
+
+  if (!out.endsWith("\x1b[0m")) {
+    return `${out}${ellipsis}\x1b[0m`;
+  }
+
+  return `${out}${ellipsis}`;
+}
+
+function splitAnsiParts(text: string): Array<{ type: "ansi" | "text"; value: string }> {
+  const parts: Array<{ type: "ansi" | "text"; value: string }> = [];
+  let i = 0;
+
+  while (i < text.length) {
+    const escIndex = text.indexOf("\x1b", i);
+    if (escIndex === -1) {
+      const tail = text.slice(i);
+      if (tail) parts.push({ type: "text", value: tail });
+      break;
+    }
+
+    if (escIndex > i) {
+      const chunk = text.slice(i, escIndex);
+      if (chunk) parts.push({ type: "text", value: chunk });
+    }
+
+    const parsed = parseAnsiSequence(text, escIndex);
+    if (parsed) {
+      parts.push({ type: "ansi", value: parsed.sequence });
+      i = parsed.nextIndex;
+    } else {
+      parts.push({ type: "text", value: "\x1b" });
+      i = escIndex + 1;
+    }
+  }
+
+  return parts;
+}
+
+function parseAnsiSequence(
+  text: string,
+  start: number,
+): { sequence: string; nextIndex: number } | null {
+  if (text[start] !== "\x1b") return null;
+
+  const next = text[start + 1];
+
+  if (next === "[") {
+    let i = start + 2;
+    while (i < text.length) {
+      const code = text.charCodeAt(i);
+      if (code >= 0x40 && code <= 0x7e) {
+        i++;
+        return { sequence: text.slice(start, i), nextIndex: i };
+      }
+      i++;
+    }
+    return { sequence: text.slice(start), nextIndex: text.length };
+  }
+
+  if (next === "]") {
+    let i = start + 2;
+    while (i < text.length) {
+      const c = text[i];
+      if (c === "\x07") {
+        i++;
+        return { sequence: text.slice(start, i), nextIndex: i };
+      }
+
+      if (c === "\x1b" && text[i + 1] === "\\") {
+        i += 2;
+        return { sequence: text.slice(start, i), nextIndex: i };
+      }
+
+      i++;
+    }
+    return { sequence: text.slice(start), nextIndex: text.length };
+  }
+
+  return null;
+}
+
 function normalizeInlineTextPreservePadding(text: string): string {
   // Keep this strictly single-line but preserve intentional padding segments (e.g. " ").
   // Callers should trim user-provided segments (e.g. commands) as needed.

--- a/src/tui/ui/custom_editor.ts
+++ b/src/tui/ui/custom_editor.ts
@@ -1,7 +1,10 @@
 import { Key, matchesKey, visibleWidth } from "@mariozechner/pi-tui";
 import { DOUBLE_PRESS_WINDOW_MS } from "../constants.js";
 import { Editor } from "./components/editor.js";
-import { truncateFromEndByWidth } from "./components/one_line_segments.js";
+import {
+  truncateFromEndByWidth,
+  truncateFromEndByWidthPreserveAnsi,
+} from "./components/one_line_segments.js";
 import { getMentionAutocompleteToken } from "./slash_autocomplete.js";
 import type { Theme } from "./theme/index.js";
 
@@ -523,124 +526,9 @@ export class CustomEditor extends Editor {
     const lineWidth = visibleWidth(line);
     if (lineWidth === width) return line;
     if (lineWidth > width) {
-      return this.padToWidth(this.truncateFromEndByWidthPreserveAnsi(line, width), width);
+      return this.padToWidth(truncateFromEndByWidthPreserveAnsi(line, width), width);
     }
     return this.padToWidth(line, width);
-  }
-
-  private truncateFromEndByWidthPreserveAnsi(text: string, maxCols: number): string {
-    if (!text.includes("\x1b")) {
-      return truncateFromEndByWidth(text, maxCols);
-    }
-
-    if (maxCols <= 0) return "";
-    if (visibleWidth(text) <= maxCols) return text;
-    if (maxCols === 1) return "…";
-
-    const ellipsis = "…";
-    const targetCols = Math.max(0, maxCols - visibleWidth(ellipsis));
-    if (targetCols <= 0) return ellipsis;
-
-    const parts = this.splitAnsiParts(text);
-
-    let out = "";
-    let outCols = 0;
-
-    outer: for (const part of parts) {
-      if (part.type === "ansi") {
-        out += part.value;
-        continue;
-      }
-
-      for (const g of this.segmentGraphemes(part.value)) {
-        const gCols = visibleWidth(g);
-        if (outCols + gCols > targetCols) break outer;
-        out += g;
-        outCols += gCols;
-      }
-    }
-
-    // If we truncated, ensure we reset any active SGR to avoid leaking styles.
-    if (!out.endsWith("\x1b[0m")) {
-      out += `${ellipsis}\x1b[0m`;
-      return out;
-    }
-
-    return `${out}${ellipsis}`;
-  }
-
-  private splitAnsiParts(text: string): Array<{ type: "ansi" | "text"; value: string }> {
-    const parts: Array<{ type: "ansi" | "text"; value: string }> = [];
-    let i = 0;
-
-    while (i < text.length) {
-      const escIndex = text.indexOf("\x1b", i);
-      if (escIndex === -1) {
-        const tail = text.slice(i);
-        if (tail) parts.push({ type: "text", value: tail });
-        break;
-      }
-
-      if (escIndex > i) {
-        const chunk = text.slice(i, escIndex);
-        if (chunk) parts.push({ type: "text", value: chunk });
-      }
-
-      const parsed = this.parseAnsiSequence(text, escIndex);
-      if (parsed) {
-        parts.push({ type: "ansi", value: parsed.sequence });
-        i = parsed.nextIndex;
-      } else {
-        parts.push({ type: "text", value: "\x1b" });
-        i = escIndex + 1;
-      }
-    }
-
-    return parts;
-  }
-
-  private parseAnsiSequence(
-    text: string,
-    start: number,
-  ): { sequence: string; nextIndex: number } | null {
-    if (text[start] !== "\x1b") return null;
-
-    const next = text[start + 1];
-
-    if (next === "[") {
-      let i = start + 2;
-      while (i < text.length) {
-        const code = text.charCodeAt(i);
-        if (code >= 0x40 && code <= 0x7e) {
-          i++;
-          return { sequence: text.slice(start, i), nextIndex: i };
-        }
-        i++;
-      }
-      return { sequence: text.slice(start), nextIndex: text.length };
-    }
-
-    if (next === "]") {
-      // OSC: terminate on BEL or ST (ESC backslash)
-      let i = start + 2;
-      while (i < text.length) {
-        const c = text[i];
-        if (c === "\x07") {
-          i++;
-          return { sequence: text.slice(start, i), nextIndex: i };
-        }
-
-        if (c === "\x1b" && text[i + 1] === "\\") {
-          i += 2;
-          return { sequence: text.slice(start, i), nextIndex: i };
-        }
-
-        i++;
-      }
-      return { sequence: text.slice(start), nextIndex: text.length };
-    }
-
-    return null;
   }
 
   private renderEditorContent(

--- a/src/tui/ui/subagent_editor_pane.ts
+++ b/src/tui/ui/subagent_editor_pane.ts
@@ -1,5 +1,8 @@
-import { type Component, truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
-import { truncateFromEndByWidth } from "./components/one_line_segments.js";
+import { type Component, visibleWidth } from "@mariozechner/pi-tui";
+import {
+  truncateFromEndByWidth,
+  truncateFromEndByWidthPreserveAnsi,
+} from "./components/one_line_segments.js";
 import type { CustomEditor } from "./custom_editor.js";
 import type { SubagentPanelComponent } from "./subagent_panel.js";
 import type { Theme } from "./theme/index.js";
@@ -52,7 +55,7 @@ export class SubagentEditorPaneComponent implements Component {
     const border = this.theme.palette.editorSubagentBorder;
     const vertical = border("│");
     const pad = " ".repeat(Math.max(0, paddingX));
-    const truncated = truncateToWidth(line, contentWidth, "…");
+    const truncated = truncateFromEndByWidthPreserveAnsi(line, contentWidth);
     const padded = this.padToWidth(truncated, contentWidth);
     return `${vertical}${pad}${padded}${pad}${vertical}`;
   }

--- a/src/tui/ui/subagent_panel.ts
+++ b/src/tui/ui/subagent_panel.ts
@@ -1,5 +1,6 @@
-import { type Component, truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
+import { type Component, visibleWidth } from "@mariozechner/pi-tui";
 import type { SubagentStateSnapshot, SubagentUiEvent } from "../../core/subagents/types.js";
+import { truncateFromEndByWidthPreserveAnsi } from "./components/one_line_segments.js";
 import type { Theme } from "./theme/index.js";
 
 type SubagentPanelLine = {
@@ -270,7 +271,7 @@ export class SubagentPanelComponent implements Component {
   }
 
   private fitLine(line: string, width: number): string {
-    const truncated = truncateToWidth(line, width, "…");
+    const truncated = truncateFromEndByWidthPreserveAnsi(line, width);
     const pad = Math.max(0, width - visibleWidth(truncated));
     return `${truncated}${" ".repeat(pad)}`;
   }

--- a/test/ui_components.test.js
+++ b/test/ui_components.test.js
@@ -8,6 +8,7 @@ import { renderChatMessage } from "../dist/tui/ui/chat_message_model.js";
 import {
   OneLineSegmentsComponent,
   truncateFromEndByWidth,
+  truncateFromEndByWidthPreserveAnsi,
 } from "../dist/tui/ui/components/one_line_segments.js";
 import { CustomEditor } from "../dist/tui/ui/custom_editor.js";
 import { FooterComponent } from "../dist/tui/ui/footer.js";
@@ -212,6 +213,15 @@ test("truncateFromEndByWidth respects max width", () => {
   expect(truncateFromEndByWidth("hello", 1)).toBe("…");
   expect(truncateFromEndByWidth("hello", 4)).toBe("hel…");
   expect(truncateFromEndByWidth("hello", 5)).toBe("hello");
+});
+
+test("truncateFromEndByWidthPreserveAnsi keeps the ellipsis inside the active style", () => {
+  const red = `\x1b[31mhello world\x1b[0m`;
+  const truncated = truncateFromEndByWidthPreserveAnsi(red, 6);
+
+  expect(stripAnsi(truncated)).toBe("hello…");
+  expect(truncated).toContain("hello…\x1b[0m");
+  expect(truncated).not.toContain("\x1b[0m…");
 });
 
 test("CustomEditor clamps wrapped lines to the inner width", () => {


### PR DESCRIPTION
- keep the truncation ellipsis inside the active ANSI style span
- use the ANSI-aware truncation helper in subagent panel rendering and the editor path
- add a regression test for styled ellipsis truncation
