### PR TITLE
allow resizing thread reply textareas

### DIFF
--- a/src/diff_tool/app/src/components/thread_card.css
+++ b/src/diff_tool/app/src/components/thread_card.css
@@ -79,9 +79,9 @@
 }
 
 .thread-reply-input {
-  height: calc(1.5em * 3 + 0.75rem * 2);
+  min-height: calc(1.5em * 3 + 0.75rem * 2);
   padding: 0.75rem;
-  resize: none;
+  resize: vertical;
 }
 
 .thread-actions {


### PR DESCRIPTION
- allow resizing the inline reply textarea for existing diff comment threads
- keep the existing default composer height while letting users drag it taller
