### PR TITLE
add TUI steering controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,7 +296,7 @@ Slash commands only trigger on single-line inputs. `/diff` treats its payload as
 
 RPC mode command surface is protocol-based (`initialize`, `session.submit`, `session.interrupt`, `session.snapshot`, `session.reset`, `session.shutdown`) over NDJSON stdin/stdout.
 
-**Keybindings**: `Shift+Tab` (cycle reasoning), `Ctrl+R` (cycle risk level), `Ctrl+P` (cycle personality), `Ctrl+T` (toggle thinking), `Ctrl+O` (compact UI), `Ctrl+F` (expand @<file> and @@skill:<name> mentions), `Ctrl+S` (stash input to clipboard), `Ctrl+Y` (toggle voice recording for `/listen`), `Ctrl+G` (terminate selected subagent), `Enter x2` (retry last response on empty input), `Escape x2` (clear current prompt), `Alt+Up` (pop queued message), `Alt+C` (collapse queued messages into one), `Alt+Down` (cycle active subagents), `Escape` (interrupt active work, including cancelling `/diff`), `Ctrl+C` (press twice to exit)
+**Keybindings**: `Shift+Tab` (cycle reasoning), `Ctrl+R` (cycle risk level), `Ctrl+P` (cycle personality), `Ctrl+T` (toggle thinking), `Ctrl+O` (compact UI), `Ctrl+F` (expand @<file> and @@skill:<name> mentions), `Ctrl+S` (stash input to clipboard), `Ctrl+Y` (toggle voice recording for `/listen`), `Ctrl+G` (terminate selected subagent), `Ctrl+Enter` (steer running assistant with editor input), `Alt+S` (steer running assistant with queued messages), `Enter x2` (retry last response on empty input), `Escape x2` (clear current prompt), `Alt+Up` (pop queued message), `Alt+C` (collapse queued messages into one), `Alt+Down` (cycle active subagents), `Escape` (interrupt active work, including cancelling `/diff`), `Ctrl+C` (press twice to exit)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -412,24 +412,26 @@ the main assistant also has a TUI-only `diff_review` tool. it uses the same capt
 
 ## keyboard shortcuts
 
-| key         | action                                     |
-| ----------- | ------------------------------------------ |
-| `shift+tab` | cycle reasoning effort                     |
-| `ctrl+r`    | cycle risk level                           |
-| `ctrl+p`    | cycle personality                          |
-| `ctrl+t`    | toggle thinking visibility                 |
-| `ctrl+o`    | toggle compact tool display                |
-| `ctrl+f`    | expand @<file> and @@skill:<name> mentions |
-| `ctrl+s`    | stash input to clipboard                   |
-| `ctrl+y`    | toggle voice recording (`/listen`)         |
-| `ctrl+g`    | terminate selected sub-agent               |
-| `enter x2`  | retry last response on empty input         |
-| `esc x2`    | clear current prompt                       |
-| `alt+up`    | pop queued message                         |
-| `alt+c`     | collapse queued messages into one          |
-| `alt+down`  | cycle active sub-agents                    |
-| `esc`       | interrupt active task or cancel `/diff`    |
-| `ctrl+c`    | press twice to exit                        |
+| key          | action                                       |
+| ------------ | -------------------------------------------- |
+| `shift+tab`  | cycle reasoning effort                       |
+| `ctrl+r`     | cycle risk level                             |
+| `ctrl+p`     | cycle personality                            |
+| `ctrl+t`     | toggle thinking visibility                   |
+| `ctrl+o`     | toggle compact tool display                  |
+| `ctrl+f`     | expand @<file> and @@skill:<name> mentions   |
+| `ctrl+s`     | stash input to clipboard                     |
+| `ctrl+y`     | toggle voice recording (`/listen`)           |
+| `ctrl+g`     | terminate selected sub-agent                 |
+| `ctrl+enter` | steer running assistant with editor input    |
+| `alt+s`      | steer running assistant with queued messages |
+| `enter x2`   | retry last response on empty input           |
+| `esc x2`     | clear current prompt                         |
+| `alt+up`     | pop queued message                           |
+| `alt+c`      | collapse queued messages into one            |
+| `alt+down`   | cycle active sub-agents                      |
+| `esc`        | interrupt active task or cancel `/diff`      |
+| `ctrl+c`     | press twice to exit                          |
 
 ## configuration
 

--- a/src/core/commands/registry.ts
+++ b/src/core/commands/registry.ts
@@ -207,6 +207,8 @@ export class CommandRegistry<Ctx = unknown> {
       ["ctrl+f", "expand @<file> and @@skill:<name> mentions"],
       ["ctrl+s", "stash input to clipboard"],
       ["ctrl+y", "toggle voice recording"],
+      ["ctrl+enter", "steer running assistant with editor input"],
+      ["alt+s", "steer running assistant with queued messages"],
       ["enter x2", "retry last response"],
       ["esc x2", "clear current prompt"],
       ["esc", "interrupt active task"],

--- a/src/core/modes/rpc_server.ts
+++ b/src/core/modes/rpc_server.ts
@@ -2,6 +2,7 @@ import { createInterface } from "node:readline";
 import type { Message } from "@earendil-works/pi-ai";
 import { type CoreEvent, wrapCoreEvent } from "../events/types.js";
 import type { ChatRuntime } from "../runtime/chat_runtime.js";
+import { formatSteeringUserMessage } from "../runtime/steering.js";
 import type { HistoryEntry } from "../session/core_session.js";
 import {
   createRpcErrorResponse,
@@ -250,7 +251,7 @@ export class RpcServer {
       const preferredHistoryEntryId =
         requests.length === 1 ? primaryRequest.params.historyEntryId : undefined;
       const userHistoryEntryId = this.runtime.session.addUserText(
-        this.formatSteeringUserMessage(requests.map((item) => item.params.text)),
+        formatSteeringUserMessage(requests.map((item) => item.params.text)),
         preferredHistoryEntryId ? { historyEntryId: preferredHistoryEntryId } : undefined,
       );
       this.submitRequestByUserHistoryEntryId.set(userHistoryEntryId, primaryRequest.id);
@@ -315,14 +316,6 @@ export class RpcServer {
         );
       }
     }
-  }
-
-  private formatSteeringUserMessage(messages: string[]): string {
-    const guidance =
-      "The user sent the following message(s) while you were already working. Treat them as steering for the current task: incorporate them immediately, adjust your plan if needed, and do not continue down the previous path if this changes the requested direction.";
-    const body = messages.join("\n\n");
-
-    return `<system>\n${guidance}\n</system>\n${body}`;
   }
 
   private handleInterrupt(

--- a/src/core/runtime/steering.ts
+++ b/src/core/runtime/steering.ts
@@ -1,0 +1,8 @@
+const STEERING_GUIDANCE =
+  "The user sent the following message(s) while you were already working. Treat them as steering for the current task: incorporate them immediately, adjust your plan if needed, and do not continue down the previous path if this changes the requested direction.";
+
+export function formatSteeringUserMessage(messages: string[]): string {
+  const body = messages.join("\n\n");
+
+  return `<system>\n${STEERING_GUIDANCE}\n</system>\n${body}`;
+}

--- a/src/tui/chat_controller.ts
+++ b/src/tui/chat_controller.ts
@@ -46,6 +46,7 @@ import {
   resolveProjectContextForPromptContext,
   resolveRuntimePromptBootstrap,
 } from "../core/runtime/runtime_bootstrap.js";
+import { formatSteeringUserMessage } from "../core/runtime/steering.js";
 import { createCheckpoint } from "../core/session/checkpoint.js";
 import type { CoreSession } from "../core/session/core_session.js";
 import {
@@ -93,7 +94,10 @@ import {
   DiffReviewService,
 } from "./chat_controller/diff_review_service.js";
 import { type BusyTask, InterruptLifecycle } from "./chat_controller/interrupt_lifecycle.js";
-import { QueuedUserMessages } from "./chat_controller/queued_user_messages.js";
+import {
+  joinQueuedUserMessages,
+  QueuedUserMessages,
+} from "./chat_controller/queued_user_messages.js";
 import {
   type MaintenanceTaskOutcome,
   SessionMaintenanceService,
@@ -230,6 +234,7 @@ export class ChatController {
   private eventUnsubscribe?: () => void;
   private isStreaming = false;
   private readonly queuedMessageBuffer: QueuedUserMessages;
+  private readonly pendingSteeringMessages: string[] = [];
   private readonly interruptLifecycle: InterruptLifecycle;
   private readonly diffReviewService: DiffReviewService;
   private readonly maintenanceService: SessionMaintenanceService;
@@ -493,6 +498,8 @@ export class ChatController {
       beforeSubmit: (text: string) => this.beforeSubmit(text),
       onChange: (text: string) => this.handleEditorChange(text),
       onSubmit: (text: string) => void this.onUserInput(text),
+      onSteerSubmit: (text: string) => void this.submitSteeringMessage(text),
+      onFlushQueueAsSteer: () => void this.flushQueuedUserMessagesAsSteering(),
     };
   }
 
@@ -1329,6 +1336,48 @@ export class ChatController {
     this.queuedMessageBuffer.enqueue(text, () => this.view.requestRender());
   }
 
+  private async submitSteeringMessage(text: string): Promise<void> {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+
+    if (!this.isStreaming) {
+      await this.handleSubmit(trimmed);
+      return;
+    }
+
+    if (!this.runtime.isTurnRunning) {
+      this.queueUserMessage(trimmed);
+      this.view.addSystemMessage("current task cannot be steered; message queued", "warn");
+      return;
+    }
+
+    this.pendingSteeringMessages.push(trimmed);
+    this.runtime.requestTurnBoundaryStop();
+    this.view.addSystemMessage("steering queued for next turn boundary", "success");
+    this.view.requestRender();
+  }
+
+  private flushQueuedUserMessagesAsSteering(): void {
+    if (this.queuedMessageBuffer.length === 0) {
+      this.view.addSystemMessage("no queued messages to steer", "warn");
+      return;
+    }
+
+    if (!this.isStreaming || !this.runtime.isTurnRunning) {
+      this.view.addSystemMessage(
+        "current task cannot be steered; queued messages unchanged",
+        "warn",
+      );
+      return;
+    }
+
+    const messages = this.queuedMessageBuffer.flush();
+    this.pendingSteeringMessages.push(...messages);
+    this.runtime.requestTurnBoundaryStop();
+    this.view.addSystemMessage("queued messages will steer at the next turn boundary", "success");
+    this.view.requestRender();
+  }
+
   private popQueuedUserMessageIntoEditor(): void {
     this.queuedMessageBuffer.popIntoEditor({
       getEditorText: () => this.view.getEditorText(),
@@ -1346,6 +1395,28 @@ export class ChatController {
     this.queuedMessageBuffer.dequeueIntoEditor({
       getEditorText: () => this.view.getEditorText(),
       setEditorText: (text) => this.view.setEditorText(text),
+    });
+  }
+
+  private dequeuePendingSteeringMessagesIntoEditor(): void {
+    if (this.pendingSteeringMessages.length === 0) return;
+
+    const editorText = this.view.getEditorText();
+    const parts: string[] = [];
+    if (editorText !== "") {
+      parts.push(editorText);
+    }
+    parts.push(...this.pendingSteeringMessages.splice(0));
+    this.view.setEditorText(joinQueuedUserMessages(parts));
+  }
+
+  private async drainPendingSteeringMessages(): Promise<void> {
+    const messages = this.pendingSteeringMessages.splice(0);
+    if (messages.length === 0) return;
+
+    const text = messages.join("\n\n");
+    await this.sendUserMessage(text, {
+      textForModel: formatSteeringUserMessage(messages),
     });
   }
 
@@ -2926,7 +2997,10 @@ export class ChatController {
       this.queuedMessageBuffer.markPendingIdleNotification();
       this.view.requestRender();
       if (runResult.aborted || runResult.blocked) {
+        this.dequeuePendingSteeringMessagesIntoEditor();
         this.dequeueQueuedUserMessagesIntoEditor();
+      } else if (this.pendingSteeringMessages.length > 0) {
+        void this.drainPendingSteeringMessages();
       } else {
         void this.drainQueuedUserMessages();
       }

--- a/src/tui/chat_controller/queued_user_messages.ts
+++ b/src/tui/chat_controller/queued_user_messages.ts
@@ -11,6 +11,10 @@ type QueueDrainAdapter = {
   buildIdleNotificationTitle: () => string;
 };
 
+export function joinQueuedUserMessages(messages: string[]): string {
+  return messages.join("\n\n---\n\n");
+}
+
 export class QueuedUserMessages {
   private readonly messages: string[];
   private isDraining = false;
@@ -20,9 +24,17 @@ export class QueuedUserMessages {
     this.messages = messages;
   }
 
+  get length(): number {
+    return this.messages.length;
+  }
+
   enqueue(text: string, requestRender: () => void): void {
     this.messages.push(text);
     requestRender();
+  }
+
+  flush(): string[] {
+    return this.messages.splice(0);
   }
 
   popIntoEditor(editor: EditorAdapter): void {
@@ -37,7 +49,7 @@ export class QueuedUserMessages {
   collapse(): boolean {
     if (this.messages.length < 2) return false;
 
-    const collapsed = this.messages.join("\n\n---\n\n");
+    const collapsed = joinQueuedUserMessages(this.messages);
     this.messages.length = 0;
     this.messages.push(collapsed);
     return true;
@@ -55,7 +67,7 @@ export class QueuedUserMessages {
 
     parts.push(...this.messages);
     this.messages.length = 0;
-    editor.setEditorText(parts.join("\n\n---\n\n"));
+    editor.setEditorText(joinQueuedUserMessages(parts));
   }
 
   markPendingIdleNotification(): void {

--- a/src/tui/chat_view.ts
+++ b/src/tui/chat_view.ts
@@ -60,6 +60,8 @@ export type ChatViewInputHandlers = {
   beforeSubmit?: (text: string) => boolean;
   onChange?: (text: string) => void;
   onSubmit?: (text: string) => void;
+  onSteerSubmit?: (text: string) => void;
+  onFlushQueueAsSteer?: () => void;
 };
 
 export type RewindPickerOptions = {
@@ -404,6 +406,8 @@ export class TuiChatView implements ChatView {
     this.editor.beforeSubmit = handlers.beforeSubmit;
     this.editor.onChange = handlers.onChange;
     this.editor.onSubmit = handlers.onSubmit;
+    this.editor.onSteerSubmit = handlers.onSteerSubmit;
+    this.editor.onFlushQueueAsSteer = handlers.onFlushQueueAsSteer;
   }
 
   setAutocompleteProvider(provider: AutocompleteProvider): void {

--- a/src/tui/ui/components/editor.ts
+++ b/src/tui/ui/components/editor.ts
@@ -634,20 +634,8 @@ export class Editor implements Component {
 
     // Submit (Enter)
     if (kb.matches(data, "tui.input.submit")) {
-      if (this.disableSubmit) return;
-
-      let result = this.state.lines.join("\n").trim();
-      result = this.expandPasteMarkers(result);
-
-      this.state = { lines: [""], cursorLine: 0, cursorCol: 0 };
-      this.pastes.clear();
-      this.pasteCounter = 0;
-      this.historyIndex = -1;
-      this.undoStack.clear();
-      this.lastAction = null;
-
-      if (this.onChange) this.onChange("");
-      if (this.onSubmit) this.onSubmit(result);
+      const result = this.takeSubmission();
+      if (result !== undefined && this.onSubmit) this.onSubmit(result);
       return;
     }
 
@@ -786,6 +774,23 @@ export class Editor implements Component {
     }
 
     return layoutLines;
+  }
+
+  protected takeSubmission(): string | undefined {
+    if (this.disableSubmit) return undefined;
+
+    let result = this.state.lines.join("\n").trim();
+    result = this.expandPasteMarkers(result);
+
+    this.state = { lines: [""], cursorLine: 0, cursorCol: 0 };
+    this.pastes.clear();
+    this.pasteCounter = 0;
+    this.historyIndex = -1;
+    this.undoStack.clear();
+    this.lastAction = null;
+
+    if (this.onChange) this.onChange("");
+    return result;
   }
 
   getText(): string {

--- a/src/tui/ui/custom_editor.ts
+++ b/src/tui/ui/custom_editor.ts
@@ -39,6 +39,8 @@ export class CustomEditor extends Editor {
   public onAltDown?: () => void;
   public onAltC?: () => void;
   public beforeSubmit?: (text: string) => boolean;
+  public onSteerSubmit?: (text: string) => void;
+  public onFlushQueueAsSteer?: () => void;
 
   constructor(theme: Theme) {
     super(theme.editorTheme);
@@ -127,6 +129,7 @@ export class CustomEditor extends Editor {
     const isAltUp = matchesKey(data, Key.alt("up")) || data === "\x1b[1;3A";
     const isAltDown = matchesKey(data, Key.alt("down")) || data === "\x1b[1;3B";
     const isAltC = matchesKey(data, Key.alt("c")) || data === "\x1bc";
+    const isAltS = matchesKey(data, Key.alt("s")) || data === "\x1bs";
 
     if (!isEscape) {
       this.lastEscapeAt = undefined;
@@ -196,6 +199,26 @@ export class CustomEditor extends Editor {
 
     if (isAltC && this.onAltC && !this.isShowingAutocomplete()) {
       this.onAltC();
+      return;
+    }
+
+    if (isAltS && this.onFlushQueueAsSteer && !this.isShowingAutocomplete() && this.inputEnabled) {
+      this.onFlushQueueAsSteer();
+      return;
+    }
+
+    if (
+      matchesKey(data, Key.ctrl(Key.enter)) &&
+      this.onSteerSubmit &&
+      !this.isShowingAutocomplete() &&
+      this.inputEnabled
+    ) {
+      if (this.beforeSubmit && !this.beforeSubmit(this.getText())) {
+        return;
+      }
+
+      const result = this.takeSubmission();
+      if (result !== undefined) this.onSteerSubmit(result);
       return;
     }
 

--- a/src/tui/ui/queued_messages.ts
+++ b/src/tui/ui/queued_messages.ts
@@ -24,7 +24,7 @@ export class QueuedMessagesComponent implements Component {
 
     const { palette, markdownTheme } = this.theme;
     const lines: string[] = [];
-    const headerRaw = `queued (${this.messages.length}) — alt+up edit · alt+c collapse`;
+    const headerRaw = `queued (${this.messages.length}) — alt+up edit · alt+c collapse · alt+s steer all`;
     const headerPad = " ";
     const headerWidth = Math.max(0, width - visibleWidth(headerPad));
     lines.push(palette.textDim(`${headerPad}${truncateToWidth(headerRaw, headerWidth, "…")}`));

--- a/test/chat_controller.test.js
+++ b/test/chat_controller.test.js
@@ -181,6 +181,16 @@ function getUserText(controller, index) {
   return textBlock?.text ?? "";
 }
 
+async function waitFor(predicate, timeoutMs = 2000) {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error("waitFor timeout");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
 function createMockDeps(spawn, platform = "darwin") {
   return {
     clock: {
@@ -621,6 +631,118 @@ describe("ChatController queued message draining", () => {
 
     expect(calls).toEqual(["first", "second"]);
     expect(queuedUserMessages.length).toBe(0);
+  });
+
+  it("submits editor input as steering after the active turn reaches a boundary", async () => {
+    const stub = createStubView();
+    const controller = createController(stub.view);
+    let resolveFirstTurn;
+    const firstTurn = new Promise((resolve) => {
+      resolveFirstTurn = resolve;
+    });
+    const runSpy = vi
+      .spyOn(controller.runtime, "runTurn")
+      .mockImplementationOnce(async () => {
+        await firstTurn;
+        return { aborted: false };
+      })
+      .mockResolvedValue({ aborted: false });
+    vi.spyOn(controller.runtime, "isTurnRunning", "get").mockImplementation(
+      () => controller.isStreaming,
+    );
+    const stopSpy = vi.spyOn(controller.runtime, "requestTurnBoundaryStop");
+
+    const turnPromise = controller.runAssistantTurn();
+    await waitFor(() => controller.isStreaming);
+
+    const handlers = controller.getInputHandlers();
+    handlers.onSteerSubmit?.("change direction");
+
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+    expect(stub.systemMessages).toContainEqual({
+      text: "steering queued for next turn boundary",
+      kind: "success",
+    });
+
+    resolveFirstTurn();
+    await turnPromise;
+    await waitFor(() => runSpy.mock.calls.length === 2);
+
+    expect(getUserText(controller, 0)).toContain("<system>");
+    expect(getUserText(controller, 0)).toContain("change direction");
+    expect(stub.added).toContainEqual({ type: "user", text: "change direction" });
+  });
+
+  it("routes idle steering submissions through normal input handling", async () => {
+    const stub = createStubView();
+    const controller = createController(stub.view, {
+      prompts: [{ id: "intro", template: "hello there" }],
+    });
+    const runSpy = vi.spyOn(controller.runtime, "runTurn").mockResolvedValue({ aborted: false });
+
+    const handlers = controller.getInputHandlers();
+    handlers.onSteerSubmit?.("/prompt:intro");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(stub.editorTextUpdates).toEqual(["hello there"]);
+    expect(runSpy).not.toHaveBeenCalled();
+  });
+
+  it("leaves queued messages unchanged when flushing as steering while idle", () => {
+    const stub = createStubView();
+    const queuedUserMessages = ["first queued", "second queued"];
+    const controller = createController(stub.view, { queuedUserMessages });
+
+    const handlers = controller.getInputHandlers();
+    handlers.onFlushQueueAsSteer?.();
+
+    expect(queuedUserMessages).toEqual(["first queued", "second queued"]);
+    expect(stub.systemMessages).toContainEqual({
+      text: "current task cannot be steered; queued messages unchanged",
+      kind: "warn",
+    });
+  });
+
+  it("flushes queued messages into one steering turn", async () => {
+    const stub = createStubView();
+    const queuedUserMessages = ["first queued", "second queued"];
+    const controller = createController(stub.view, { queuedUserMessages });
+    let resolveFirstTurn;
+    const firstTurn = new Promise((resolve) => {
+      resolveFirstTurn = resolve;
+    });
+    const runSpy = vi
+      .spyOn(controller.runtime, "runTurn")
+      .mockImplementationOnce(async () => {
+        await firstTurn;
+        return { aborted: false };
+      })
+      .mockResolvedValue({ aborted: false });
+    vi.spyOn(controller.runtime, "isTurnRunning", "get").mockImplementation(
+      () => controller.isStreaming,
+    );
+    const stopSpy = vi.spyOn(controller.runtime, "requestTurnBoundaryStop");
+
+    const turnPromise = controller.runAssistantTurn();
+    await waitFor(() => controller.isStreaming);
+
+    const handlers = controller.getInputHandlers();
+    handlers.onFlushQueueAsSteer?.();
+
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+    expect(queuedUserMessages).toEqual([]);
+    expect(stub.systemMessages).toContainEqual({
+      text: "queued messages will steer at the next turn boundary",
+      kind: "success",
+    });
+
+    resolveFirstTurn();
+    await turnPromise;
+    await waitFor(() => runSpy.mock.calls.length === 2);
+
+    expect(getUserText(controller, 0)).toContain("<system>");
+    expect(getUserText(controller, 0)).toContain("first queued\n\nsecond queued");
+    expect(stub.added).toContainEqual({ type: "user", text: "first queued\n\nsecond queued" });
   });
 });
 

--- a/test/ui_components.test.js
+++ b/test/ui_components.test.js
@@ -262,7 +262,9 @@ test("QueuedMessagesComponent renders numbered, italicized previews", () => {
   const theme = createTagTheme();
   const component = new QueuedMessagesComponent(theme, ["first line\nsecond", "third"]);
   const lines = renderLines(component, 80);
-  expect(lines[0]).toBe("<textDim> queued (2) — alt+up edit · alt+c collapse</textDim>");
+  expect(lines[0]).toBe(
+    "<textDim> queued (2) — alt+up edit · alt+c collapse · alt+s steer all</textDim>",
+  );
   expect(lines[1]).toBe(
     "<textDim>  1› </textDim><italic><textMuted>first line</textMuted></italic>",
   );


### PR DESCRIPTION
- add ctrl+enter to steer the running assistant with editor input
- add ctrl+shift+enter to flush queued messages as one steering turn
- share steering prompt formatting between RPC and TUI
- update queue hints, help text, docs, and tests

fixes #231
