### PR TITLE
collapse queued messages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,7 +296,7 @@ Slash commands only trigger on single-line inputs. `/diff` treats its payload as
 
 RPC mode command surface is protocol-based (`initialize`, `session.submit`, `session.interrupt`, `session.snapshot`, `session.reset`, `session.shutdown`) over NDJSON stdin/stdout.
 
-**Keybindings**: `Shift+Tab` (cycle reasoning), `Ctrl+R` (cycle risk level), `Ctrl+P` (cycle personality), `Ctrl+T` (toggle thinking), `Ctrl+O` (compact UI), `Ctrl+F` (expand @<file> and @@skill:<name> mentions), `Ctrl+S` (stash input to clipboard), `Ctrl+Y` (toggle voice recording for `/listen`), `Ctrl+G` (terminate selected subagent), `Enter x2` (retry last response on empty input), `Escape x2` (clear current prompt), `Alt+Up` (pop queued message), `Alt+Down` (cycle active subagents), `Escape` (interrupt active work, including cancelling `/diff`), `Ctrl+C` (press twice to exit)
+**Keybindings**: `Shift+Tab` (cycle reasoning), `Ctrl+R` (cycle risk level), `Ctrl+P` (cycle personality), `Ctrl+T` (toggle thinking), `Ctrl+O` (compact UI), `Ctrl+F` (expand @<file> and @@skill:<name> mentions), `Ctrl+S` (stash input to clipboard), `Ctrl+Y` (toggle voice recording for `/listen`), `Ctrl+G` (terminate selected subagent), `Enter x2` (retry last response on empty input), `Escape x2` (clear current prompt), `Alt+Up` (pop queued message), `Alt+C` (collapse queued messages into one), `Alt+Down` (cycle active subagents), `Escape` (interrupt active work, including cancelling `/diff`), `Ctrl+C` (press twice to exit)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -426,6 +426,7 @@ the main assistant also has a TUI-only `diff_review` tool. it uses the same capt
 | `enter x2`  | retry last response on empty input         |
 | `esc x2`    | clear current prompt                       |
 | `alt+up`    | pop queued message                         |
+| `alt+c`     | collapse queued messages into one          |
 | `alt+down`  | cycle active sub-agents                    |
 | `esc`       | interrupt active task or cancel `/diff`    |
 | `ctrl+c`    | press twice to exit                        |

--- a/src/tui/chat_controller.ts
+++ b/src/tui/chat_controller.ts
@@ -488,6 +488,7 @@ export class ChatController {
       },
       onAltUp: () => this.popQueuedUserMessageIntoEditor(),
       onAltDown: () => this.cycleSubagentSelection(),
+      onAltC: () => this.collapseQueuedUserMessages(),
       onCtrlG: () => this.terminateSelectedSubagent(),
       beforeSubmit: (text: string) => this.beforeSubmit(text),
       onChange: (text: string) => this.handleEditorChange(text),
@@ -1333,6 +1334,12 @@ export class ChatController {
       getEditorText: () => this.view.getEditorText(),
       setEditorText: (text) => this.view.setEditorText(text),
     });
+  }
+
+  private collapseQueuedUserMessages(): void {
+    if (this.queuedMessageBuffer.collapse()) {
+      this.view.requestRender();
+    }
   }
 
   private dequeueQueuedUserMessagesIntoEditor(): void {

--- a/src/tui/chat_controller/queued_user_messages.ts
+++ b/src/tui/chat_controller/queued_user_messages.ts
@@ -34,6 +34,15 @@ export class QueuedUserMessages {
     editor.setEditorText(last);
   }
 
+  collapse(): boolean {
+    if (this.messages.length < 2) return false;
+
+    const collapsed = this.messages.join("\n\n---\n\n");
+    this.messages.length = 0;
+    this.messages.push(collapsed);
+    return true;
+  }
+
   dequeueIntoEditor(editor: EditorAdapter): void {
     if (this.messages.length === 0) return;
 

--- a/src/tui/chat_view.ts
+++ b/src/tui/chat_view.ts
@@ -55,6 +55,7 @@ export type ChatViewInputHandlers = {
   onCtrlF?: () => void;
   onAltUp?: () => void;
   onAltDown?: () => void;
+  onAltC?: () => void;
   onCtrlG?: () => void;
   beforeSubmit?: (text: string) => boolean;
   onChange?: (text: string) => void;
@@ -398,6 +399,7 @@ export class TuiChatView implements ChatView {
     this.editor.onCtrlF = handlers.onCtrlF;
     this.editor.onAltUp = handlers.onAltUp;
     this.editor.onAltDown = handlers.onAltDown;
+    this.editor.onAltC = handlers.onAltC;
     this.editor.onCtrlG = handlers.onCtrlG;
     this.editor.beforeSubmit = handlers.beforeSubmit;
     this.editor.onChange = handlers.onChange;

--- a/src/tui/ui/custom_editor.ts
+++ b/src/tui/ui/custom_editor.ts
@@ -37,6 +37,7 @@ export class CustomEditor extends Editor {
   public onCtrlG?: () => void;
   public onAltUp?: () => void;
   public onAltDown?: () => void;
+  public onAltC?: () => void;
   public beforeSubmit?: (text: string) => boolean;
 
   constructor(theme: Theme) {
@@ -125,6 +126,7 @@ export class CustomEditor extends Editor {
     const isEscape = matchesKey(data, Key.escape);
     const isAltUp = matchesKey(data, Key.alt("up")) || data === "\x1b[1;3A";
     const isAltDown = matchesKey(data, Key.alt("down")) || data === "\x1b[1;3B";
+    const isAltC = matchesKey(data, Key.alt("c")) || data === "\x1bc";
 
     if (!isEscape) {
       this.lastEscapeAt = undefined;
@@ -189,6 +191,11 @@ export class CustomEditor extends Editor {
 
     if (isAltDown && this.onAltDown && !this.isShowingAutocomplete()) {
       this.onAltDown();
+      return;
+    }
+
+    if (isAltC && this.onAltC && !this.isShowingAutocomplete()) {
+      this.onAltC();
       return;
     }
 

--- a/src/tui/ui/queued_messages.ts
+++ b/src/tui/ui/queued_messages.ts
@@ -24,7 +24,7 @@ export class QueuedMessagesComponent implements Component {
 
     const { palette, markdownTheme } = this.theme;
     const lines: string[] = [];
-    const headerRaw = `queued (${this.messages.length}) — alt+up to edit next`;
+    const headerRaw = `queued (${this.messages.length}) — alt+up edit · alt+c collapse`;
     const headerPad = " ";
     const headerWidth = Math.max(0, width - visibleWidth(headerPad));
     lines.push(palette.textDim(`${headerPad}${truncateToWidth(headerRaw, headerWidth, "…")}`));

--- a/test/queued_user_messages.test.js
+++ b/test/queued_user_messages.test.js
@@ -37,6 +37,15 @@ describe("QueuedUserMessages", () => {
     expect(queue).toEqual([]);
   });
 
+  it("collapses queued messages into one message", () => {
+    const queue = ["one", "two", "three"];
+    const manager = new QueuedUserMessages(queue);
+
+    expect(manager.collapse()).toBe(true);
+
+    expect(queue).toEqual(["one\n\n---\n\ntwo\n\n---\n\nthree"]);
+  });
+
   it("fires pending idle notification once after draining", async () => {
     const queue = [];
     const manager = new QueuedUserMessages(queue);

--- a/test/ui_components.test.js
+++ b/test/ui_components.test.js
@@ -262,7 +262,7 @@ test("QueuedMessagesComponent renders numbered, italicized previews", () => {
   const theme = createTagTheme();
   const component = new QueuedMessagesComponent(theme, ["first line\nsecond", "third"]);
   const lines = renderLines(component, 80);
-  expect(lines[0]).toBe("<textDim> queued (2) — alt+up to edit next</textDim>");
+  expect(lines[0]).toBe("<textDim> queued (2) — alt+up edit · alt+c collapse</textDim>");
   expect(lines[1]).toBe(
     "<textDim>  1› </textDim><italic><textMuted>first line</textMuted></italic>",
   );


### PR DESCRIPTION
Adds an `alt+c` keybinding to collapse queued messages into a single queued message, updates the queued-message hint, and covers the behavior in tests.

fixes #224
