### PR TITLE
wrap tool headers by character

### DIFF
--- a/src/tui/ui/components/header_line.ts
+++ b/src/tui/ui/components/header_line.ts
@@ -3,13 +3,10 @@ import {
   iterateGraphemes,
   normalizeInlineTextPreservePadding,
   type OneLineSegment,
-  OneLineSegmentsComponent,
 } from "./one_line_segments.js";
 
 export interface HeaderLineModel {
   segments: OneLineSegment[];
-  flexIndices?: number[];
-  wrapIndex?: number;
 }
 
 type WrappedLineSegment = { index: number; text: string };
@@ -23,8 +20,8 @@ function appendWrappedLineSegment(chunks: WrappedLineSegment[], index: number, t
   chunks.push({ index, text });
 }
 
-class CharacterWrappedSegmentsComponent implements Component {
-  constructor(private segments: OneLineSegment[]) {}
+export class HeaderLineComponent implements Component {
+  constructor(private model: HeaderLineModel) {}
 
   invalidate() {}
 
@@ -32,7 +29,9 @@ class CharacterWrappedSegmentsComponent implements Component {
     const minWidth = Math.max(0, width);
     if (minWidth <= 0) return [""];
 
-    const texts = this.segments.map((segment) => normalizeInlineTextPreservePadding(segment.text));
+    const texts = this.model.segments.map((segment) =>
+      normalizeInlineTextPreservePadding(segment.text),
+    );
     const lines: WrappedLineSegment[][] = [];
     let currentLine: WrappedLineSegment[] = [];
     let currentWidth = 0;
@@ -64,34 +63,17 @@ class CharacterWrappedSegmentsComponent implements Component {
       flushLine();
     }
 
-    return lines.map((line) => {
-      const rendered = line
-        .map((chunk) => {
-          const style = this.segments[chunk.index]?.style ?? ((s: string) => s);
-          return style(chunk.text);
-        })
-        .join("");
-      const lineWidth = line.reduce((acc, chunk) => acc + visibleWidth(chunk.text), 0);
-      return `${rendered}${" ".repeat(Math.max(0, minWidth - lineWidth))}`;
-    });
-  }
-}
-
-export class HeaderLineComponent implements Component {
-  private inner: Component;
-
-  constructor(model: HeaderLineModel) {
-    this.inner =
-      model.wrapIndex !== undefined
-        ? new CharacterWrappedSegmentsComponent(model.segments)
-        : new OneLineSegmentsComponent(model.segments, model.flexIndices ?? []);
+    return lines.map((line) => this.renderLine(line, minWidth));
   }
 
-  invalidate() {
-    this.inner.invalidate?.();
-  }
-
-  render(width: number): string[] {
-    return this.inner.render(width);
+  private renderLine(line: WrappedLineSegment[], width: number): string {
+    const rendered = line
+      .map((chunk) => {
+        const style = this.model.segments[chunk.index]?.style ?? ((s: string) => s);
+        return style(chunk.text);
+      })
+      .join("");
+    const lineWidth = line.reduce((acc, chunk) => acc + visibleWidth(chunk.text), 0);
+    return `${rendered}${" ".repeat(Math.max(0, width - lineWidth))}`;
   }
 }

--- a/src/tui/ui/components/header_line.ts
+++ b/src/tui/ui/components/header_line.ts
@@ -1,8 +1,9 @@
-import type { Component } from "@mariozechner/pi-tui";
+import { type Component, visibleWidth } from "@mariozechner/pi-tui";
 import {
+  iterateGraphemes,
+  normalizeInlineTextPreservePadding,
   type OneLineSegment,
   OneLineSegmentsComponent,
-  WrappedSegmentsComponent,
 } from "./one_line_segments.js";
 
 export interface HeaderLineModel {
@@ -11,18 +12,83 @@ export interface HeaderLineModel {
   wrapIndex?: number;
 }
 
+type WrappedLineSegment = { index: number; text: string };
+
+function appendWrappedLineSegment(chunks: WrappedLineSegment[], index: number, text: string): void {
+  const last = chunks.at(-1);
+  if (last?.index === index) {
+    last.text += text;
+    return;
+  }
+  chunks.push({ index, text });
+}
+
+class CharacterWrappedSegmentsComponent implements Component {
+  constructor(private segments: OneLineSegment[]) {}
+
+  invalidate() {}
+
+  render(width: number): string[] {
+    const minWidth = Math.max(0, width);
+    if (minWidth <= 0) return [""];
+
+    const texts = this.segments.map((segment) => normalizeInlineTextPreservePadding(segment.text));
+    const lines: WrappedLineSegment[][] = [];
+    let currentLine: WrappedLineSegment[] = [];
+    let currentWidth = 0;
+
+    const flushLine = () => {
+      lines.push(currentLine);
+      currentLine = [];
+      currentWidth = 0;
+    };
+
+    for (let index = 0; index < texts.length; index++) {
+      const text = texts[index] ?? "";
+      for (const grapheme of iterateGraphemes(text)) {
+        const graphemeWidth = visibleWidth(grapheme);
+        if (currentWidth + graphemeWidth > minWidth && currentLine.length > 0) {
+          flushLine();
+        }
+
+        appendWrappedLineSegment(currentLine, index, grapheme);
+        currentWidth += graphemeWidth;
+
+        if (currentWidth >= minWidth) {
+          flushLine();
+        }
+      }
+    }
+
+    if (currentLine.length > 0 || lines.length === 0) {
+      flushLine();
+    }
+
+    return lines.map((line) => {
+      const rendered = line
+        .map((chunk) => {
+          const style = this.segments[chunk.index]?.style ?? ((s: string) => s);
+          return style(chunk.text);
+        })
+        .join("");
+      const lineWidth = line.reduce((acc, chunk) => acc + visibleWidth(chunk.text), 0);
+      return `${rendered}${" ".repeat(Math.max(0, minWidth - lineWidth))}`;
+    });
+  }
+}
+
 export class HeaderLineComponent implements Component {
   private inner: Component;
 
   constructor(model: HeaderLineModel) {
     this.inner =
       model.wrapIndex !== undefined
-        ? new WrappedSegmentsComponent(model.segments, model.wrapIndex)
+        ? new CharacterWrappedSegmentsComponent(model.segments)
         : new OneLineSegmentsComponent(model.segments, model.flexIndices ?? []);
   }
 
   invalidate() {
-    this.inner.invalidate();
+    this.inner.invalidate?.();
   }
 
   render(width: number): string[] {

--- a/src/tui/ui/components/one_line_segments.ts
+++ b/src/tui/ui/components/one_line_segments.ts
@@ -3,7 +3,7 @@ import { visibleWidth } from "@mariozechner/pi-tui";
 
 export type OneLineSegment = { text: string; style: (s: string) => string };
 
-function iterateGraphemes(text: string): string[] {
+export function iterateGraphemes(text: string): string[] {
   if (typeof Intl !== "undefined" && typeof Intl.Segmenter !== "undefined") {
     const seg = new Intl.Segmenter(undefined, { granularity: "grapheme" });
     return Array.from(seg.segment(text), (s) => s.segment);
@@ -144,43 +144,10 @@ function parseAnsiSequence(
   return null;
 }
 
-function normalizeInlineTextPreservePadding(text: string): string {
+export function normalizeInlineTextPreservePadding(text: string): string {
   // Keep this strictly single-line but preserve intentional padding segments (e.g. " ").
   // Callers should trim user-provided segments (e.g. commands) as needed.
   return text.replace(/[\r\n\t]+/g, " ").replace(/ {2,}/g, " ");
-}
-
-function wrapTextByWidths(text: string, firstMaxCols: number, nextMaxCols: number): string[] {
-  if (firstMaxCols <= 0) return [""];
-  if (text.length === 0) return [""];
-
-  const graphemes = iterateGraphemes(text);
-  const lines: string[] = [];
-  let line = "";
-  let lineCols = 0;
-
-  for (const g of graphemes) {
-    const maxCols = lines.length === 0 ? firstMaxCols : nextMaxCols;
-    const gCols = visibleWidth(g);
-    if (lineCols + gCols > maxCols && line.length > 0) {
-      lines.push(line);
-      line = "";
-      lineCols = 0;
-    }
-    const nextMaxColsForLine = lines.length === 0 ? firstMaxCols : nextMaxCols;
-    if (gCols > nextMaxColsForLine && line.length === 0) {
-      lines.push(g);
-      continue;
-    }
-    line += g;
-    lineCols += gCols;
-  }
-
-  if (line.length > 0) {
-    lines.push(line);
-  }
-
-  return lines;
 }
 
 export class OneLineSegmentsComponent implements Component {
@@ -247,52 +214,5 @@ export class OneLineSegmentsComponent implements Component {
     const visibleLen = total();
     const pad = Math.max(0, minWidth - visibleLen);
     return [`${rendered}${" ".repeat(pad)}`];
-  }
-}
-
-export class WrappedSegmentsComponent implements Component {
-  constructor(
-    private segments: OneLineSegment[],
-    private wrapIndex?: number,
-  ) {}
-
-  invalidate() {}
-
-  render(width: number): string[] {
-    const minWidth = Math.max(0, width);
-    if (this.segments.length === 0) {
-      return [" ".repeat(minWidth)];
-    }
-
-    const texts = this.segments.map((s) => normalizeInlineTextPreservePadding(s.text));
-    const wrapAt = this.wrapIndex ?? texts.length - 1;
-
-    if (wrapAt < 0 || wrapAt >= texts.length || wrapAt !== texts.length - 1) {
-      return new OneLineSegmentsComponent(this.segments, []).render(width);
-    }
-
-    const prefixTexts = texts.slice(0, wrapAt);
-    const wrapText = texts[wrapAt] ?? "";
-    const prefixWidth = visibleWidth(prefixTexts.join(""));
-    if (prefixWidth >= minWidth || minWidth <= 0) {
-      return new OneLineSegmentsComponent(this.segments, []).render(width);
-    }
-
-    const availableWidth = Math.max(1, minWidth - prefixWidth);
-    const wrapped = wrapTextByWidths(wrapText, availableWidth, minWidth);
-    const prefixRendered = prefixTexts
-      .map((t, i) => {
-        const style = this.segments[i]?.style ?? ((s: string) => s);
-        return style(t);
-      })
-      .join("");
-    const wrapStyle = this.segments[wrapAt]?.style ?? ((s: string) => s);
-
-    return wrapped.map((line, index) => {
-      const leading = index === 0 ? prefixRendered : "";
-      const lineWidth = (index === 0 ? prefixWidth : 0) + visibleWidth(line);
-      const pad = Math.max(0, minWidth - lineWidth);
-      return `${leading}${wrapStyle(line)}${" ".repeat(pad)}`;
-    });
   }
 }

--- a/src/tui/ui/tool_output.ts
+++ b/src/tui/ui/tool_output.ts
@@ -3,7 +3,6 @@ import type { ToolUiLine, ToolUiText } from "../../core/tools/registry.js";
 import { DynamicBorder } from "./components/dynamic_border.js";
 import { HeaderLineComponent, type HeaderLineModel } from "./components/header_line.js";
 import type { OneLineSegment } from "./components/one_line_segments.js";
-import { OneLineSegmentsComponent } from "./components/one_line_segments.js";
 import type { UiComponent } from "./components/ui_component.js";
 import type { Theme } from "./theme/index.js";
 
@@ -41,19 +40,9 @@ export interface HeaderSegmentsSpec {
   accentStyle?: (text: string) => string;
 }
 
-export interface HeaderLineSpec extends HeaderSegmentsSpec {
-  tailSegments?: OneLineSegment[];
-  flexAccent?: boolean;
-  flexTailIndices?: number[];
-  wrapIndex?: number;
-}
-
-export function buildHeaderSegments(spec: HeaderSegmentsSpec): {
-  segments: OneLineSegment[];
-  accentIndex: number;
-} {
+function buildHeaderSegments(spec: HeaderSegmentsSpec): OneLineSegment[] {
   const bullet = spec.bullet ?? "▪";
-  const segments: OneLineSegment[] = [
+  return [
     { text: " ", style: (s) => s },
     { text: bullet, style: spec.bulletStyle },
     { text: " ", style: (s) => s },
@@ -61,32 +50,6 @@ export function buildHeaderSegments(spec: HeaderSegmentsSpec): {
     { text: " ", style: (s) => s },
     { text: spec.accent, style: spec.accentStyle ?? ((s) => s) },
   ];
-  return { segments, accentIndex: segments.length - 1 };
-}
-
-export function buildHeaderLine(spec: HeaderLineSpec): HeaderLineModel {
-  const { segments, accentIndex } = buildHeaderSegments(spec);
-  const baseLength = segments.length;
-  if (spec.tailSegments && spec.tailSegments.length > 0) {
-    segments.push(...spec.tailSegments);
-  }
-  const flexIndices: number[] = [];
-  if (spec.flexAccent !== false) {
-    flexIndices.push(accentIndex);
-  }
-  if (spec.flexTailIndices && spec.flexTailIndices.length > 0) {
-    for (const idx of spec.flexTailIndices) {
-      const absolute = baseLength + idx;
-      if (absolute >= 0 && absolute < segments.length) {
-        flexIndices.push(absolute);
-      }
-    }
-  }
-  return {
-    segments,
-    flexIndices,
-    wrapIndex: spec.wrapIndex,
-  };
 }
 
 export function buildSection(lines: Array<string | undefined>): string | undefined {
@@ -133,7 +96,7 @@ export const TOOL_UI_INDENT = 4;
 const DEFAULT_STATUS_WRAPPER = (text: string) => `(${text})`;
 
 export function buildToolHeaderLine(spec: HeaderSegmentsSpec): HeaderLineModel {
-  return buildHeaderLine({ ...spec, wrapIndex: 5 });
+  return { segments: buildHeaderSegments(spec) };
 }
 
 export function renderToolUiCompactText(args: {
@@ -190,8 +153,6 @@ export interface ToolOutputExpandedView {
 
 export interface ToolOutputCompactView {
   headerComponent?: Component;
-  segments?: OneLineSegment[];
-  flexIndices?: number[];
   extraText?: string;
   extraComponent?: Component;
   paddingX?: number;
@@ -213,19 +174,9 @@ export class ToolOutputComponent extends Container implements UiComponent<ToolOu
   update(props: ToolOutputProps): void {
     this.clear();
     if (props.compact) {
-      const {
-        headerComponent,
-        segments,
-        flexIndices,
-        extraText,
-        extraComponent,
-        paddingX,
-        paddingY,
-      } = props.compactView;
+      const { headerComponent, extraText, extraComponent, paddingX, paddingY } = props.compactView;
       if (headerComponent) {
         this.addChild(headerComponent);
-      } else if (segments) {
-        this.addChild(new OneLineSegmentsComponent(segments, flexIndices ?? []));
       }
 
       if (extraComponent) {

--- a/test/ui_components.test.js
+++ b/test/ui_components.test.js
@@ -320,21 +320,23 @@ test("OneLineSegmentsComponent truncates flex segments", () => {
   expect(line).toBe("hellowo…");
 });
 
-test("HeaderLineComponent uses character wrapping for wrapped headers", () => {
+test("HeaderLineComponent wraps styled header text by character", () => {
   const component = new HeaderLineComponent({
     segments: [
       { text: " ", style: (s) => s },
-      { text: "✓", style: (s) => s },
+      { text: "✓", style: (s) => `<ok>${s}</ok>` },
       { text: " ", style: (s) => s },
-      { text: "ran", style: (s) => s },
+      { text: "ran", style: (s) => `<muted>${s}</muted>` },
       { text: " ", style: (s) => s },
-      { text: "alpha beta gamma delta epsilon", style: (s) => s },
+      { text: "alpha beta gamma delta epsilon", style: (s) => `<accent>${s}</accent>` },
     ],
-    wrapIndex: 5,
   });
 
   const lines = renderLines(component, 20);
-  expect(lines).toEqual([" ✓ ran alpha beta ga", "mma delta epsilon"]);
+  expect(lines).toEqual([
+    " <ok>✓</ok> <muted>ran</muted> <accent>alpha beta ga</accent>",
+    "<accent>mma delta epsilon</accent>",
+  ]);
 });
 
 test("truncateFromEndByWidth respects max width", () => {

--- a/test/ui_components.test.js
+++ b/test/ui_components.test.js
@@ -5,11 +5,11 @@ import { createCommandRegistry } from "../dist/core/commands/index.js";
 import { AssistantMessageComponent } from "../dist/tui/ui/assistant_message.js";
 import { ChatContainerComponent } from "../dist/tui/ui/chat_container.js";
 import { renderChatMessage } from "../dist/tui/ui/chat_message_model.js";
+import { HeaderLineComponent } from "../dist/tui/ui/components/header_line.js";
 import {
   OneLineSegmentsComponent,
   truncateFromEndByWidth,
   truncateFromEndByWidthPreserveAnsi,
-  WrappedSegmentsComponent,
 } from "../dist/tui/ui/components/one_line_segments.js";
 import { CustomEditor } from "../dist/tui/ui/custom_editor.js";
 import { FooterComponent } from "../dist/tui/ui/footer.js";
@@ -320,21 +320,21 @@ test("OneLineSegmentsComponent truncates flex segments", () => {
   expect(line).toBe("hellowo…");
 });
 
-test("WrappedSegmentsComponent uses full width for continuation lines", () => {
-  const component = new WrappedSegmentsComponent(
-    [
+test("HeaderLineComponent uses character wrapping for wrapped headers", () => {
+  const component = new HeaderLineComponent({
+    segments: [
       { text: " ", style: (s) => s },
       { text: "✓", style: (s) => s },
       { text: " ", style: (s) => s },
       { text: "ran", style: (s) => s },
       { text: " ", style: (s) => s },
-      { text: "abcdefghijklmnopqrstuvwxyz0123456789", style: (s) => s },
+      { text: "alpha beta gamma delta epsilon", style: (s) => s },
     ],
-    5,
-  );
+    wrapIndex: 5,
+  });
 
   const lines = renderLines(component, 20);
-  expect(lines).toEqual([" ✓ ran abcdefghijklm", "nopqrstuvwxyz0123456", "789"]);
+  expect(lines).toEqual([" ✓ ran alpha beta ga", "mma delta epsilon"]);
 });
 
 test("truncateFromEndByWidth respects max width", () => {


### PR DESCRIPTION
- wrap compact tool headers at character boundaries instead of word boundaries
- remove the prefix-width wrapping behavior that caused continuation lines to wrap too early
- cover wrapped header rendering in UI component tests
