### PR TITLE
fail on unexpected codex usage windows

### DIFF
--- a/src/core/auth/providers/openai_codex.ts
+++ b/src/core/auth/providers/openai_codex.ts
@@ -15,6 +15,16 @@ const PROVIDER_ID = "openai-codex";
 const PROVIDER_LABEL = "OpenAI Codex";
 const USAGE_ENDPOINT = "https://chatgpt.com/backend-api/wham/usage";
 const FORCED_ACCOUNT_ENV = "TAU_CODEX_ACCOUNT";
+const ALLOWED_USAGE_WINDOW_SECONDS = new Set([5 * 60 * 60, 7 * 24 * 60 * 60]);
+
+class UnexpectedUsageWindowError extends Error {
+  constructor(name: "primary" | "secondary", windowSeconds: number) {
+    super(
+      `unexpected ChatGPT Codex ${name} usage window: ${windowSeconds} seconds ` +
+        "(expected 18000 for 5h or 604800 for 7d)",
+    );
+  }
+}
 
 type CodexAccount = StoredOAuthAccount;
 type UnknownRecord = Record<string, unknown>;
@@ -244,7 +254,10 @@ export class OpenAICodexAdapter implements AuthProviderAdapter {
         usage: refreshedUsage,
       }));
       return usage;
-    } catch {
+    } catch (error) {
+      if (error instanceof UnexpectedUsageWindowError) {
+        throw error;
+      }
       return usage;
     }
   }
@@ -420,11 +433,16 @@ function parseUsageWindow(
   const window = asRecord(value);
   if (!window) return undefined;
 
+  const windowSeconds = normalizeNumber(window.limit_window_seconds);
+  if (!ALLOWED_USAGE_WINDOW_SECONDS.has(windowSeconds)) {
+    throw new UnexpectedUsageWindowError(name, windowSeconds);
+  }
+
   return {
     name,
     usedPercent: clampPercent(window.used_percent),
     resetAt: normalizeNumber(window.reset_at),
-    windowSeconds: normalizeNumber(window.limit_window_seconds),
+    windowSeconds,
   };
 }
 

--- a/test/auth_storage.test.js
+++ b/test/auth_storage.test.js
@@ -174,7 +174,7 @@ describe("CredentialResolver", () => {
                           name: "primary",
                           usedPercent: 100,
                           resetAt: 4102444800,
-                          windowSeconds: 3600,
+                          windowSeconds: 18000,
                         },
                       ],
                     },
@@ -192,7 +192,7 @@ describe("CredentialResolver", () => {
                           name: "primary",
                           usedPercent: 100,
                           resetAt: 4102444800,
-                          windowSeconds: 3600,
+                          windowSeconds: 18000,
                         },
                       ],
                     },
@@ -249,7 +249,7 @@ describe("CredentialResolver", () => {
                 primary_window: {
                   used_percent: usedPercent,
                   reset_at: 4102444800,
-                  limit_window_seconds: 3600,
+                  limit_window_seconds: 18000,
                 },
               },
             }),
@@ -265,6 +265,73 @@ describe("CredentialResolver", () => {
 
       const apiKey = await resolver.getApiKey("openai-codex", { sessionId: "session-1" });
       expect(apiKey).toBe("api-next");
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("fails early when codex usage windows change unexpectedly", async () => {
+    const fx = createTempAuthPath();
+    try {
+      writeFileSync(
+        fx.authPath,
+        JSON.stringify(
+          {
+            providers: {
+              "openai-codex": {
+                accounts: [
+                  {
+                    type: "oauth",
+                    accountId: "acct-old",
+                    providerAccountId: "provider-old",
+                    access: "old-access",
+                    refresh: "old-refresh",
+                    expires: 0,
+                  },
+                ],
+              },
+            },
+          },
+          null,
+          2,
+        ),
+      );
+
+      getOAuthApiKey.mockResolvedValue({
+        apiKey: "new-access",
+        newCredentials: {
+          access: "old-access",
+          refresh: "old-refresh",
+          expires: 0,
+          accountId: "provider-old",
+        },
+      });
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => ({
+          ok: true,
+          json: async () => ({
+            rate_limit: {
+              primary_window: {
+                used_percent: 12,
+                reset_at: 4102444800,
+                limit_window_seconds: 3600,
+              },
+            },
+          }),
+        })),
+      );
+
+      const storage = new AuthStorage(fx.authPath);
+      const resolver = createCredentialResolver({
+        authStorage: storage,
+        getConfig: () => ({}),
+      });
+
+      await expect(resolver.getApiKey("openai-codex", { sessionId: "session-1" })).rejects.toThrow(
+        "unexpected ChatGPT Codex primary usage window: 3600 seconds (expected 18000 for 5h or 604800 for 7d)",
+      );
     } finally {
       fx.cleanup();
     }


### PR DESCRIPTION
- reject ChatGPT Codex usage windows unless they are the expected 5h or 7d values
- rethrow the unexpected-window error instead of silently falling back
- add coverage for the fail-fast behavior
