### PR TITLE
add compaction metadata

### DIFF
--- a/src/core/diff_review/review_thread.ts
+++ b/src/core/diff_review/review_thread.ts
@@ -188,7 +188,7 @@ export class DiffReviewThread implements DiffReviewThreadSession {
 
   createForkSource(): DiffReviewThreadForkSource {
     return {
-      historyEntries: this.session.historyEntries.map((entry) => ({
+      historyEntries: this.session.rawHistoryEntries.map((entry) => ({
         id: entry.id,
         message: structuredClone(entry.message),
       })),

--- a/src/core/session/compaction.ts
+++ b/src/core/session/compaction.ts
@@ -1,10 +1,7 @@
 import type { AssistantMessage, Message } from "@mariozechner/pi-ai";
-import {
-  buildCompactionUserMessage,
-  formatHistoryForCompaction,
-  partitionHistoryForCompaction,
-} from "../utils/compact.js";
+import { buildCompactionUserMessage, formatHistoryForCompaction } from "../utils/compact.js";
 import { extractAssistantText } from "../utils/messages.js";
+import { getCompactionMetadataFromMessage } from "../utils/user_metadata.js";
 
 export type SessionCompactionMode = "only-summary" | "with-last-assistant";
 
@@ -107,17 +104,29 @@ Rules:
 export function prepareSessionCompaction(
   history: readonly Message[],
 ): SessionCompactionPreparation | undefined {
-  const { previousSummary, messagesToSummarize } = partitionHistoryForCompaction(history);
+  const latestCompaction = findLatestCompaction(history);
+  const messagesToSummarize = history.slice(latestCompaction.index + 1);
   const formattedHistory = formatHistoryForCompaction(messagesToSummarize);
   if (!formattedHistory) {
     return undefined;
   }
 
   return {
-    previousSummary,
+    previousSummary: latestCompaction.summary,
     messagesToSummarize,
     formattedHistory,
   };
+}
+
+function findLatestCompaction(history: readonly Message[]): { index: number; summary?: string } {
+  for (let index = history.length - 1; index >= 0; index -= 1) {
+    const metadata = getCompactionMetadataFromMessage(history[index]!);
+    if (metadata) {
+      return { index, summary: metadata.summary };
+    }
+  }
+
+  return { index: -1 };
 }
 
 export function buildSessionCompactionPrompt(args: {

--- a/src/core/session/compaction.ts
+++ b/src/core/session/compaction.ts
@@ -17,9 +17,9 @@ export type SessionCompactionMessageResult = {
 };
 
 export const COMPACTION_SUMMARIZATION_SYSTEM_PROMPT =
-  "You are a context summarization assistant. Do not continue the conversation. Do not answer any conversation questions. Only output the structured summary in the exact format requested.";
+  "You are a context compaction assistant. Your output will replace the conversation history for another assistant. Do not continue the conversation. Do not answer any conversation questions. Only output the structured summary in the exact format requested.";
 
-const COMPACTION_SUMMARIZATION_PROMPT = `The messages above are a conversation to summarize. Create a structured context checkpoint summary that another assistant will use to continue the work.
+const COMPACTION_SUMMARIZATION_PROMPT = `The messages above are a conversation to compact. Create an information-dense context checkpoint summary that will replace the full conversation history. Another assistant should be able to continue the session from this summary as if the original conversation were still available.
 
 Use this exact format:
 
@@ -47,24 +47,26 @@ Use this exact format:
 1. [Ordered next action]
 
 ## Critical Context
-- [Concrete details needed to resume: file paths, function names, commands, errors]
+- [Concrete details needed to resume: file paths, function names, commands, errors, test/build status, assumptions]
 
 Rules:
-- Preserve enough detail for seamless continuation from this summary alone.
-- Keep each section concise and focused on continuity-critical information.
+- Preserve as much continuity-critical context as possible while removing tokens.
+- Keep each section information-dense and focused; do not omit useful details solely for brevity.
+- When unsure whether a detail may matter later, preserve it in compact form.
+- Preserve the current state of the work: files touched, commands run, test/build status, known failures, unverified assumptions, and pending validation.
 - Distinguish attempted work from confirmed outcomes.
 - If goals evolved over time, capture the current goal and briefly note the change.
 - Collapse tangents, retries, and pleasantries unless they materially affect decisions, blockers, or next steps.
 - Preserve exact file paths, function names, commands, and error messages.`;
 
-const COMPACTION_UPDATE_SUMMARIZATION_PROMPT = `The messages above are new conversation messages to incorporate into the existing summary in <previous-summary> tags.
+const COMPACTION_UPDATE_SUMMARIZATION_PROMPT = `The messages above are new conversation messages to incorporate into the existing summary in <previous-summary> tags. The updated summary will replace the prior summary plus these new messages as the session's continuity context.
 
 Update the existing structured summary with these rules:
 - Preserve all still-relevant information from the previous summary.
 - Add new progress, decisions, and context from the new messages.
 - Move items from In Progress to Done when completed.
 - Update Next Steps based on the current state.
-- Remove information that is no longer relevant.
+- Remove only information that is clearly obsolete, superseded, or irrelevant to continuing the session.
 
 Use the exact same format as before:
 
@@ -91,11 +93,13 @@ Use the exact same format as before:
 1. [Updated ordered actions]
 
 ## Critical Context
-- [Concrete details needed to resume: file paths, function names, commands, errors]
+- [Concrete details needed to resume: file paths, function names, commands, errors, test/build status, assumptions]
 
 Rules:
-- Preserve enough detail for seamless continuation from this summary alone.
-- Keep each section concise and focused on continuity-critical information.
+- Preserve as much continuity-critical context as possible while removing tokens.
+- Keep each section information-dense and focused; do not omit useful details solely for brevity.
+- When unsure whether a detail may matter later, preserve it in compact form.
+- Preserve the current state of the work: files touched, commands run, test/build status, known failures, unverified assumptions, and pending validation.
 - Distinguish attempted work from confirmed outcomes.
 - If goals evolved over time, capture the current goal and briefly note the change.
 - Collapse tangents, retries, and pleasantries unless they materially affect decisions, blockers, or next steps.

--- a/src/core/session/core_session.ts
+++ b/src/core/session/core_session.ts
@@ -107,6 +107,10 @@ export class CoreSession {
     return this.engine.rawHistory;
   }
 
+  get rawHistoryEntries(): readonly HistoryEntry[] {
+    return this.engine.rawHistoryEntriesSnapshot;
+  }
+
   get historyEntries(): readonly HistoryEntry[] {
     return this.engine.historyEntriesSnapshot;
   }

--- a/src/core/session/core_session.ts
+++ b/src/core/session/core_session.ts
@@ -103,6 +103,10 @@ export class CoreSession {
     return this.engine.history;
   }
 
+  get rawHistory(): readonly Message[] {
+    return this.engine.rawHistory;
+  }
+
   get historyEntries(): readonly HistoryEntry[] {
     return this.engine.historyEntriesSnapshot;
   }

--- a/src/core/session/session_engine.ts
+++ b/src/core/session/session_engine.ts
@@ -30,6 +30,11 @@ import { streamModel } from "../utils/model_stream.js";
 import type { TauStreamOptions } from "../utils/streaming_settings.js";
 import { parseStreamingSettings } from "../utils/streaming_settings.js";
 import {
+  prependTauUserMetadata,
+  stripTauUserMetadata,
+  stripTauUserMetadataFromMessage,
+} from "../utils/user_metadata.js";
+import {
   buildSessionCompactionMessage,
   buildSessionCompactionPrompt,
   COMPACTION_SUMMARIZATION_SYSTEM_PROMPT,
@@ -248,11 +253,18 @@ export class SessionEngine {
   }
 
   get history(): readonly Message[] {
+    return this.historyEntries.map((entry) => stripTauUserMetadataFromMessage(entry.message));
+  }
+
+  get rawHistory(): readonly Message[] {
     return this.historyEntries.map((entry) => entry.message);
   }
 
   get historyEntriesSnapshot(): readonly HistoryEntry[] {
-    return this.historyEntries;
+    return this.historyEntries.map((entry) => ({
+      ...entry,
+      message: stripTauUserMetadataFromMessage(entry.message),
+    }));
   }
 
   get sessionIdValue(): string {
@@ -260,7 +272,7 @@ export class SessionEngine {
   }
 
   async compact(options: SessionCompactionOptions): Promise<SessionCompactionResult> {
-    const preparation = prepareSessionCompaction(this.history);
+    const preparation = prepareSessionCompaction(this.rawHistory);
     if (!preparation) {
       throw new Error("no conversation to compact.");
     }
@@ -303,8 +315,25 @@ export class SessionEngine {
       messagesToSummarize: preparation.messagesToSummarize,
     });
 
+    const textWithModelNotice = prependModelNotice(
+      compactionMessage,
+      resolveModelNotice(this.config, this.persona.model),
+    );
+    const textWithMetadata = prependTauUserMetadata(textWithModelNotice, [
+      {
+        type: "compaction",
+        version: 1,
+        summary,
+        mode: options.mode,
+      },
+    ]);
+
     this.reset();
-    this.addUserText(compactionMessage);
+    this.addMessage({
+      role: "user",
+      content: [{ type: "text", text: textWithMetadata }],
+      timestamp: this.deps.clock.now(),
+    });
 
     return {
       compactionMessage,
@@ -340,7 +369,7 @@ export class SessionEngine {
 
   private extractUserText(message: Message): string {
     if (typeof message.content === "string") {
-      return message.content.trim();
+      return stripTauUserMetadata(message.content).trim();
     }
 
     const parts: string[] = [];
@@ -352,7 +381,7 @@ export class SessionEngine {
       }
     }
 
-    return parts.join("\n\n").trim();
+    return stripTauUserMetadata(parts.join("\n\n")).trim();
   }
 
   private extractRewindUserText(message: Message): string {

--- a/src/core/session/session_engine.ts
+++ b/src/core/session/session_engine.ts
@@ -260,6 +260,10 @@ export class SessionEngine {
     return this.historyEntries.map((entry) => entry.message);
   }
 
+  get rawHistoryEntriesSnapshot(): readonly HistoryEntry[] {
+    return this.historyEntries;
+  }
+
   get historyEntriesSnapshot(): readonly HistoryEntry[] {
     return this.historyEntries.map((entry) => ({
       ...entry,
@@ -324,7 +328,6 @@ export class SessionEngine {
         type: "compaction",
         version: 1,
         summary,
-        mode: options.mode,
       },
     ]);
 

--- a/src/core/utils/compact.ts
+++ b/src/core/utils/compact.ts
@@ -2,6 +2,7 @@ import type { AssistantMessage, Message, ToolResultMessage } from "@mariozechner
 import { TOOL_NAME_BASH, TOOL_NAME_EDIT } from "../tools/tool_names.js";
 import { buildLineDiff, collapseLongUnchangedDiffRuns } from "./line_diff.js";
 import { truncateForTokens } from "./truncate.js";
+import { stripTauUserMetadata } from "./user_metadata.js";
 
 export const COMPACTION_SUMMARY_HEADER =
   "The conversation history before this point was compacted into the following summary:";
@@ -123,7 +124,7 @@ export function formatHistoryForCompaction(history: readonly Message[]): string 
 
   for (const message of history) {
     if (message.role === "user") {
-      const text = extractTextFromContent(message.content);
+      const text = stripTauUserMetadata(extractTextFromContent(message.content));
       if (text) {
         lines.push(formatCompactionBlock("[User]:", text));
       }
@@ -161,89 +162,4 @@ export function buildCompactionUserMessage(args: {
   }
 
   return lines.join("\n");
-}
-
-export function extractCompactionSummaryFromText(text: string): string | undefined {
-  const summaryPrefix = `${COMPACTION_SUMMARY_HEADER}\n\n${SUMMARY_OPEN_TAG}\n`;
-  if (!text.startsWith(summaryPrefix)) {
-    return undefined;
-  }
-
-  const summaryContentStart = summaryPrefix.length;
-  const summaryEndMarker = `\n${SUMMARY_CLOSE_TAG}`;
-  const summaryEnd = text.indexOf(summaryEndMarker, summaryContentStart);
-  if (summaryEnd === -1) {
-    return undefined;
-  }
-
-  const summary = text.slice(summaryContentStart, summaryEnd).trim();
-  if (!summary) {
-    return undefined;
-  }
-
-  const remainderStart = summaryEnd + summaryEndMarker.length;
-  const remainder = text.slice(remainderStart);
-  if (!remainder) {
-    return summary;
-  }
-
-  if (!remainder.startsWith("\n\n")) {
-    return undefined;
-  }
-
-  const lastAssistantPrefix = `${LAST_ASSISTANT_OPEN_TAG}\n`;
-  const lastAssistantBlock = remainder.slice(2);
-  if (!lastAssistantBlock.startsWith(lastAssistantPrefix)) {
-    return undefined;
-  }
-
-  const lastAssistantContentStart = lastAssistantPrefix.length;
-  const lastAssistantEndMarker = `\n${LAST_ASSISTANT_CLOSE_TAG}`;
-  const lastAssistantEnd = lastAssistantBlock.indexOf(
-    lastAssistantEndMarker,
-    lastAssistantContentStart,
-  );
-  if (lastAssistantEnd === -1) {
-    return undefined;
-  }
-
-  const trailing = lastAssistantBlock.slice(lastAssistantEnd + lastAssistantEndMarker.length);
-  if (trailing.length > 0) {
-    return undefined;
-  }
-
-  return summary;
-}
-
-export function extractCompactionSummaryFromMessage(message: Message): string | undefined {
-  if (message.role !== "user") {
-    return undefined;
-  }
-
-  const text = extractTextFromContent(message.content);
-  if (!text) {
-    return undefined;
-  }
-
-  return extractCompactionSummaryFromText(text);
-}
-
-export function partitionHistoryForCompaction(history: readonly Message[]): {
-  previousSummary?: string;
-  messagesToSummarize: Message[];
-} {
-  const messagesToSummarize: Message[] = [];
-  let previousSummary: string | undefined;
-
-  for (const message of history) {
-    const summary = extractCompactionSummaryFromMessage(message);
-    if (summary) {
-      previousSummary = summary;
-      continue;
-    }
-
-    messagesToSummarize.push(message);
-  }
-
-  return { previousSummary, messagesToSummarize };
 }

--- a/src/core/utils/user_metadata.ts
+++ b/src/core/utils/user_metadata.ts
@@ -8,7 +8,6 @@ export type TauCompactionUserMetadata = {
   type: "compaction";
   version: 1;
   summary: string;
-  mode: "only-summary" | "with-last-assistant";
 };
 
 export type TauUserMetadata = TauCompactionUserMetadata;
@@ -54,15 +53,10 @@ function parseMetadataRecord(value: unknown): TauUserMetadata {
   if (typeof record.summary !== "string" || record.summary.trim() === "") {
     throw new Error("invalid tau user metadata: compaction summary must be a non-empty string");
   }
-  if (record.mode !== "only-summary" && record.mode !== "with-last-assistant") {
-    throw new Error("invalid tau user metadata: invalid compaction mode");
-  }
-
   return {
     type: "compaction",
     version: 1,
     summary: record.summary,
-    mode: record.mode,
   };
 }
 

--- a/src/core/utils/user_metadata.ts
+++ b/src/core/utils/user_metadata.ts
@@ -1,0 +1,173 @@
+import { Buffer } from "node:buffer";
+import type { Message } from "@mariozechner/pi-ai";
+
+export const TAU_USER_METADATA_PREFIX = "\u001eTAU_METADATA_V1:";
+const TAU_USER_METADATA_SUFFIX = "\u001e";
+
+export type TauCompactionUserMetadata = {
+  type: "compaction";
+  version: 1;
+  summary: string;
+  mode: "only-summary" | "with-last-assistant";
+};
+
+export type TauUserMetadata = TauCompactionUserMetadata;
+
+export type TauUserMetadataSplit = {
+  metadata: TauUserMetadata[];
+  visibleText: string;
+};
+
+function encodeMetadata(metadata: readonly TauUserMetadata[]): string {
+  const json = JSON.stringify(metadata);
+  return Buffer.from(json, "utf8").toString("base64url");
+}
+
+function decodeMetadata(encoded: string): TauUserMetadata[] {
+  let parsed: unknown;
+  try {
+    const json = Buffer.from(encoded, "base64url").toString("utf8");
+    parsed = JSON.parse(json);
+  } catch (err) {
+    throw new Error(`invalid tau user metadata: ${(err as Error).message}`);
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new Error("invalid tau user metadata: payload must be an array");
+  }
+
+  return parsed.map(parseMetadataRecord);
+}
+
+function parseMetadataRecord(value: unknown): TauUserMetadata {
+  if (!value || typeof value !== "object") {
+    throw new Error("invalid tau user metadata: record must be an object");
+  }
+
+  const record = value as Record<string, unknown>;
+  if (record.type !== "compaction") {
+    throw new Error("invalid tau user metadata: unknown record type");
+  }
+  if (record.version !== 1) {
+    throw new Error("invalid tau user metadata: unsupported compaction metadata version");
+  }
+  if (typeof record.summary !== "string" || record.summary.trim() === "") {
+    throw new Error("invalid tau user metadata: compaction summary must be a non-empty string");
+  }
+  if (record.mode !== "only-summary" && record.mode !== "with-last-assistant") {
+    throw new Error("invalid tau user metadata: invalid compaction mode");
+  }
+
+  return {
+    type: "compaction",
+    version: 1,
+    summary: record.summary,
+    mode: record.mode,
+  };
+}
+
+export function splitTauUserMetadata(text: string): TauUserMetadataSplit {
+  if (!text.startsWith(TAU_USER_METADATA_PREFIX)) {
+    return { metadata: [], visibleText: text };
+  }
+
+  const payloadStart = TAU_USER_METADATA_PREFIX.length;
+  const payloadEnd = text.indexOf(TAU_USER_METADATA_SUFFIX, payloadStart);
+  if (payloadEnd < 0) {
+    throw new Error("invalid tau user metadata: missing metadata terminator");
+  }
+
+  const encoded = text.slice(payloadStart, payloadEnd);
+  if (!encoded) {
+    throw new Error("invalid tau user metadata: empty payload");
+  }
+
+  return {
+    metadata: decodeMetadata(encoded),
+    visibleText: text.slice(payloadEnd + TAU_USER_METADATA_SUFFIX.length),
+  };
+}
+
+export function stripTauUserMetadata(text: string): string {
+  return splitTauUserMetadata(text).visibleText;
+}
+
+export function prependTauUserMetadata(
+  visibleText: string,
+  metadata: readonly TauUserMetadata[],
+): string {
+  if (metadata.length === 0) {
+    return visibleText;
+  }
+
+  const existing = splitTauUserMetadata(visibleText);
+  return `${TAU_USER_METADATA_PREFIX}${encodeMetadata([...metadata, ...existing.metadata])}${TAU_USER_METADATA_SUFFIX}${existing.visibleText}`;
+}
+
+function splitMessageText(message: Message): TauUserMetadataSplit | undefined {
+  if (message.role !== "user") {
+    return undefined;
+  }
+
+  if (typeof message.content === "string") {
+    return splitTauUserMetadata(message.content);
+  }
+
+  const firstBlock = message.content[0];
+  if (typeof firstBlock === "string") {
+    return splitTauUserMetadata(firstBlock);
+  }
+  if (firstBlock?.type === "text") {
+    return splitTauUserMetadata(firstBlock.text ?? "");
+  }
+
+  return { metadata: [], visibleText: "" };
+}
+
+export function getTauUserMetadataFromMessage(message: Message): TauUserMetadata[] {
+  return splitMessageText(message)?.metadata ?? [];
+}
+
+export function getCompactionMetadataFromMessage(
+  message: Message,
+): TauCompactionUserMetadata | undefined {
+  return getTauUserMetadataFromMessage(message)
+    .filter((metadata): metadata is TauCompactionUserMetadata => metadata.type === "compaction")
+    .at(-1);
+}
+
+export function stripTauUserMetadataFromMessage(message: Message): Message {
+  if (message.role !== "user") {
+    return message;
+  }
+
+  if (typeof message.content === "string") {
+    const visibleText = stripTauUserMetadata(message.content);
+    if (visibleText === message.content) {
+      return message;
+    }
+    return { ...message, content: visibleText };
+  }
+
+  const firstBlock = message.content[0];
+  if (typeof firstBlock === "string") {
+    const visibleText = stripTauUserMetadata(firstBlock);
+    if (visibleText === firstBlock) {
+      return message;
+    }
+    const content = [...message.content] as unknown[];
+    content[0] = visibleText;
+    return { ...message, content } as Message;
+  }
+  if (firstBlock?.type === "text") {
+    const visibleText = stripTauUserMetadata(firstBlock.text ?? "");
+    if (visibleText === firstBlock.text) {
+      return message;
+    }
+    const content = [...message.content];
+    content[0] = { ...firstBlock, text: visibleText };
+    return { ...message, content };
+  }
+
+  return message;
+}

--- a/src/tui/chat_controller.ts
+++ b/src/tui/chat_controller.ts
@@ -77,6 +77,7 @@ import { transcribeMistralAudio } from "../core/utils/mistral_transcription.js";
 import { streamModel } from "../core/utils/model_stream.js";
 import { listProjectFilesAsync } from "../core/utils/project_files.js";
 import type { SpawnCaptureResult } from "../core/utils/spawn_capture.js";
+import { stripTauUserMetadata } from "../core/utils/user_metadata.js";
 import { APP_VERSION } from "../core/version.js";
 import {
   type DiffReviewReturnedReview,
@@ -674,7 +675,7 @@ export class ChatController {
 
   private extractUserText(message: Message): string {
     if (typeof message.content === "string") {
-      return message.content.trim();
+      return stripTauUserMetadata(message.content).trim();
     }
     const parts: string[] = [];
     for (const block of message.content) {
@@ -682,7 +683,7 @@ export class ChatController {
         parts.push(block.text);
       }
     }
-    return parts.join("\n").trim();
+    return stripTauUserMetadata(parts.join("\n")).trim();
   }
 
   private formatToolResultNotice(toolResult: ToolResultMessage): string {
@@ -2074,7 +2075,7 @@ export class ChatController {
   }
 
   private async checkpointSession(): Promise<void> {
-    const history = this.engine.history;
+    const history = this.engine.rawHistory;
     if (history.length === 0) {
       this.view.addSystemMessage("no conversation to checkpoint.", "warn", { persist: false });
       return;

--- a/test/core_runtime.test.js
+++ b/test/core_runtime.test.js
@@ -214,7 +214,6 @@ describe("core session rewind APIs", () => {
         type: "compaction",
         version: 1,
         summary: "summary",
-        mode: "only-summary",
       },
     ]);
 
@@ -757,7 +756,6 @@ describe("compaction context message", () => {
         type: "compaction",
         version: 1,
         summary: "## Goal\nShip feature",
-        mode: "only-summary",
       },
     ]);
     const message = {
@@ -773,7 +771,6 @@ describe("compaction context message", () => {
       type: "compaction",
       version: 1,
       summary: "## Goal\nShip feature",
-      mode: "only-summary",
     });
   });
 
@@ -791,7 +788,6 @@ describe("compaction context message", () => {
           type: "compaction",
           version: 1,
           summary: "old summary",
-          mode: "only-summary",
         },
       ],
     );

--- a/test/core_runtime.test.js
+++ b/test/core_runtime.test.js
@@ -7,6 +7,7 @@ import { createCommandRegistry } from "../dist/core/commands/index.js";
 import { resolveRuntimePromptBootstrap } from "../dist/core/index.js";
 import { personas } from "../dist/core/personas.js";
 import { composeSessionPrompts } from "../dist/core/runtime/session_prompt_composer.js";
+import { prepareSessionCompaction } from "../dist/core/session/compaction.js";
 import { CoreSession } from "../dist/core/session/core_session.js";
 import { ToolCatalog } from "../dist/core/tools/catalog.js";
 import { createLocalToolExecutionBackend } from "../dist/core/tools/execution_backend.js";
@@ -19,14 +20,19 @@ import {
 } from "../dist/core/tools/tool_names.js";
 import {
   buildCompactionUserMessage,
-  extractCompactionSummaryFromText,
   formatHistoryForCompaction,
-  partitionHistoryForCompaction,
 } from "../dist/core/utils/compact.js";
 import {
   buildEnvironmentTag,
   buildProjectContextBlock,
 } from "../dist/core/utils/context_builder.js";
+import {
+  getCompactionMetadataFromMessage,
+  prependTauUserMetadata,
+  stripTauUserMetadata,
+  stripTauUserMetadataFromMessage,
+  TAU_USER_METADATA_PREFIX,
+} from "../dist/core/utils/user_metadata.js";
 
 describe("command registry", () => {
   it("parses and dispatches commands", async () => {
@@ -191,6 +197,37 @@ describe("core session rewind APIs", () => {
     expect(remaining[1]?.role).toBe("assistant");
 
     expect(session.rewindToHistoryEntryId("missing-id")).toBeUndefined();
+  });
+
+  it("keeps tau metadata in raw history and strips it from visible history", () => {
+    const backend = createLocalToolExecutionBackend();
+    const toolRegistry = ToolCatalog.createRegistry(backend);
+    const session = new CoreSession({
+      persona: personas[0],
+      systemPrompt: "system",
+      subagentPrompts: {},
+      riskLevel: "read-only",
+      toolRegistry,
+    });
+    const text = prependTauUserMetadata("visible summary", [
+      {
+        type: "compaction",
+        version: 1,
+        summary: "summary",
+        mode: "only-summary",
+      },
+    ]);
+
+    session.addMessage({
+      role: "user",
+      content: [{ type: "text", text }],
+      timestamp: 0,
+    });
+
+    expect(session.rawHistory[0].content[0].text.startsWith(TAU_USER_METADATA_PREFIX)).toBe(true);
+    expect(session.history[0].content[0].text).toBe("visible summary");
+    expect(session.historyEntries[0].message.content[0].text).toBe("visible summary");
+    expect(session.listRewindCandidates()[0].text).toBe("visible summary");
   });
 });
 
@@ -703,7 +740,7 @@ describe("summary formatting", () => {
 });
 
 describe("compaction context message", () => {
-  it("builds and extracts compaction summary text", () => {
+  it("builds visible compaction summary text", () => {
     const message = buildCompactionUserMessage({
       summary: "## Goal\nShip feature",
       lastAssistantMessage: "Done. Tests passed.",
@@ -711,35 +748,57 @@ describe("compaction context message", () => {
 
     expect(message).toContain("<summary>");
     expect(message).toContain("<last-assistant-message-verbatim>");
-    expect(extractCompactionSummaryFromText(message)).toBe("## Goal\nShip feature");
   });
 
-  it("does not extract summary from non-canonical marker text", () => {
-    const quotedCompactionText = [
-      "Please echo this format:",
-      "The conversation history before this point was compacted into the following summary:",
-      "<summary>",
-      "quoted content",
-      "</summary>",
-    ].join("\n");
+  it("round-trips tau user metadata", () => {
+    const visibleText = buildCompactionUserMessage({ summary: "## Goal\nShip feature" });
+    const text = prependTauUserMetadata(visibleText, [
+      {
+        type: "compaction",
+        version: 1,
+        summary: "## Goal\nShip feature",
+        mode: "only-summary",
+      },
+    ]);
+    const message = {
+      role: "user",
+      content: [{ type: "text", text }],
+      timestamp: 0,
+    };
 
-    expect(extractCompactionSummaryFromText(quotedCompactionText)).toBeUndefined();
+    expect(text.startsWith(TAU_USER_METADATA_PREFIX)).toBe(true);
+    expect(stripTauUserMetadata(text)).toBe(visibleText);
+    expect(stripTauUserMetadataFromMessage(message).content[0].text).toBe(visibleText);
+    expect(getCompactionMetadataFromMessage(message)).toEqual({
+      type: "compaction",
+      version: 1,
+      summary: "## Goal\nShip feature",
+      mode: "only-summary",
+    });
   });
 
-  it("does not extract summary when extra trailing text is present", () => {
-    const messageWithTrailingText = `${buildCompactionUserMessage({
-      summary: "old summary",
-    })}\n\ntrailing text`;
-
-    expect(extractCompactionSummaryFromText(messageWithTrailingText)).toBeUndefined();
+  it("fails fast for invalid tau user metadata", () => {
+    expect(() =>
+      stripTauUserMetadata(`${TAU_USER_METADATA_PREFIX}not-base64\u001evisible`),
+    ).toThrow("invalid tau user metadata");
   });
 
-  it("excludes previous compaction user message from the next summary input", () => {
-    const compactionMessage = buildCompactionUserMessage({ summary: "old summary" });
+  it("uses compaction metadata as previous summary for the next compaction", () => {
+    const compactionText = prependTauUserMetadata(
+      buildCompactionUserMessage({ summary: "old summary" }),
+      [
+        {
+          type: "compaction",
+          version: 1,
+          summary: "old summary",
+          mode: "only-summary",
+        },
+      ],
+    );
     const history = [
       {
         role: "user",
-        content: [{ type: "text", text: compactionMessage }],
+        content: [{ type: "text", text: compactionText }],
         timestamp: 0,
       },
       {
@@ -749,10 +808,34 @@ describe("compaction context message", () => {
       },
     ];
 
-    const result = partitionHistoryForCompaction(history);
+    const result = prepareSessionCompaction(history);
 
     expect(result.previousSummary).toBe("old summary");
     expect(result.messagesToSummarize).toHaveLength(1);
-    expect(result.messagesToSummarize[0].role).toBe("user");
+    expect(result.formattedHistory).toContain("new request");
+    expect(result.formattedHistory).not.toContain("old summary");
+  });
+
+  it("treats visible compaction text without metadata as ordinary user text", () => {
+    const oldVisibleCompactionText = buildCompactionUserMessage({ summary: "old summary" });
+    const history = [
+      {
+        role: "user",
+        content: [{ type: "text", text: oldVisibleCompactionText }],
+        timestamp: 0,
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "new request" }],
+        timestamp: 1,
+      },
+    ];
+
+    const result = prepareSessionCompaction(history);
+
+    expect(result.previousSummary).toBeUndefined();
+    expect(result.messagesToSummarize).toHaveLength(2);
+    expect(result.formattedHistory).toContain("old summary");
+    expect(result.formattedHistory).toContain("new request");
   });
 });

--- a/test/diff_review_thread.test.js
+++ b/test/diff_review_thread.test.js
@@ -55,6 +55,9 @@ vi.mock("../src/core/session/core_session.ts", () => ({
         message,
       });
     }
+    get rawHistoryEntries() {
+      return this.historyEntries;
+    }
     get sessionId() {
       return "review-session-1";
     }


### PR DESCRIPTION
- add Tau-internal user metadata for compaction summaries
- make repeated manual compaction use metadata instead of visible summary parsing
- preserve metadata in checkpoints while stripping it from model-visible and UI history
- add coverage for metadata round-trips and repeated compaction preparation
