### PR TITLE
cap view_image at 2000px

### DIFF
--- a/src/core/tools/view_image.ts
+++ b/src/core/tools/view_image.ts
@@ -20,9 +20,9 @@ const VIEW_IMAGE_PATH_DESCRIPTION = "Path to the image file to view.";
 
 const VIEW_IMAGE_READ_MAX_BYTES = 50 * 1024 * 1024;
 const VIEW_IMAGE_MODEL_MAX_BYTES = 2.5 * 1024 * 1024;
-const VIEW_IMAGE_MAX_DIMENSION_PX = 2048;
+const VIEW_IMAGE_MAX_DIMENSION_PX = 2000;
 const VIEW_IMAGE_DIMENSION_STEPS = [
-  2048, 1920, 1792, 1664, 1536, 1408, 1280, 1152, 1024, 896, 768, 640, 512,
+  2000, 1920, 1792, 1664, 1536, 1408, 1280, 1152, 1024, 896, 768, 640, 512,
 ] as const;
 const VIEW_IMAGE_LOSSY_QUALITY_STEPS = [95, 90, 85, 80, 75] as const;
 const SUPPORTED_IMAGE_TYPES = ["image/jpeg", "image/png", "image/webp"] as const;

--- a/test/view_image_tool.test.js
+++ b/test/view_image_tool.test.js
@@ -69,7 +69,7 @@ function getImageBlock(content) {
 }
 
 describe("view_image tool", () => {
-  it("downscales images to fit inside a 2048x2048 square", async () => {
+  it("downscales images to fit inside a 2000x2000 square", async () => {
     const fx = setupFixture();
 
     try {
@@ -103,8 +103,8 @@ describe("view_image tool", () => {
       const imageBlock = getImageBlock(result.toolResult.content);
       const outputBuffer = Buffer.from(imageBlock.data, "base64");
       const outputMetadata = await sharp(outputBuffer).metadata();
-      expect(outputMetadata.width).toBe(2048);
-      expect(outputMetadata.height).toBe(1536);
+      expect(outputMetadata.width).toBe(2000);
+      expect(outputMetadata.height).toBe(1500);
     } finally {
       fx.cleanup();
     }
@@ -186,7 +186,7 @@ describe("view_image tool", () => {
       expect(result.uiEvent.bytes).toBe(outputBuffer.byteLength);
       expect(result.uiEvent.mimeType).toBe(imageBlock.mimeType);
       expect(Math.max(outputMetadata.width ?? 0, outputMetadata.height ?? 0)).toBeLessThanOrEqual(
-        2048,
+        2000,
       );
       expect(getTextBlock(result.toolResult.content)).toBe(
         `Viewed ${filePath} (${result.uiEvent.mimeType})`,


### PR DESCRIPTION
- lower the view_image max dimension from 2048px to 2000px to stay within Anthropic's many-image limit
- update the view_image regression tests to match the new cap

fixes #188
