### PR TITLE
fix diff tool path and toolbar overflow

### DIFF
--- a/src/core/diff_review/snapshot.ts
+++ b/src/core/diff_review/snapshot.ts
@@ -90,7 +90,7 @@ export async function captureDiffReviewSnapshot(
   const captured =
     diffArgs.length > 0
       ? await captureExplicitDiffSnapshot(cwd, diffArgs, deps, signal)
-      : await captureWorkingTreeSnapshot(repoRoot, cwd, deps, signal);
+      : await captureWorkingTreeSnapshot(repoRoot, deps, signal);
 
   return new DiffReviewSnapshot({
     repoRoot,
@@ -163,15 +163,14 @@ async function captureExplicitDiffSnapshot(
 
 async function captureWorkingTreeSnapshot(
   repoRoot: string,
-  cwd: string,
   deps: Pick<CoreDeps, "spawn" | "env">,
   signal?: AbortSignal,
 ): Promise<CapturedSnapshotData> {
-  const hasHead = await gitRefExists(cwd, "HEAD", deps, signal);
+  const hasHead = await gitRefExists(repoRoot, "HEAD", deps, signal);
   const tracked = hasHead
-    ? await captureTrackedWorkingTreeSnapshot(cwd, deps, signal)
-    : await captureTrackedWorkingTreeSnapshotWithoutHead(cwd, deps, signal);
-  const untracked = await captureUntrackedFilePatches(repoRoot, cwd, deps, signal);
+    ? await captureTrackedWorkingTreeSnapshot(repoRoot, deps, signal)
+    : await captureTrackedWorkingTreeSnapshotWithoutHead(repoRoot, deps, signal);
+  const untracked = await captureUntrackedFilePatches(repoRoot, deps, signal);
   const patchByPath = new Map(tracked.patchByPath);
   for (const [path, patch] of untracked.patchByPath) {
     patchByPath.set(path, patch);
@@ -185,16 +184,16 @@ async function captureWorkingTreeSnapshot(
 }
 
 async function captureTrackedWorkingTreeSnapshot(
-  cwd: string,
+  repoRoot: string,
   deps: Pick<CoreDeps, "spawn" | "env">,
   signal?: AbortSignal,
 ): Promise<CapturedSnapshotData> {
-  const patch = await runGitCommand(cwd, ["diff", "HEAD"], deps, {}, signal);
+  const patch = await runGitCommand(repoRoot, ["diff", "HEAD"], deps, {}, signal);
   const files = parseNameStatusOutput(
-    await runGitCommand(cwd, ["diff", "--name-status", "-z", "HEAD"], deps, {}, signal),
+    await runGitCommand(repoRoot, ["diff", "--name-status", "-z", "HEAD"], deps, {}, signal),
   );
   const patchSections = splitPatchSections(
-    await runGitCommand(cwd, ["diff", "HEAD", "--patch"], deps, {}, signal),
+    await runGitCommand(repoRoot, ["diff", "HEAD", "--patch"], deps, {}, signal),
   );
 
   return {
@@ -205,18 +204,24 @@ async function captureTrackedWorkingTreeSnapshot(
 }
 
 async function captureTrackedWorkingTreeSnapshotWithoutHead(
-  cwd: string,
+  repoRoot: string,
   deps: Pick<CoreDeps, "spawn" | "env">,
   signal?: AbortSignal,
 ): Promise<CapturedSnapshotData> {
-  const unstagedPatch = await runGitCommand(cwd, ["diff"], deps, {}, signal);
-  const stagedPatch = await runGitCommand(cwd, ["diff", "--cached", "--root"], deps, {}, signal);
+  const unstagedPatch = await runGitCommand(repoRoot, ["diff"], deps, {}, signal);
+  const stagedPatch = await runGitCommand(
+    repoRoot,
+    ["diff", "--cached", "--root"],
+    deps,
+    {},
+    signal,
+  );
   const unstagedFiles = parseNameStatusOutput(
-    await runGitCommand(cwd, ["diff", "--name-status", "-z"], deps, {}, signal),
+    await runGitCommand(repoRoot, ["diff", "--name-status", "-z"], deps, {}, signal),
   );
   const stagedFiles = parseNameStatusOutput(
     await runGitCommand(
-      cwd,
+      repoRoot,
       ["diff", "--cached", "--name-status", "-z", "--root"],
       deps,
       {},
@@ -235,7 +240,6 @@ async function captureTrackedWorkingTreeSnapshotWithoutHead(
 
 async function captureUntrackedFilePatches(
   repoRoot: string,
-  cwd: string,
   deps: Pick<CoreDeps, "spawn" | "env">,
   signal?: AbortSignal,
 ): Promise<{
@@ -245,7 +249,7 @@ async function captureUntrackedFilePatches(
 }> {
   const paths = parseNullSeparatedPaths(
     await runGitCommand(
-      cwd,
+      repoRoot,
       ["ls-files", "--others", "--exclude-standard", "-z"],
       deps,
       {},
@@ -257,7 +261,7 @@ async function captureUntrackedFilePatches(
   const patchByPath = new Map<string, string>();
 
   for (const path of paths) {
-    const filePath = resolveSnapshotFilePath(repoRoot, cwd, path);
+    const filePath = resolve(repoRoot, path);
     if (!existsSync(filePath)) {
       continue;
     }
@@ -282,14 +286,6 @@ async function captureUntrackedFilePatches(
     patches,
     patchByPath,
   };
-}
-
-function resolveSnapshotFilePath(repoRoot: string, cwd: string, path: string): string {
-  const fromCwd = resolve(cwd, path);
-  if (existsSync(fromCwd)) {
-    return fromCwd;
-  }
-  return resolve(repoRoot, path);
 }
 
 function createUntrackedFilePatch(path: string, content: string): string {

--- a/src/diff_tool/app/src/components/top_bar.css
+++ b/src/diff_tool/app/src/components/top_bar.css
@@ -20,7 +20,9 @@
 }
 
 .top-bar-left {
+  flex: 1 1 auto;
   gap: 12px;
+  overflow: hidden;
 }
 
 .top-bar-meta {
@@ -53,10 +55,14 @@
   align-items: center;
   gap: 8px;
   min-width: 0;
+  overflow: hidden;
   font-size: var(--font-size-sm);
 }
 
 .top-bar-diff-command {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
   opacity: 0.4;
 }

--- a/src/diff_tool/app/src/components/top_bar.tsx
+++ b/src/diff_tool/app/src/components/top_bar.tsx
@@ -98,7 +98,10 @@ export function TopBar({
         >
           <DiffStats additions={additions} deletions={deletions} />
           {diffCommand && (
-            <span className="top-bar-meta top-bar-meta-dim top-bar-diff-command">
+            <span
+              className="top-bar-meta top-bar-meta-dim top-bar-diff-command"
+              title={diffCommand}
+            >
               {diffCommand}
             </span>
           )}

--- a/test/diff_review_snapshot.test.js
+++ b/test/diff_review_snapshot.test.js
@@ -22,6 +22,7 @@ function runGit(cwd, args) {
 function createRepoFixture() {
   const repo = mkdtempSync(join(tmpdir(), "tau-diff-review-"));
   mkdirSync(join(repo, "src"), { recursive: true });
+  mkdirSync(join(repo, "packages", "app"), { recursive: true });
   writeFileSync(join(repo, "src", "foo.ts"), "export const value = 1;\n", "utf-8");
   writeFileSync(join(repo, "src", "bar.ts"), "export const removed = true;\n", "utf-8");
   writeFileSync(join(repo, "src", "baz.ts"), "export const draft = false;\n", "utf-8");
@@ -136,6 +137,29 @@ describe("diff_review snapshot", () => {
       expect(snapshot.getFilePatch("src/baz.ts")).toContain("+export const draft = true;");
       expect(snapshot.getFilePatch("src/qux.ts")).toContain("new file mode 100644");
       expect(snapshot.getFilePatch("src/qux.ts")).toContain("+export const untracked = true;");
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("keeps plain /diff file paths repo-root relative when launched from a subdirectory", async () => {
+    const fx = createRepoFixture();
+
+    try {
+      const snapshot = await captureDiffReviewSnapshot({
+        cwd: join(fx.repo, "packages", "app"),
+      });
+
+      expect(snapshot.cwd).toBe(join(fx.repo, "packages", "app"));
+      expect(snapshot.files.map((file) => file.path)).toEqual([
+        "src/bar.ts",
+        "src/baz.ts",
+        "src/foo.ts",
+        "src/qux.ts",
+      ]);
+      expect(snapshot.patch).toContain("diff --git a/src/foo.ts b/src/foo.ts");
+      expect(snapshot.patch).not.toContain("diff --git a/../");
+      expect(snapshot.getFilePatch("src/qux.ts")).toContain("+++ b/src/qux.ts");
     } finally {
       fx.cleanup();
     }


### PR DESCRIPTION
- truncate long diff commands in the built-in diff tool top bar without breaking the layout
- capture plain /diff working-tree snapshots from the repo root so file paths stay consistently repo-root relative even when launched from a subdirectory
- add a regression test for subdirectory-launched plain /diff snapshots

fixes #196
