### PR TITLE
add configurable speech transcription

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,10 +192,11 @@ On conflicts, the most specific level wins (built-ins are the base layer).
 
 ## Configuration
 
-- **Global**: `~/.config/tau/config.json` (API keys, `defaultPersona`, `defaultRisk`, `disableBuiltinPersonas`, `disableBuiltinThemes`, `defaultTheme`, `diffTool`, `builtInDiffTool`, `bashCommands`, `agentContextFiles`, `subagents`, `autoCompact`, `modelSystemNotices`, `async`). This level is only included when cwd is inside home.
+- **Global**: `~/.config/tau/config.json` (API keys, `defaultPersona`, `defaultRisk`, `disableBuiltinPersonas`, `disableBuiltinThemes`, `defaultTheme`, `diffTool`, `builtInDiffTool`, `bashCommands`, `agentContextFiles`, `subagents`, `autoCompact`, `modelSystemNotices`, `speechToText`, `async`). This level is only included when cwd is inside home.
   - `apiKeys` (optional): Map of provider id to API key (`apiKeys.<provider>`). Keys merge by provider id across config levels.
   - `apiKeys.parallel` (optional): Parallel API key for `web_search`/`web_fetch` usage in subagents.
-  - `apiKeys.mistral` (optional): Mistral API key for `/listen` and Telegram audio transcription.
+  - `apiKeys.mistral` (optional): Mistral API key for `/listen`, Telegram audio transcription, and PDF OCR.
+  - `apiKeys.google` (optional): Google API key for Gemini chat models, `/speak`, and speech-to-text when `speechToText.provider` is `gemini`.
   - `defaultPersona` (optional): String persona reference used by default when starting the app. Accepts `<id>` or `<id>:<reasoning>` and matches are exact/case-sensitive. Overridden by `--persona` flag.
   - `defaultRisk` (optional): Default risk level (`read-only`, `read-write`). Overridden by `--risk` flag. Defaults to `read-only`.
   - `disableBuiltinPersonas` (optional): If true, tau will not load built-in personas, only entries from disk.
@@ -206,6 +207,7 @@ On conflicts, the most specific level wins (built-ins are the base layer).
   - `subagents.defaultLaunchModels` (optional): Allowlisted `spawn_agent` launch overrides for the built-in `default` subagent (`<provider>/<model>:<effort>` entries).
   - `autoCompact` (optional): Automatic compaction settings, merged field-by-field. Defaults are `{ "enabled": true, "reserveTokens": 16384, "keepRecentTokens": 20000 }`. Threshold detection uses only provider-reported assistant usage against `model.contextWindow - reserveTokens`; Tau's token heuristic is only used after threshold crossing to choose the retained-tail cut point, with retention capped at that threshold. Auto-compaction summarizes older context, keeps a recent tail, inserts a hidden continuation user message, and emits `compaction_start`/`compaction_end` core events. Context-overflow compact-and-retry is not implemented.
   - `modelSystemNotices` (optional): Map of `<provider>/<model>` to notice text. Provider ids must be known and model ids are exact/case-sensitive against the merged configured model catalog (built-in + layered `models.json`). Tau prepends the notice as a `<system>` block before each user message sent to that model (main session and subagents).
+  - `speechToText` (optional): Speech-to-text config for `/listen` and Telegram audio transcription. `provider` is required when present and accepts `mistral` (default, Voxtral) or `gemini` (Gemini 3.5 Flash with minimal thinking).
   - `async.client` (optional): Async client config (`defaultTarget`, `defaultProjectId`, `targets.<id>.url`, `targets.<id>.token`, `targets.<id>.timeoutMs`).
   - daemon-side async settings are loaded from a separate JSON file passed via `tau async daemon --config-file <path>` (`host`, `port`, `authToken`, `maxSessions`, `telegram` (map keyed by bot id, with optional `allowedProjectIds`; sessions are chat-scoped within each bot, and allowed groups share one chat-scoped namespace), `cron` (including `cron.jobsDir`), `projects`, `workspaceRoot`, `systemMessage`, and project fields like `workingDirectory`, `description`, `bootstrapCommands`, and `backgroundBootstrapCommands`). On daemon startup, Tau removes existing entries under configured async workspace roots (`workspaceRoot` plus any per-project overrides) before adapters start, and the Telegram adapter prunes stale `tau-telegram-attachments-*` directories under the system temp directory. Assume zero or one async daemon process per host; concurrent daemons are unsupported.
 
@@ -277,7 +279,8 @@ The `--debug` flag respects `--persona` and `--no-agent-context-files`, so you c
 - `TAU_ASYNC_AUTH_TOKEN` (env var) - Optional override for daemon-file `authToken` in daemon mode
 - `TAU_CODEX_ACCOUNT` (env var) - Force a specific Codex account by email or account id (same matching as logout); disables failover
 - `PARALLEL_API_KEY` (env var) - Optional override for `apiKeys.parallel` used by `web_search`/`web_fetch`
-- `MISTRAL_API_KEY` (env var) - Optional override for `/listen` microphone, Telegram audio transcription, and `tau tool pdf-unpack`
+- `GEMINI_API_KEY` (env var) - Optional override for `apiKeys.google` used by Google Gemini models, `/speak`, and Google speech-to-text
+- `MISTRAL_API_KEY` (env var) - Optional override for Mistral `/listen` microphone transcription, Telegram audio transcription, and `tau tool pdf-unpack`
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ for built-in providers and features, use these `apiKeys` entries: `anthropic`, `
 
 `parallel` is only needed for `web_search`/`web_fetch` usage in sub-agents and can be provided through `apiKeys.parallel` or `PARALLEL_API_KEY` (`PARALLEL_API_KEY` takes precedence).
 
-`/listen`, Telegram audio transcription, and `tau tool pdf-unpack` all use `apiKeys.mistral` or `MISTRAL_API_KEY` (`MISTRAL_API_KEY` takes precedence). `/listen` also requires `ffmpeg` on your system and is currently supported only on macOS. `tau tool pdf-unpack` also requires `pdftoppm` from Poppler on your system.
+`/listen` and Telegram audio transcription use Mistral by default (`apiKeys.mistral` or `MISTRAL_API_KEY`, with `MISTRAL_API_KEY` taking precedence). set `speechToText.provider` to `gemini` to use Gemini 3.5 Flash instead (`apiKeys.google` or `GEMINI_API_KEY`). `/listen` also requires `ffmpeg` on your system and is currently supported only on macOS.
+
+`tau tool pdf-unpack` uses Mistral OCR (`apiKeys.mistral` or `MISTRAL_API_KEY`) and requires `pdftoppm` from Poppler on your system.
 
 `/speak` uses the Google provider (`apiKeys.google` or `GEMINI_API_KEY`) and is currently supported only on macOS.
 
@@ -399,7 +401,7 @@ the compact commands are manual and useful when you want to force a reset. they 
 
 the prune commands drop bash tool results from the active context without summarizing and compact edit call payloads/results. all three accept an optional fraction between `0` and `1` (for example, `/prune:largest 0.4`) and default to `0.25` when omitted. `/prune:smart` also accepts optional guidance text, either after a fraction (for example, `/prune:smart 0.3 keep only repetitive output`) or by itself (for example, `/prune:smart keep build logs`).
 
-`/listen` (or `ctrl+y`) starts microphone recording on macOS, including while the assistant is working. while recording, editor typing is disabled, and `ctrl+y` stops recording and starts transcription at the cursor. `esc` stops recording first without interrupting the assistant; press it again to interrupt active work. recording also auto-stops after 5 minutes. on Linux, `/listen` is currently unavailable and tau shows a warning.
+`/listen` (or `ctrl+y`) starts microphone recording on macOS, including while the assistant is working. while recording, editor typing is disabled, and `ctrl+y` stops recording and starts transcription at the cursor using the configured speech-to-text provider. `esc` stops recording first without interrupting the assistant; press it again to interrupt active work. recording also auto-stops after 5 minutes. on Linux, `/listen` is currently unavailable and tau shows a warning.
 
 `/speak` rewrites the last assistant message into naturally speakable text with Gemini 3.5 Flash, synthesizes audio with Gemini 3.1 Flash TTS, and starts playing on macOS at 1.4x speed as soon as the first speech chunk is ready.
 
@@ -467,6 +469,9 @@ model definitions can be extended and overridden through `~/.config/tau/models.j
     "reserveTokens": 16384,
     "keepRecentTokens": 20000
   },
+  "speechToText": {
+    "provider": "mistral"
+  },
   "modelSystemNotices": {
     "openai-codex/gpt-5.3-codex": "avoid apply_patch heredocs, use tau tools directly"
   }
@@ -480,6 +485,8 @@ the `defaultPersona` field specifies which persona to use when starting the app.
 the `defaultRisk` field sets the initial risk level (`read-only` or `read-write`). the `--risk` flag overrides this setting. if not specified, defaults to `read-only`.
 
 the `defaultTheme` field sets the theme id to load at startup. it must be non-empty, and matching is exact/case-sensitive. if not specified, it defaults to `gold`.
+
+`speechToText.provider` selects the `/listen` and Telegram audio transcription provider. supported values are `mistral` (default, uses Voxtral) and `gemini` (uses Gemini 3.5 Flash with minimal thinking).
 
 tau ships a built-in browser diff review demo tool, so `/diff` works without any `diffTool` config. set `diffTool` only when you want to override that default launcher. `command` is required when `diffTool` is present. `args` and `env` are optional. relative `command` paths resolve from the config level root (directory containing `.tau`, or home for the global config). set `builtInDiffTool.codeTheme` to choose the built-in diff tool's initial code theme, for example `{ "builtInDiffTool": { "codeTheme": "github-dark-dimmed" } }`. the default is `github-dark-dimmed`.
 

--- a/docs/async.md
+++ b/docs/async.md
@@ -209,14 +209,14 @@ Supported commands:
 - in DMs, plain text sends to the selected session (if no active session is selected and exactly one session exists, it is auto-selected)
 - in allowed groups, only messages that explicitly mention the bot username (`@botusername`) trigger a turn; non-triggering text/caption messages, attachments, audio transcripts, and processing errors are buffered as sender-attributed context and the last 50 pending messages since the previous bot-triggering turn are included with the triggering turn. attachment/audio processing runs eagerly for buffered context, but processing errors are reported to Telegram only after a later bot-triggering message is accepted
 - group commands must mention the bot, for example `/sessions@botusername`, `/sessions @botusername`, or `@botusername /sessions`; each group has one shared chat-scoped session namespace and one selected session
-- Telegram `voice` and `audio` messages are downloaded, transcribed with Mistral, and then sent to the selected session
+- Telegram `voice` and `audio` messages are downloaded, transcribed with the configured speech-to-text provider, and then sent to the selected session
 - attachments (`image/*`, PDF, `.txt`, `.md`, `.json`, `.csv`, `.yaml`, `.yml`) are downloaded to local temp files immediately, queued per session, and prepended to the next text/voice turn as local temp paths with mime, size, and caption metadata
   - attachment-only messages do not trigger a turn
   - captions are non-triggering and are preserved in the attachment metadata block
   - unsupported attachments and over-limit attachments are skipped with an immediate Telegram warning
   - limits: 10 attachments/turn, 20 MB/file, 50 MB/turn
 
-Telegram audio transcription requires `MISTRAL_API_KEY` (or `apiKeys.mistral` in regular tau config).
+Telegram audio transcription uses Mistral by default and requires `MISTRAL_API_KEY` (or `apiKeys.mistral` in regular tau config). set `speechToText.provider` to `gemini` to use Gemini 3.5 Flash instead, with `GEMINI_API_KEY` or `apiKeys.google`.
 
 When a plain-text or audio message is accepted for a session, the adapter tries to add a 👀 reaction to that user message (best effort).
 

--- a/src/core/async/cli.ts
+++ b/src/core/async/cli.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { createDefaultConfigDeps } from "../config/deps.js";
 import type { Config } from "../config/schema.js";
-import { getMistralApiKey, loadConfig } from "../config/schema.js";
+import { getGoogleApiKey, getMistralApiKey, loadConfig } from "../config/schema.js";
 import { AsyncDaemonRuntimeError, startAsyncDaemonRuntime } from "./daemon_runtime.js";
 import { AsyncDaemonConfigError, loadAsyncDaemonConfig } from "./server_config.js";
 import { createAsyncSessionManager } from "./session_manager.js";
@@ -597,6 +597,8 @@ async function runDaemon(args: {
   }
 
   const authToken = getTrimmedEnvValue("TAU_ASYNC_AUTH_TOKEN", args.env) ?? daemonConfig.authToken;
+  const speechToTextProvider = args.config.speechToText?.provider ?? "mistral";
+  const geminiApiKey = getGoogleApiKey(args.config, args.env);
   const mistralApiKey = getMistralApiKey(args.config, args.env);
 
   if (!authToken) {
@@ -626,6 +628,8 @@ async function runDaemon(args: {
     runtime = await startAsyncDaemonRuntime({
       daemonConfig,
       authToken,
+      speechToTextProvider,
+      geminiApiKey,
       mistralApiKey,
       sessionManager,
       onLog: args.stdout,

--- a/src/core/async/daemon_runtime.ts
+++ b/src/core/async/daemon_runtime.ts
@@ -1,3 +1,4 @@
+import type { SpeechToTextProvider } from "../config/schema.js";
 import { type AsyncCronScheduler, startAsyncCronScheduler } from "./cron.js";
 import { type AsyncHttpServerHandle, startAsyncHttpServer } from "./http_server.js";
 import type { AsyncDaemonConfig } from "./server_config.js";
@@ -13,6 +14,8 @@ type AsyncDaemonRuntimeDependencies = {
 export type StartAsyncDaemonRuntimeOptions = {
   daemonConfig: AsyncDaemonConfig;
   authToken: string;
+  speechToTextProvider?: SpeechToTextProvider;
+  geminiApiKey?: string;
   mistralApiKey?: string;
   sessionManager: AsyncSessionManager;
   onLog?: (line: string) => void;
@@ -138,6 +141,8 @@ export async function startAsyncDaemonRuntime(
         allowedChatIds: telegramConfig.allowedChatIds,
         pollIntervalMs: telegramConfig.pollIntervalMs,
         requestTimeoutSeconds: telegramConfig.requestTimeoutSeconds,
+        speechToTextProvider: options.speechToTextProvider,
+        geminiApiKey: options.geminiApiKey,
         mistralApiKey: options.mistralApiKey,
         sessionManager: options.sessionManager,
         onLog: (entry) => {

--- a/src/core/async/telegram.ts
+++ b/src/core/async/telegram.ts
@@ -2,8 +2,8 @@ import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, extname, join } from "node:path";
 import { z } from "zod";
-import type { AsyncProjectConfig } from "../config/schema.js";
-import { transcribeMistralAudio } from "../utils/mistral_transcription.js";
+import type { AsyncProjectConfig, SpeechToTextProvider } from "../config/schema.js";
+import { transcribeAudio } from "../utils/speech_to_text.js";
 import { formatZodError } from "../utils/zod.js";
 import {
   type AsyncSessionManager,
@@ -125,6 +125,8 @@ export type AsyncTelegramAdapterOptions = {
   allowedChatIds?: number[];
   pollIntervalMs?: number;
   requestTimeoutSeconds?: number;
+  speechToTextProvider?: SpeechToTextProvider;
+  geminiApiKey?: string;
   mistralApiKey?: string;
   sessionManager: AsyncSessionManager;
   api?: AsyncTelegramApi;
@@ -888,6 +890,8 @@ class AsyncTelegramAdapterImpl {
   private readonly botUsername: string;
   private readonly pollIntervalMs: number;
   private readonly requestTimeoutSeconds: number;
+  private readonly speechToTextProvider: SpeechToTextProvider;
+  private readonly geminiApiKey?: string;
   private readonly mistralApiKey?: string;
   private readonly sessionManager: AsyncSessionManager;
   private readonly enforceChatOwnership: boolean;
@@ -940,6 +944,8 @@ class AsyncTelegramAdapterImpl {
     this.botUsername = options.botUsername;
     this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
     this.requestTimeoutSeconds = options.requestTimeoutSeconds ?? DEFAULT_REQUEST_TIMEOUT_SECONDS;
+    this.speechToTextProvider = options.speechToTextProvider ?? "mistral";
+    this.geminiApiKey = options.geminiApiKey?.trim() || undefined;
     this.mistralApiKey = options.mistralApiKey?.trim() || undefined;
     this.sessionManager = options.sessionManager;
     this.enforceChatOwnership = true;
@@ -2395,13 +2401,24 @@ class AsyncTelegramAdapterImpl {
     }
   }
 
+  private getSpeechToTextApiKey(): string | undefined {
+    return this.speechToTextProvider === "gemini" ? this.geminiApiKey : this.mistralApiKey;
+  }
+
+  private getSpeechToTextApiKeyErrorMessage(action: string): string {
+    return this.speechToTextProvider === "gemini"
+      ? `set GEMINI_API_KEY or apiKeys.google to ${action}`
+      : `set MISTRAL_API_KEY or apiKeys.mistral to ${action}`;
+  }
+
   private async transcribeTelegramAudio(
     chatId: number,
     message: TelegramAudioMessage,
     options: { silent?: boolean } = {},
   ): Promise<TelegramAudioTranscriptionResult> {
-    if (!this.mistralApiKey) {
-      const error = "set MISTRAL_API_KEY or apiKeys.mistral to transcribe Telegram audio";
+    const apiKey = this.getSpeechToTextApiKey();
+    if (!apiKey) {
+      const error = this.getSpeechToTextApiKeyErrorMessage("transcribe Telegram audio");
       if (!options.silent) {
         await this.reply(chatId, error);
       }
@@ -2412,8 +2429,9 @@ class AsyncTelegramAdapterImpl {
     try {
       const audio = await this.api.downloadFile(message.fileId);
       transcript = (
-        await transcribeMistralAudio({
-          apiKey: this.mistralApiKey,
+        await transcribeAudio({
+          provider: this.speechToTextProvider,
+          apiKey,
           audio,
           fileName: message.fileName,
           mimeType: message.mimeType,

--- a/src/core/config/index.ts
+++ b/src/core/config/index.ts
@@ -17,10 +17,13 @@ export type {
   AsyncServerTelegramConfig,
   Config,
   NormalizedAutoCompactConfig,
+  SpeechToTextConfig,
+  SpeechToTextProvider,
 } from "./schema.js";
 export {
   DEFAULT_AUTO_COMPACT_CONFIG,
   getApiKeyForProvider,
+  getGoogleApiKey,
   getMistralApiKey,
   getParallelApiKey,
   loadConfig,

--- a/src/core/config/schema.ts
+++ b/src/core/config/schema.ts
@@ -35,11 +35,18 @@ export interface Config {
   };
   autoCompact?: AutoCompactConfig;
   modelSystemNotices?: Record<string, string>;
+  speechToText?: SpeechToTextConfig;
   async?: AsyncConfig;
 }
 
 export type BuiltInDiffToolConfig = {
   codeTheme?: string;
+};
+
+export type SpeechToTextProvider = "mistral" | "gemini";
+
+export type SpeechToTextConfig = {
+  provider: SpeechToTextProvider;
 };
 
 export type AutoCompactConfig = {
@@ -185,6 +192,7 @@ const KNOWN_TOP_LEVEL_CONFIG_KEYS = new Set([
   "subagents",
   "autoCompact",
   "modelSystemNotices",
+  "speechToText",
   "async",
 ]);
 
@@ -193,6 +201,11 @@ const BooleanSchema = z.boolean();
 const AgentContextFilesSchema = z.array(NonEmptyStringSchema);
 const ApiKeyProviderSchema = z.string();
 const ApiKeysSchema = z.object({}).catchall(z.unknown());
+const SpeechToTextConfigSchema = z
+  .object({
+    provider: z.enum(["mistral", "gemini"]),
+  })
+  .passthrough();
 const SubagentsConfigSchema = z
   .object({
     defaultLaunchModels: z.array(z.string()).optional(),
@@ -455,6 +468,15 @@ function validateConfigData(
     modelSystemNoticesResult.errors,
   );
 
+  const speechToTextResult = parseSpeechToTextConfig(data.speechToText, sourceLabel);
+  assignParsedConfigValue(
+    config,
+    errors,
+    "speechToText",
+    speechToTextResult.config,
+    speechToTextResult.errors,
+  );
+
   const asyncResult = parseAsyncConfig(data.async, sourceLabel);
   assignParsedConfigValue(config, errors, "async", asyncResult.config, asyncResult.errors);
 
@@ -503,6 +525,27 @@ function parseBuiltInDiffToolConfig(
   }
 
   return { config: Object.keys(config).length > 0 ? config : undefined, errors: [] };
+}
+
+function parseSpeechToTextConfig(
+  raw: unknown,
+  sourceLabel: string,
+): { config?: SpeechToTextConfig; errors: string[] } {
+  if (raw === undefined) {
+    return { errors: [] };
+  }
+
+  const parsed = SpeechToTextConfigSchema.safeParse(raw);
+  if (!parsed.success) {
+    if (parsed.error.issues.some((issue) => issue.path[0] === "provider")) {
+      return {
+        errors: [`${sourceLabel}: speechToText.provider must be 'mistral' or 'gemini'.`],
+      };
+    }
+    return { errors: [`${sourceLabel}: 'speechToText' must be an object.`] };
+  }
+
+  return { config: { provider: parsed.data.provider }, errors: [] };
 }
 
 function parseSubagentsConfig(
@@ -947,6 +990,7 @@ function mergeConfigLevels(levels: ConfigLevel[], configs: Config[]): Config {
   let builtInDiffTool: BuiltInDiffToolConfig | undefined;
   let subagents: Config["subagents"] | undefined;
   let modelSystemNotices: Config["modelSystemNotices"] | undefined;
+  let speechToText: SpeechToTextConfig | undefined;
   let asyncConfig: AsyncConfig | undefined;
   const bashCommands = new Map<string, BashCommand>();
   const agentContextFiles: string[] = [];
@@ -967,6 +1011,9 @@ function mergeConfigLevels(levels: ConfigLevel[], configs: Config[]): Config {
       merged.autoCompact = mergeOptionalObject(merged.autoCompact, config.autoCompact);
     }
     modelSystemNotices = mergeOptionalObject(modelSystemNotices, config.modelSystemNotices);
+    if (config.speechToText !== undefined) {
+      speechToText = { ...config.speechToText };
+    }
     asyncConfig = mergeAsyncConfig(asyncConfig, config.async);
 
     if (config.defaultPersona !== undefined) {
@@ -1018,6 +1065,10 @@ function mergeConfigLevels(levels: ConfigLevel[], configs: Config[]): Config {
 
   if (modelSystemNotices && Object.keys(modelSystemNotices).length > 0) {
     merged.modelSystemNotices = modelSystemNotices;
+  }
+
+  if (speechToText) {
+    merged.speechToText = speechToText;
   }
 
   if (asyncConfig && Object.keys(asyncConfig).length > 0) {
@@ -1099,6 +1150,16 @@ export function getParallelApiKey(config: Config, env?: NodeJS.ProcessEnv): stri
   }
 
   const configKey = config.apiKeys?.parallel?.trim();
+  return configKey || undefined;
+}
+
+export function getGoogleApiKey(config: Config, env?: NodeJS.ProcessEnv): string | undefined {
+  const envKey = getTrimmedEnvValue("GEMINI_API_KEY", env);
+  if (envKey) {
+    return envKey;
+  }
+
+  const configKey = config.apiKeys?.google?.trim();
   return configKey || undefined;
 }
 

--- a/src/core/utils/gemini_transcription.ts
+++ b/src/core/utils/gemini_transcription.ts
@@ -1,0 +1,164 @@
+import { z } from "zod";
+
+const GEMINI_GENERATE_CONTENT_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/models";
+const DEFAULT_GEMINI_TRANSCRIPTION_MODEL = "gemini-3.5-flash";
+const DEFAULT_GEMINI_TRANSCRIPTION_THINKING_LEVEL = "minimal";
+const DEFAULT_GEMINI_AUDIO_MIME_TYPE = "audio/wav";
+
+const errorPayloadSchema = z.object({
+  error: z
+    .object({
+      message: z.string().trim().min(1).optional(),
+      status: z.string().trim().min(1).optional(),
+      code: z.number().int().optional(),
+    })
+    .optional(),
+});
+
+const GEMINI_TRANSCRIPTION_RESPONSE_SCHEMA = {
+  type: "OBJECT",
+  properties: {
+    transcription: { type: "STRING" },
+  },
+  required: ["transcription"],
+};
+
+const textPartSchema = z.object({ text: z.string() });
+const apiResponseSchema = z.object({
+  candidates: z
+    .array(
+      z.object({
+        content: z.object({
+          parts: z.array(z.unknown()).optional(),
+        }),
+      }),
+    )
+    .optional(),
+});
+const transcriptionResultSchema = z.object({
+  transcription: z.string(),
+});
+
+export type GeminiTranscriptionOptions = {
+  apiKey: string;
+  audio: Buffer;
+  model?: string;
+  mimeType?: string;
+  fetchImpl?: typeof fetch;
+};
+
+export async function transcribeGeminiAudio(options: GeminiTranscriptionOptions): Promise<string> {
+  const apiKey = options.apiKey.trim();
+  if (!apiKey) {
+    throw new Error("missing Gemini API key");
+  }
+
+  const fetchFn = options.fetchImpl ?? fetch;
+  const model = options.model ?? DEFAULT_GEMINI_TRANSCRIPTION_MODEL;
+  const response = await fetchFn(
+    `${GEMINI_GENERATE_CONTENT_BASE_URL}/${encodeURIComponent(model)}:generateContent`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-goog-api-key": apiKey,
+      },
+      body: JSON.stringify({
+        systemInstruction: {
+          parts: [
+            {
+              text: buildTranscriptionSystemInstruction(),
+            },
+          ],
+        },
+        contents: [
+          {
+            parts: [
+              {
+                text: buildTranscriptionPrompt(),
+              },
+              {
+                inlineData: {
+                  mimeType: options.mimeType ?? DEFAULT_GEMINI_AUDIO_MIME_TYPE,
+                  data: options.audio.toString("base64"),
+                },
+              },
+            ],
+          },
+        ],
+        generationConfig: {
+          responseMimeType: "application/json",
+          responseSchema: GEMINI_TRANSCRIPTION_RESPONSE_SCHEMA,
+          thinkingConfig: {
+            thinkingLevel: DEFAULT_GEMINI_TRANSCRIPTION_THINKING_LEVEL,
+          },
+        },
+      }),
+    },
+  );
+
+  const responseText = await response.text();
+  let payload: unknown;
+  try {
+    payload = responseText ? (JSON.parse(responseText) as unknown) : undefined;
+  } catch {
+    payload = undefined;
+  }
+
+  if (!response.ok) {
+    const parsed = errorPayloadSchema.safeParse(payload);
+    const fallbackMessage = responseText.trim() || `HTTP ${response.status}`;
+    throw new Error(
+      parsed.success ? (parsed.data.error?.message ?? fallbackMessage) : fallbackMessage,
+    );
+  }
+
+  return extractGeminiText(payload).trim();
+}
+
+function buildTranscriptionSystemInstruction(): string {
+  return [
+    "You are a speech-to-text engine.",
+    "Transcribe the speaker's intended message for insertion into a chat input.",
+    "Detect the speaker's language and transcribe in that same language; never translate unless the speaker explicitly asks for translation.",
+    "Preserve the speaker's wording and register as spoken, including colloquial forms, dialect, and informal language; do not normalize informal speech into formal standard language.",
+    "Use natural punctuation and capitalization where helpful, without changing the speaker's wording or register.",
+    "Lightly clean only speech artifacts that do not affect meaning, such as filler words, repeated stutters, obvious false starts, and unintelligible mumbling.",
+    "Do not rewrite, paraphrase, summarize, answer the speaker, add labels, add timestamps, or describe background sounds.",
+  ].join("\n");
+}
+
+function buildTranscriptionPrompt(): string {
+  return [
+    "Transcribe the attached audio into the transcription field.",
+    "Return only the lightly cleaned transcript text, with no timestamps or commentary.",
+  ].join("\n");
+}
+
+function extractGeminiText(payload: unknown): string {
+  const parsed = apiResponseSchema.safeParse(payload);
+  if (!parsed.success) {
+    return "";
+  }
+
+  const responseText = (parsed.data.candidates?.[0]?.content.parts ?? [])
+    .map((part) => {
+      const parsedPart = textPartSchema.safeParse(part);
+      return parsedPart.success ? parsedPart.data.text : "";
+    })
+    .join("");
+
+  let transcriptionPayload: unknown;
+  try {
+    transcriptionPayload = responseText ? (JSON.parse(responseText) as unknown) : undefined;
+  } catch {
+    return "";
+  }
+
+  const transcription = transcriptionResultSchema.safeParse(transcriptionPayload);
+  if (!transcription.success) {
+    return "";
+  }
+
+  return transcription.data.transcription;
+}

--- a/src/core/utils/speech_to_text.ts
+++ b/src/core/utils/speech_to_text.ts
@@ -1,0 +1,34 @@
+import type { SpeechToTextProvider } from "../config/schema.js";
+import { transcribeGeminiAudio } from "./gemini_transcription.js";
+import { transcribeMistralAudio } from "./mistral_transcription.js";
+
+export type SpeechToTextOptions = {
+  provider: SpeechToTextProvider;
+  apiKey: string;
+  audio: Buffer;
+  mimeType?: string;
+  fileName?: string;
+  language?: string;
+  fetchImpl?: typeof fetch;
+};
+
+export async function transcribeAudio(options: SpeechToTextOptions): Promise<string> {
+  switch (options.provider) {
+    case "gemini":
+      return await transcribeGeminiAudio({
+        apiKey: options.apiKey,
+        audio: options.audio,
+        mimeType: options.mimeType,
+        fetchImpl: options.fetchImpl,
+      });
+    case "mistral":
+      return await transcribeMistralAudio({
+        apiKey: options.apiKey,
+        audio: options.audio,
+        mimeType: options.mimeType,
+        fileName: options.fileName,
+        language: options.language,
+        fetchImpl: options.fetchImpl,
+      });
+  }
+}

--- a/src/tui/chat_controller.ts
+++ b/src/tui/chat_controller.ts
@@ -24,9 +24,11 @@ import {
   type Config,
   createDefaultConfigDeps,
   type DiffToolConfig,
+  getGoogleApiKey,
   getMistralApiKey,
   loadRuntimeConfig,
   type RuntimeConfigResult,
+  type SpeechToTextProvider,
   type ThemeDefinition,
 } from "../core/config/index.js";
 import type {
@@ -76,10 +78,10 @@ import {
 } from "../core/utils/format.js";
 import { streamGeminiSpeechAudio } from "../core/utils/gemini_speech.js";
 import { extractAllFencedCodeBlocks, extractAssistantText } from "../core/utils/messages.js";
-import { transcribeMistralAudio } from "../core/utils/mistral_transcription.js";
 import { streamModel } from "../core/utils/model_stream.js";
 import { listProjectFilesAsync } from "../core/utils/project_files.js";
 import type { SpawnCaptureResult } from "../core/utils/spawn_capture.js";
+import { transcribeAudio } from "../core/utils/speech_to_text.js";
 import {
   getAutoCompactionMetadataFromMessage,
   hasAutoCompactionContinuationMetadata,
@@ -1629,9 +1631,9 @@ export class ChatController {
       return;
     }
 
-    const apiKey = getMistralApiKey(this.config, this.deps.env.env());
+    const apiKey = this.getSpeechToTextApiKey();
     if (!apiKey) {
-      this.view.addSystemMessage("set MISTRAL_API_KEY or apiKeys.mistral to use /listen", "error");
+      this.view.addSystemMessage(this.getSpeechToTextApiKeyErrorMessage("use /listen"), "error");
       return;
     }
 
@@ -1810,13 +1812,33 @@ export class ChatController {
     return path;
   }
 
+  private getSpeechToTextProvider(): SpeechToTextProvider {
+    return this.config.speechToText?.provider ?? "mistral";
+  }
+
+  private getSpeechToTextApiKey(): string | undefined {
+    const provider = this.getSpeechToTextProvider();
+    return provider === "gemini"
+      ? getGoogleApiKey(this.config, this.deps.env.env())
+      : getMistralApiKey(this.config, this.deps.env.env());
+  }
+
+  private getSpeechToTextApiKeyErrorMessage(action: string): string {
+    const provider = this.getSpeechToTextProvider();
+    return provider === "gemini"
+      ? `set GEMINI_API_KEY or apiKeys.google to ${action}`
+      : `set MISTRAL_API_KEY or apiKeys.mistral to ${action}`;
+  }
+
   private async transcribeListenAudio(audio: Buffer): Promise<string> {
-    const apiKey = getMistralApiKey(this.config, this.deps.env.env());
+    const provider = this.getSpeechToTextProvider();
+    const apiKey = this.getSpeechToTextApiKey();
     if (!apiKey) {
-      throw new Error("missing MISTRAL_API_KEY or apiKeys.mistral");
+      throw new Error(this.getSpeechToTextApiKeyErrorMessage("transcribe speech"));
     }
 
-    return await transcribeMistralAudio({
+    return await transcribeAudio({
+      provider,
       apiKey,
       audio,
       mimeType: "audio/wav",

--- a/test/async_telegram.test.js
+++ b/test/async_telegram.test.js
@@ -893,6 +893,93 @@ describe("async telegram adapter", () => {
     }
   });
 
+  it("transcribes voice messages with Gemini when configured", async () => {
+    const apiHarness = createApiHarness([
+      [
+        {
+          update_id: 1,
+          message: {
+            chat: { id: 211, type: "private" },
+            from: { id: 7 },
+            text: "/use s22",
+          },
+        },
+        {
+          update_id: 2,
+          message: {
+            chat: { id: 211, type: "private" },
+            from: { id: 7 },
+            voice: {
+              file_id: "voice-456",
+              mime_type: "audio/ogg",
+            },
+          },
+        },
+      ],
+    ]);
+
+    const managerHarness = createSessionManagerHarness(
+      [
+        {
+          id: "s22",
+          projectId: "demo",
+          state: "waiting-input",
+          createdAt: "2024-01-01T00:00:00.000Z",
+          updatedAt: "2024-01-01T00:00:00.000Z",
+        },
+      ],
+      { defaultOwnerId: ownerIdForChat(211) },
+    );
+
+    const geminiFetch = vi.fn(async () =>
+      createJsonResponse({
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  text: JSON.stringify({
+                    transcription: "use google transcription",
+                  }),
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    );
+
+    const adapter = await startAdapter({
+      botToken: "token",
+      projects: { demo: { repo: "git@example.com:demo.git" } },
+      speechToTextProvider: "gemini",
+      geminiApiKey: "gemini-key",
+      sessionManager: managerHarness.manager,
+      api: apiHarness.api,
+      fetchImpl: geminiFetch,
+      pollIntervalMs: 1,
+      requestTimeoutSeconds: 1,
+    });
+
+    try {
+      await waitFor(() => managerHarness.manager.sendMessage.mock.calls.length === 1);
+      expect(apiHarness.downloadFileCalls).toEqual(["voice-456"]);
+      expect(managerHarness.manager.sendMessage).toHaveBeenCalledWith(
+        "s22",
+        "use google transcription",
+        undefined,
+      );
+      expect(geminiFetch).toHaveBeenCalledTimes(1);
+      const request = JSON.parse(geminiFetch.mock.calls[0][1].body);
+      expect(request.generationConfig.responseMimeType).toBe("application/json");
+      expect(request.generationConfig.responseSchema.required).toEqual(["transcription"]);
+      expect(request.generationConfig.thinkingConfig.thinkingLevel).toBe("minimal");
+      expect(request.contents[0].parts[1].inlineData.mimeType).toBe("audio/ogg");
+    } finally {
+      await adapter.close();
+    }
+  });
+
   it("supports /close all for waiting-input and failed sessions", async () => {
     const apiHarness = createApiHarness([
       [

--- a/test/config_layers.test.js
+++ b/test/config_layers.test.js
@@ -102,6 +102,7 @@ describe("config paths", () => {
           subagents: {
             defaultLaunchModels: ["anthropic/claude-haiku-4-5:low"],
           },
+          speechToText: { provider: "mistral" },
           autoCompact: { enabled: false, reserveTokens: 1000 },
           modelSystemNotices: {
             "openai/gpt-5.4": "global codex notice",
@@ -128,6 +129,7 @@ describe("config paths", () => {
           subagents: {
             defaultLaunchModels: ["openai/gpt-5.4:high"],
           },
+          speechToText: { provider: "gemini" },
           autoCompact: { keepRecentTokens: 2000 },
           modelSystemNotices: {
             "openai/gpt-5.4": "repo codex notice",
@@ -176,6 +178,7 @@ describe("config paths", () => {
       expect(config.subagents).toEqual({
         defaultLaunchModels: ["openai/gpt-5.4:high"],
       });
+      expect(config.speechToText).toEqual({ provider: "gemini" });
       expect(config.autoCompact).toEqual({
         enabled: false,
         reserveTokens: 1000,

--- a/test/gemini_transcription.test.js
+++ b/test/gemini_transcription.test.js
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import { transcribeGeminiAudio } from "../dist/core/utils/gemini_transcription.js";
+
+describe("gemini transcription", () => {
+  it("transcribes audio with minimal thinking", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            candidates: [
+              {
+                content: {
+                  parts: [
+                    {
+                      text: JSON.stringify({
+                        transcription: "ship the fix",
+                      }),
+                    },
+                  ],
+                },
+              },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+
+    const transcript = await transcribeGeminiAudio({
+      apiKey: "gemini-key",
+      audio: Buffer.from("audio payload"),
+      mimeType: "audio/ogg",
+      fetchImpl: fetchMock,
+    });
+
+    expect(transcript).toBe("ship the fix");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toContain(
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent",
+    );
+    expect(fetchMock.mock.calls[0][1].headers["x-goog-api-key"]).toBe("gemini-key");
+
+    const request = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(request.systemInstruction.parts[0].text).toContain("You are a speech-to-text engine.");
+    expect(request.systemInstruction.parts[0].text).toContain(
+      "Transcribe the speaker's intended message for insertion into a chat input.",
+    );
+    expect(request.systemInstruction.parts[0].text).toContain(
+      "Detect the speaker's language and transcribe in that same language",
+    );
+    expect(request.systemInstruction.parts[0].text).toContain(
+      "do not normalize informal speech into formal standard language",
+    );
+    expect(request.systemInstruction.parts[0].text).toContain(
+      "Lightly clean only speech artifacts that do not affect meaning",
+    );
+    expect(request.contents[0].parts[0].text).toContain(
+      "Transcribe the attached audio into the transcription field.",
+    );
+    expect(request.contents[0].parts[1].inlineData.mimeType).toBe("audio/ogg");
+    expect(request.contents[0].parts[1].inlineData.data).toBe(
+      Buffer.from("audio payload").toString("base64"),
+    );
+    expect(request.generationConfig.responseMimeType).toBe("application/json");
+    expect(request.generationConfig.responseSchema).toEqual({
+      type: "OBJECT",
+      properties: {
+        transcription: { type: "STRING" },
+      },
+      required: ["transcription"],
+    });
+    expect(request.generationConfig.thinkingConfig.thinkingLevel).toBe("minimal");
+  });
+});


### PR DESCRIPTION
- add `speechToText.provider` with `mistral` default and `gemini` alternative
- route `/listen` and Telegram audio transcription through shared speech-to-text dispatch
- add Gemini 3.5 Flash transcription with structured JSON output and minimal thinking
- update docs and tests

verification: `npm test`
