### PR TITLE
avoid diff tool comment rerenders

### DIFF
--- a/src/diff_tool/app/src/App.tsx
+++ b/src/diff_tool/app/src/App.tsx
@@ -302,43 +302,42 @@ export function App() {
         ) {
           return prev;
         }
-        return { fileId, lineNumber, side, body: "" };
+        return { fileId, lineNumber, side };
       });
     },
     [],
   );
 
-  const updateDraft = useCallback((body: string) => {
-    setDraft((prev) => (prev ? { ...prev, body } : prev));
-  }, []);
+  const saveDraft = useCallback(
+    (body: string) => {
+      if (!draft) {
+        return;
+      }
 
-  const saveDraft = useCallback(() => {
-    if (!draft) {
-      return;
-    }
-
-    const body = draft.body.trim();
-    if (!body) {
-      setDraft(null);
-      return;
-    }
-
-    void syncState(
-      createThread({
-        body,
-        anchor: {
-          kind: "line",
-          fileId: draft.fileId,
-          filePath: resolveDraftFilePath(draft, files),
-          lineNumber: draft.lineNumber,
-          side: draft.side,
-        },
-      }).then((result) => {
+      const trimmedBody = body.trim();
+      if (!trimmedBody) {
         setDraft(null);
-        return result;
-      }),
-    );
-  }, [draft, files, syncState]);
+        return;
+      }
+
+      void syncState(
+        createThread({
+          body: trimmedBody,
+          anchor: {
+            kind: "line",
+            fileId: draft.fileId,
+            filePath: resolveDraftFilePath(draft, files),
+            lineNumber: draft.lineNumber,
+            side: draft.side,
+          },
+        }).then((result) => {
+          setDraft(null);
+          return result;
+        }),
+      );
+    },
+    [draft, files, syncState],
+  );
 
   const cancelDraft = useCallback(() => setDraft(null), []);
 
@@ -636,7 +635,6 @@ export function App() {
                 onToggleCollapsed={toggleCollapsed}
                 onToggleViewed={toggleViewed}
                 onLineActivate={activateLine}
-                onDraftChange={updateDraft}
                 onSaveDraft={saveDraft}
                 onCancelDraft={cancelDraft}
                 onAddReply={addReply}

--- a/src/diff_tool/app/src/comments.ts
+++ b/src/diff_tool/app/src/comments.ts
@@ -14,7 +14,6 @@ export type CommentDraft = {
   fileId: string;
   lineNumber: number;
   side: LineSide;
-  body: string;
 };
 
 export type CommentAnnotation =

--- a/src/diff_tool/app/src/components/comment_editor.tsx
+++ b/src/diff_tool/app/src/components/comment_editor.tsx
@@ -2,15 +2,11 @@ import { memo, useEffect, useRef } from "react";
 import "./comment_editor.css";
 
 type CommentEditorProps = {
-  body: string;
-  onChange: (body: string) => void;
-  onSave: () => void;
+  onSave: (body: string) => void;
   onCancel: () => void;
 };
 
 export const CommentEditor = memo(function CommentEditor({
-  body,
-  onChange,
   onSave,
   onCancel,
 }: CommentEditorProps) {
@@ -20,10 +16,15 @@ export const CommentEditor = memo(function CommentEditor({
     ref.current?.focus();
   }, []);
 
+  const submit = () => {
+    const body = ref.current?.value ?? "";
+    onSave(body);
+  };
+
   const handleKeyDown = (event: React.KeyboardEvent) => {
     if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
       event.preventDefault();
-      onSave();
+      submit();
     }
     if (event.key === "Escape") {
       event.preventDefault();
@@ -36,8 +37,6 @@ export const CommentEditor = memo(function CommentEditor({
       <textarea
         ref={ref}
         className="text-input-area comment-input"
-        value={body}
-        onChange={(event) => onChange(event.target.value)}
         onKeyDown={handleKeyDown}
         placeholder="Add a comment…"
         rows={2}
@@ -46,7 +45,7 @@ export const CommentEditor = memo(function CommentEditor({
         <button type="button" className="btn ghost" onClick={onCancel}>
           cancel
         </button>
-        <button type="button" className="btn primary" onClick={onSave}>
+        <button type="button" className="btn primary" onClick={submit}>
           comment
         </button>
       </div>

--- a/src/diff_tool/app/src/components/file_section.tsx
+++ b/src/diff_tool/app/src/components/file_section.tsx
@@ -43,8 +43,7 @@ type FileSectionProps = {
   onToggleCollapsed: (id: string) => void;
   onToggleViewed: (id: string) => void;
   onLineActivate: (fileId: string, lineNumber: number, side: LineSide) => void;
-  onDraftChange: (body: string) => void;
-  onSaveDraft: () => void;
+  onSaveDraft: (body: string) => void;
   onCancelDraft: () => void;
   onAddReply: (threadId: string, text: string) => void;
   onRequestAgent: (threadId: string) => void;
@@ -63,7 +62,6 @@ export const FileSection = memo(function FileSection({
   onToggleCollapsed,
   onToggleViewed,
   onLineActivate,
-  onDraftChange,
   onSaveDraft,
   onCancelDraft,
   onAddReply,
@@ -95,14 +93,7 @@ export const FileSection = memo(function FileSection({
   const renderAnnotation = useCallback(
     (annotation: LineAnnotation) => {
       if (annotation.metadata.type === "draft") {
-        return (
-          <CommentEditor
-            body={annotation.metadata.draft.body}
-            onChange={onDraftChange}
-            onSave={onSaveDraft}
-            onCancel={onCancelDraft}
-          />
-        );
+        return <CommentEditor onSave={onSaveDraft} onCancel={onCancelDraft} />;
       }
 
       const { thread } = annotation.metadata;
@@ -121,7 +112,6 @@ export const FileSection = memo(function FileSection({
     [
       onAddReply,
       onCancelDraft,
-      onDraftChange,
       onRequestAgent,
       onSaveDraft,
       onToggleResolved,

--- a/src/diff_tool/app/src/components/thread_card.tsx
+++ b/src/diff_tool/app/src/components/thread_card.tsx
@@ -20,7 +20,7 @@ export const ThreadCard = memo(function ThreadCard({
   onToggleCollapsed,
 }: ThreadCardProps) {
   const [isReplying, setIsReplying] = useState(false);
-  const [replyBody, setReplyBody] = useState("");
+  const [hasReplyText, setHasReplyText] = useState(false);
   const replyInputRef = useRef<HTMLTextAreaElement>(null);
   const lastMessage = thread.messages[thread.messages.length - 1];
   const canAsk =
@@ -37,14 +37,17 @@ export const ThreadCard = memo(function ThreadCard({
   }, [isReplying]);
 
   const handleAddReply = useCallback(() => {
-    const text = replyBody.trim();
+    const text = replyInputRef.current?.value.trim() ?? "";
     if (!text) {
       return;
     }
-    setReplyBody("");
+    if (replyInputRef.current) {
+      replyInputRef.current.value = "";
+    }
+    setHasReplyText(false);
     setIsReplying(false);
     onAddReply(text);
-  }, [onAddReply, replyBody]);
+  }, [onAddReply]);
 
   const handleReplyKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
@@ -61,7 +64,10 @@ export const ThreadCard = memo(function ThreadCard({
   }, [onToggleResolved, thread.resolved]);
 
   const handleCancelReply = useCallback(() => {
-    setReplyBody("");
+    if (replyInputRef.current) {
+      replyInputRef.current.value = "";
+    }
+    setHasReplyText(false);
     setIsReplying(false);
   }, []);
 
@@ -148,8 +154,12 @@ export const ThreadCard = memo(function ThreadCard({
             <textarea
               ref={replyInputRef}
               className="text-input-area thread-reply-input"
-              value={replyBody}
-              onChange={(event) => setReplyBody(event.target.value)}
+              onChange={(event) => {
+                const nextHasReplyText = event.target.value.trim().length > 0;
+                setHasReplyText((prev) =>
+                  prev === nextHasReplyText ? prev : nextHasReplyText,
+                );
+              }}
               onKeyDown={handleReplyKeyDown}
               placeholder="Reply…"
               rows={3}
@@ -165,7 +175,7 @@ export const ThreadCard = memo(function ThreadCard({
               <button
                 type="button"
                 className="btn primary"
-                disabled={!replyBody.trim()}
+                disabled={!hasReplyText}
                 onClick={handleAddReply}
               >
                 comment


### PR DESCRIPTION
- keep line comment drafts out of app state so typing does not rerender the annotated file diff on every keystroke
- make inline thread replies use uncontrolled textareas so reply typing does not trigger repeated React renders inside large diffs
- verified with `npm run check`, `npm run build`, and `npm test`
