### PR TITLE
split long telegram replies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,8 @@ Tau is pre-v1 and the priority is to reach a clean, stable v1 design. Prefer exp
   - `commands/registry.ts` - Slash command parsing and dispatch
   - `cli.ts` - CLI argument parsing and help text
   - `async/` - Async daemon/client modules (`cli.ts`, `cron.ts`, `http_protocol.ts`, `http_server.ts`, `server_config.ts`, `session_manager.ts`, `telegram.ts`, `workspace.ts`)
-    - `telegram.ts` handles DM commands, voice/audio transcription, and immediate attachment materialization/queueing for text/voice-triggered turns
+
+    - `telegram.ts` handles DM commands, voice/audio transcription, immediate attachment materialization/queueing for text/voice-triggered turns, and splits oversized Telegram replies into 95%-of-limit chunks sent 1 second apart
   - `debug.ts` - `--debug` output
   - `config/deps.ts` - Config loader dependencies
   - `config/paths.ts` - Config level discovery

--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ for daemon/API/Telegram details, see [docs/async.md](docs/async.md).
 
 daemon config uses a bot-id map (`telegram.<botId>.botToken`), with optional per-bot `allowedProjectIds` scoping. Telegram sessions are chat-scoped per bot (no cross-chat or cross-bot session sharing).
 
-Telegram DM input supports plain text, voice/audio transcription, and attachment queueing (`image/*`, PDF, `.txt`, `.md`, `.json`, `.csv`, `.yaml`, `.yml`). attachment-only messages do not trigger turns, attachments are downloaded to local temp files immediately, and queued attachments are prepended to the next text/voice turn as local temp file metadata.
+
+Telegram DM input supports plain text, voice/audio transcription, and attachment queueing (`image/*`, PDF, `.txt`, `.md`, `.json`, `.csv`, `.yaml`, `.yml`). attachment-only messages do not trigger turns, attachments are downloaded to local temp files immediately, queued attachments are prepended to the next text/voice turn as local temp file metadata, and oversized Telegram replies are split into 95%-of-limit chunks sent 1 second apart.
 
 daemon config also supports `systemMessage`, `cron.jobsDir`, and `cron.systemMessage` for scheduled runs, plus per-project `workingDirectory` (for monorepos), `description` (used by Telegram `/projects`), `bootstrapCommands` (blocking), and `backgroundBootstrapCommands` (non-blocking). on startup, the daemon wipes existing entries under configured async workspace roots. on Telegram adapter startup, tau also prunes stale `tau-telegram-attachments-*` directories under the system temp directory. Telegram `/close` deletes session workspaces from disk when closing sessions.
 

--- a/docs/async.md
+++ b/docs/async.md
@@ -205,6 +205,8 @@ Supported DM commands:
 - `/close all` (closes sessions in `waiting-input` or `failed`, and deletes their workspaces)
 - `/verbose` (for the selected session, streams run lifecycle + progress updates)
 - `/quiet` (for the selected session, default mode, send only the run's final assistant message)
+
+  - oversized Telegram replies are split into 95%-of-limit chunks (3891 bytes) and sent 1 second apart
 - plain text sends to the selected session (if no active session is selected and exactly one session exists, it is auto-selected)
 - Telegram `voice` and `audio` messages are downloaded, transcribed with Mistral, and then sent to the selected session
 - attachments (`image/*`, PDF, `.txt`, `.md`, `.json`, `.csv`, `.yaml`, `.yml`) are downloaded to local temp files immediately, queued per session, and prepended to the next text/voice turn as local temp paths with mime, size, and caption metadata

--- a/src/core/async/telegram.ts
+++ b/src/core/async/telegram.ts
@@ -180,6 +180,13 @@ const DEFAULT_TELEGRAM_PHOTO_MIME_TYPE = "image/jpeg";
 const DEFAULT_TELEGRAM_DOCUMENT_MIME_TYPE = "application/octet-stream";
 const MESSAGE_QUEUED_REACTION_EMOJI = "👀";
 const MESSAGE_QUEUED_REACTION_DELAY_MS = 1000;
+const TELEGRAM_MAX_MESSAGE_BYTES = 4096;
+
+const TELEGRAM_MESSAGE_BYTE_BUFFER_RATIO = 0.95;
+const TELEGRAM_SAFE_MESSAGE_BYTES = Math.floor(
+  TELEGRAM_MAX_MESSAGE_BYTES * TELEGRAM_MESSAGE_BYTE_BUFFER_RATIO,
+);
+const TELEGRAM_MESSAGE_SPLIT_DELAY_MS = 1000;
 const ABORTED = Symbol("aborted");
 const CALLBACK_ACTION_PREFIX = "tau:action:";
 const CALLBACK_USE_PREFIX = "tau:use:";
@@ -312,6 +319,38 @@ function truncateText(text: string, maxChars: number): string {
   }
 
   return `${trimmed.slice(0, maxChars - 1)}…`;
+}
+
+function splitTelegramMessage(text: string): string[] {
+
+  if (Buffer.byteLength(text, "utf8") <= TELEGRAM_SAFE_MESSAGE_BYTES) {
+    return [text];
+  }
+
+  const chunks: string[] = [];
+  let currentChunk = "";
+
+  for (const character of text) {
+    const nextChunk = `${currentChunk}${character}`;
+    if (Buffer.byteLength(nextChunk, "utf8") <= TELEGRAM_SAFE_MESSAGE_BYTES) {
+      currentChunk = nextChunk;
+      continue;
+    }
+
+    if (currentChunk) {
+      chunks.push(currentChunk);
+      currentChunk = character;
+      continue;
+    }
+
+    chunks.push(character);
+  }
+
+  if (currentChunk) {
+    chunks.push(currentChunk);
+  }
+
+  return chunks;
 }
 
 function normalizeSizeBytes(value: number | undefined): number | undefined {
@@ -2304,13 +2343,24 @@ class AsyncTelegramAdapterImpl {
       replyMarkup?: TelegramInlineKeyboardMarkup;
     },
   ): Promise<void> {
-    try {
-      await this.api.sendMessage(chatId, text, options);
-    } catch (error) {
-      this.log("warn", "failed to send telegram message", {
-        chatId,
-        cause: error instanceof Error ? error.message : String(error),
-      });
+    const chunks = splitTelegramMessage(text);
+
+    for (const [index, chunk] of chunks.entries()) {
+      try {
+        await this.api.sendMessage(chatId, chunk, {
+          replyMarkup: index === chunks.length - 1 ? options?.replyMarkup : undefined,
+        });
+      } catch (error) {
+        this.log("warn", "failed to send telegram message", {
+          chatId,
+          cause: error instanceof Error ? error.message : String(error),
+        });
+        return;
+      }
+
+      if (index < chunks.length - 1) {
+        await this.wait(TELEGRAM_MESSAGE_SPLIT_DELAY_MS);
+      }
     }
   }
 

--- a/test/async_telegram.test.js
+++ b/test/async_telegram.test.js
@@ -56,7 +56,7 @@ function createApiHarness(updateBatches) {
       return await new Promise(() => {});
     }),
     sendMessage: vi.fn(async (chatId, text, options) => {
-      sendMessages.push({ chatId, text, options });
+      sendMessages.push({ chatId, text, options, sentAt: Date.now() });
     }),
     downloadFile: vi.fn(async (fileId) => {
       downloadFileCalls.push(fileId);
@@ -708,6 +708,96 @@ describe("async telegram adapter", () => {
       expect(
         apiHarness.sendMessages.some((entry) => entry.text.includes("(s12) assistant message")),
       ).toBe(false);
+    } finally {
+      await adapter.close();
+    }
+  });
+
+  it("splits oversized quiet-mode replies into multiple telegram messages", async () => {
+    const apiHarness = createApiHarness([
+      [
+        {
+          update_id: 1,
+          message: {
+            chat: { id: 471, type: "private" },
+            from: { id: 7 },
+            text: "/use s13",
+          },
+        },
+      ],
+    ]);
+
+    const managerHarness = createSessionManagerHarness(
+      [
+        {
+          id: "s13",
+          projectId: "demo",
+          state: "waiting-input",
+          createdAt: "2024-01-01T00:00:00.000Z",
+          updatedAt: "2024-01-01T00:00:00.000Z",
+        },
+      ],
+      { defaultOwnerId: ownerIdForChat(471) },
+    );
+
+    const adapter = await startAdapter({
+      botToken: "token",
+      projects: { demo: { repo: "git@example.com:demo.git" } },
+      sessionManager: managerHarness.manager,
+      api: apiHarness.api,
+      pollIntervalMs: 1,
+      requestTimeoutSeconds: 1,
+    });
+
+    const finalAnswer = "🙂".repeat(1500);
+
+    try {
+      await waitFor(() => apiHarness.sendMessages.length >= 1);
+
+      managerHarness.manager.emit({
+        type: "session-state-changed",
+        sessionId: "s13",
+        projectId: "demo",
+        previousState: "waiting-input",
+        state: "running",
+        updatedAt: "2024-01-01T00:01:00.000Z",
+      });
+
+      managerHarness.manager.emit({
+        type: "session-progress",
+        sessionId: "s13",
+        projectId: "demo",
+        state: "running",
+        timestamp: "2024-01-01T00:02:00.000Z",
+        progress: {
+          type: "assistant-message",
+          text: finalAnswer,
+        },
+      });
+
+      managerHarness.manager.emit({
+        type: "session-state-changed",
+        sessionId: "s13",
+        projectId: "demo",
+        previousState: "running",
+        state: "waiting-input",
+        updatedAt: "2024-01-01T00:03:00.000Z",
+      });
+
+      await waitFor(
+        () =>
+          apiHarness.sendMessages.filter((entry) => String(entry.text).startsWith("🙂")).length ===
+          2,
+        4000,
+      );
+
+      const chunks = apiHarness.sendMessages.filter((entry) => String(entry.text).startsWith("🙂"));
+      expect(chunks.map((entry) => entry.text).join("")).toBe(finalAnswer);
+      for (const chunk of chunks) {
+
+        expect(Buffer.byteLength(chunk.text, "utf8")).toBeLessThanOrEqual(3891);
+      }
+      expect(chunks[1].sentAt - chunks[0].sentAt).toBeGreaterThanOrEqual(900);
     } finally {
       await adapter.close();
     }


### PR DESCRIPTION
- split oversized Telegram adapter replies into 4096-byte chunks
- send follow-up chunks 1 second apart to avoid Telegram send failures
- add a regression test for oversized quiet-mode assistant replies
