### PR TITLE
toggle diff tool sidebar width

### DIFF
--- a/src/diff_tool/app/dev-server.js
+++ b/src/diff_tool/app/dev-server.js
@@ -275,6 +275,7 @@ const state = {
   diffStyle: "split",
   overflowMode: "wrap",
   sidebarOpen: false,
+  sidebarWidth: "narrow",
   collapsedFileIds: [],
   viewedFileIds: ["dev-session-001-0-0"],
   threads: mockThreads,
@@ -348,6 +349,9 @@ const server = createServer(async (req, res) => {
       }
       if (typeof body.sidebarOpen === "boolean") {
         state.sidebarOpen = body.sidebarOpen;
+      }
+      if (body.sidebarWidth === "narrow" || body.sidebarWidth === "wide") {
+        state.sidebarWidth = body.sidebarWidth;
       }
       if (Array.isArray(body.collapsedFileIds)) {
         state.collapsedFileIds = body.collapsedFileIds.filter(

--- a/src/diff_tool/app/src/App.css
+++ b/src/diff_tool/app/src/App.css
@@ -62,7 +62,9 @@
   --code-inline-bg: hsl(142 68% 56% / 0.07);
   --code-inline-text: hsl(142 74% 68%);
   --bar-height: 48px;
-  --sidebar-width: 300px;
+  --sidebar-width-narrow: 300px;
+  --sidebar-width-wide: 480px;
+  --sidebar-width: var(--sidebar-width-narrow);
   --content-padding-x: 12px;
   --file-gap: 1rem;
   --font-size-ui: 1rem;
@@ -107,6 +109,10 @@ textarea {
 
 .app {
   min-height: 100vh;
+}
+
+.app.sidebar-wide {
+  --sidebar-width: var(--sidebar-width-wide);
 }
 
 .content {

--- a/src/diff_tool/app/src/App.tsx
+++ b/src/diff_tool/app/src/App.tsx
@@ -551,7 +551,9 @@ export function App() {
 
   return (
     <>
-      <div className={`app${reviewState.sidebarOpen ? " sidebar-open" : ""}`}>
+      <div
+        className={`app${reviewState.sidebarOpen ? " sidebar-open" : ""}${reviewState.sidebarWidth === "wide" ? " sidebar-wide" : ""}`}
+      >
         <TopBar
           fileCount={files.length}
           viewedCount={reviewState.viewedFileIds.length}
@@ -586,6 +588,7 @@ export function App() {
         />
         <Sidebar
           open={reviewState.sidebarOpen}
+          widthMode={reviewState.sidebarWidth}
           files={files}
           viewed={viewed}
           detachedThreads={detachedThreads}
@@ -597,6 +600,12 @@ export function App() {
           onJumpToFile={scrollToFile}
           onCreateDetachedThread={openDetachedThreadDraft}
           onOpenDetachedThread={openDetachedThread}
+          onToggleWidth={() => {
+            applyStatePatch({
+              sidebarWidth:
+                reviewState.sidebarWidth === "wide" ? "narrow" : "wide",
+            });
+          }}
         />
         <main className="content">
           {files.length === 0 && (

--- a/src/diff_tool/app/src/components/sidebar.css
+++ b/src/diff_tool/app/src/components/sidebar.css
@@ -19,6 +19,41 @@
   transform: translateX(0);
 }
 
+.sidebar-width-toggle {
+  background: transparent;
+  border: none;
+  bottom: 0;
+  cursor: pointer;
+  padding: 0;
+  position: absolute;
+  right: -3px;
+  top: 0;
+  width: 5px;
+}
+
+.sidebar-width-toggle::before {
+  background: transparent;
+  bottom: 0;
+  content: "";
+  left: 2px;
+  position: absolute;
+  top: 0;
+  transition:
+    background-color 120ms ease,
+    box-shadow 120ms ease;
+  width: 1px;
+}
+
+.sidebar-width-toggle:hover::before,
+.sidebar-width-toggle:focus-visible::before {
+  background: var(--border-focus);
+  box-shadow: 0 0 0 1px hsl(0 0% 100% / 0.02);
+}
+
+.sidebar-width-toggle:focus-visible {
+  outline: none;
+}
+
 .sidebar-section {
   display: flex;
   flex-direction: column;

--- a/src/diff_tool/app/src/components/sidebar.tsx
+++ b/src/diff_tool/app/src/components/sidebar.tsx
@@ -7,11 +7,13 @@ import {
 } from "react";
 import type { CommentThread } from "../comments.js";
 import type { DiffFile } from "../parse_diff.js";
+import type { SidebarWidth } from "../types.js";
 import { DiffStats } from "./diff_stats.js";
 import "./sidebar.css";
 
 type SidebarProps = {
   open: boolean;
+  widthMode: SidebarWidth;
   files: DiffFile[];
   viewed: Record<string, boolean>;
   detachedThreads: CommentThread[];
@@ -19,10 +21,12 @@ type SidebarProps = {
   onJumpToFile: (fileId: string) => void;
   onCreateDetachedThread: () => void;
   onOpenDetachedThread: (threadId: string) => void;
+  onToggleWidth: () => void;
 };
 
 export function Sidebar({
   open,
+  widthMode,
   files,
   viewed,
   detachedThreads,
@@ -30,9 +34,20 @@ export function Sidebar({
   onJumpToFile,
   onCreateDetachedThread,
   onOpenDetachedThread,
+  onToggleWidth,
 }: SidebarProps) {
+  const widthLabel =
+    widthMode === "wide" ? "Use narrow sidebar" : "Use wide sidebar";
+
   return (
     <aside className={`sidebar${open ? " open" : ""}`}>
+      <button
+        type="button"
+        className="sidebar-width-toggle"
+        aria-label={widthLabel}
+        title={widthLabel}
+        onClick={onToggleWidth}
+      />
       <section className="sidebar-section">
         <div className="sidebar-section-header">
           <h2 className="sidebar-section-title">conversations</h2>

--- a/src/diff_tool/app/src/review_state_utils.ts
+++ b/src/diff_tool/app/src/review_state_utils.ts
@@ -10,6 +10,7 @@ export const emptyReviewState: DiffToolReviewState = {
   diffStyle: "split",
   overflowMode: "wrap",
   sidebarOpen: false,
+  sidebarWidth: "narrow",
   collapsedFileIds: [],
   viewedFileIds: [],
   threads: [],
@@ -26,6 +27,7 @@ export function normalizeReviewState(
     ...state,
     diffStyle: state.diffStyle === "split" ? "split" : "stacked",
     overflowMode: state.overflowMode === "scroll" ? "scroll" : "wrap",
+    sidebarWidth: state.sidebarWidth === "wide" ? "wide" : "narrow",
     threads: state.threads.map((thread) => ({
       ...thread,
       anchor:

--- a/src/diff_tool/app/src/types.ts
+++ b/src/diff_tool/app/src/types.ts
@@ -36,6 +36,7 @@ export type ThreadReplyPayload = DiffToolThreadReplyPayload;
 export type LineSide = DiffToolLineSide;
 export type DiffStyle = DiffToolReviewState["diffStyle"];
 export type OverflowMode = DiffToolReviewState["overflowMode"];
+export type SidebarWidth = DiffToolReviewState["sidebarWidth"];
 
 export type ResolveThreadPayload = {
   id: string;

--- a/src/diff_tool/http_server.ts
+++ b/src/diff_tool/http_server.ts
@@ -522,6 +522,9 @@ function parseStatePatch(payload: Record<string, unknown>): DiffToolStatePatch {
       ? { overflowMode: payload.overflowMode }
       : {}),
     ...(typeof payload.sidebarOpen === "boolean" ? { sidebarOpen: payload.sidebarOpen } : {}),
+    ...(payload.sidebarWidth === "narrow" || payload.sidebarWidth === "wide"
+      ? { sidebarWidth: payload.sidebarWidth }
+      : {}),
     ...(Array.isArray(payload.collapsedFileIds)
       ? {
           collapsedFileIds: payload.collapsedFileIds.flatMap((value) =>

--- a/src/diff_tool/review_state.ts
+++ b/src/diff_tool/review_state.ts
@@ -18,6 +18,7 @@ export class DiffToolReviewStateStore {
     diffStyle: "split",
     overflowMode: "wrap",
     sidebarOpen: false,
+    sidebarWidth: "narrow",
     collapsedFileIds: [],
     viewedFileIds: [],
     threads: [],
@@ -29,6 +30,7 @@ export class DiffToolReviewStateStore {
       diffStyle: this.state.diffStyle,
       overflowMode: this.state.overflowMode,
       sidebarOpen: this.state.sidebarOpen,
+      sidebarWidth: this.state.sidebarWidth,
       collapsedFileIds: [...this.state.collapsedFileIds],
       viewedFileIds: [...this.state.viewedFileIds],
       threads: this.state.threads.map(cloneThread),
@@ -47,6 +49,10 @@ export class DiffToolReviewStateStore {
 
     if (typeof patch.sidebarOpen === "boolean") {
       this.state.sidebarOpen = patch.sidebarOpen;
+    }
+
+    if (patch.sidebarWidth === "narrow" || patch.sidebarWidth === "wide") {
+      this.state.sidebarWidth = patch.sidebarWidth;
     }
 
     if (Array.isArray(patch.collapsedFileIds)) {

--- a/src/diff_tool/shared_types.ts
+++ b/src/diff_tool/shared_types.ts
@@ -47,6 +47,7 @@ export type DiffToolReviewState = {
   diffStyle: "stacked" | "split";
   overflowMode: "wrap" | "scroll";
   sidebarOpen: boolean;
+  sidebarWidth: "narrow" | "wide";
   collapsedFileIds: string[];
   viewedFileIds: string[];
   threads: DiffToolCommentThread[];
@@ -57,6 +58,7 @@ export type DiffToolStatePatch = {
   diffStyle?: DiffToolReviewState["diffStyle"];
   overflowMode?: DiffToolReviewState["overflowMode"];
   sidebarOpen?: boolean;
+  sidebarWidth?: DiffToolReviewState["sidebarWidth"];
   collapsedFileIds?: string[];
   viewedFileIds?: string[];
 };

--- a/test/diff_tool_builtin.test.js
+++ b/test/diff_tool_builtin.test.js
@@ -190,6 +190,7 @@ describe("built-in diff tool", () => {
         diffStyle: "split",
         overflowMode: "wrap",
         sidebarOpen: false,
+        sidebarWidth: "narrow",
         collapsedFileIds: [],
         viewedFileIds: [],
         threads: [],


### PR DESCRIPTION
- add a clickable sidebar border that toggles between narrow and wide modes
- persist the selected width in diff tool review state
- keep sidebar file path truncation responsive to the active width
