### PR TITLE
reduce reasoning effort update cost

### DIFF
--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -661,7 +661,7 @@ params (required):
 { "sessionId": "0195d6e4-4cf9-7f44-a2d8-f8f7f49ee9d3", "reasoning": "high" }
 ```
 
-sets the session reasoning effort to `"none"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, or `"xhigh"` and returns the authoritative updated session snapshot. The host applies the change through the session mutation queue so it does not race another mutating request or an active turn.
+sets the session reasoning effort to `"none"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, or `"xhigh"` and returns `{ "revision": number, "settings": { ... } }` with the authoritative updated settings. Observed clients receive a `settings.set` snapshot patch for the same revision. The host applies the change through the session mutation queue so it does not race another mutating request or an active turn.
 
 #### session.setPersona
 

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -254,7 +254,7 @@ options:
 - `setRiskLevel("read-only" | "read-write")`
   - sends `session.setRisk` with this session id and resolves with the updated session snapshot
 - `setReasoning("none" | "minimal" | "low" | "medium" | "high" | "xhigh")`
-  - sends `session.setReasoning` with this session id and resolves with the updated session snapshot
+  - sends `session.setReasoning` with this session id and resolves with `{ revision, settings }`
 - `setPersona(personaId)`
   - sends `session.setPersona` with this session id and resolves with the updated session snapshot
 - `resolvePrompt(promptId)`

--- a/docs/session-event-protocol-redesign.md
+++ b/docs/session-event-protocol-redesign.md
@@ -388,7 +388,7 @@ For broad rewrites, do not overfit patch changes:
 
 - `session.reload`: `snapshot.reset`
 - `session.setRisk`: `snapshot.reset`
-- `session.setReasoning`: `snapshot.reset`
+- `session.setReasoning`: `settings.set`
 - `session.setPersona`: `snapshot.reset`
 - `session.compact`: `snapshot.reset`
 - `session.prune`: `snapshot.reset`
@@ -701,7 +701,7 @@ Known tool renderers can use typed facets. Unknown tools can still render name, 
 4. Tool UI payloads are stored as `SessionToolRun` updates and typed facets before they cross the protocol boundary.
 5. Notices are timeline notice records.
 6. Subagent UI events are stored as `agents` updates.
-7. `snapshot.reset` is used for reload, persona/risk/reasoning changes, rewind, compact, and prune.
+7. `snapshot.reset` is used for reload, persona/risk changes, rewind, compact, and prune; reasoning changes use `settings.set`.
 8. Transports and SDK listeners expose `session.delta`; ephemeral agent progress uses `session.ephemeral`.
 9. TUI rendering is driven from snapshots and local delta application.
 10. Themes stay in TUI-local config/content loading rather than the session protocol.

--- a/src/core/runtime/chat_runtime.ts
+++ b/src/core/runtime/chat_runtime.ts
@@ -1,7 +1,7 @@
 import type { Config } from "../config/index.js";
 import { CoreSession } from "../session/core_session.js";
 import type { ToolRegistry } from "../tools/registry.js";
-import type { Persona, RiskLevel } from "../types.js";
+import type { Persona, ReasoningEffort, RiskLevel } from "../types.js";
 import {
   type ConversationTurnResult,
   ConversationTurnRuntime,
@@ -144,6 +144,17 @@ export class ChatRuntime {
 
   setConfig(config: Config): void {
     this.sessionInstance.setConfig(config);
+  }
+
+  setReasoning(reasoning: ReasoningEffort): void {
+    this.currentPersona = {
+      ...this.currentPersona,
+      settings: {
+        ...this.currentPersona.settings,
+        reasoning,
+      },
+    };
+    this.sessionInstance.setReasoning(reasoning);
   }
 
   setRiskLevel(level: RiskLevel): void {

--- a/src/core/session/core_session.ts
+++ b/src/core/session/core_session.ts
@@ -3,7 +3,7 @@ import type { Config } from "../config/index.js";
 import type { CoreEvent, CoreSubagentUiEvent } from "../events/types.js";
 import type { CoreDeps } from "../runtime/deps.js";
 import type { ToolRegistry } from "../tools/registry.js";
-import type { Persona, RiskLevel } from "../types.js";
+import type { Persona, ReasoningEffort, RiskLevel } from "../types.js";
 import {
   type HistoryEntry,
   type ProcessTurnResult,
@@ -67,6 +67,10 @@ export class CoreSession {
     subagentPrompts: Record<string, string>,
   ): void {
     this.engine.setPersona(persona, systemPrompt, subagentPrompts);
+  }
+
+  setReasoning(reasoning: ReasoningEffort): void {
+    this.engine.setReasoning(reasoning);
   }
 
   setRiskLevel(level: RiskLevel): void {

--- a/src/core/session/session_engine.ts
+++ b/src/core/session/session_engine.ts
@@ -205,6 +205,16 @@ export class SessionEngine {
     this.subagentPrompts = subagentPrompts;
   }
 
+  setReasoning(reasoning: ReasoningEffort): void {
+    this.persona = {
+      ...this.persona,
+      settings: {
+        ...this.persona.settings,
+        reasoning,
+      },
+    };
+  }
+
   setRiskLevel(level: RiskLevel): void {
     this.riskLevel = level;
   }

--- a/src/host/local_session_host.ts
+++ b/src/host/local_session_host.ts
@@ -5,10 +5,7 @@ import type { CoreEvent } from "../core/events/types.js";
 import type { PromptTemplate } from "../core/prompts.js";
 import { ChatRuntime, type ChatRuntimeEnvironment } from "../core/runtime/chat_runtime.js";
 import type { CoreDeps } from "../core/runtime/deps.js";
-import {
-  type RuntimePromptBootstrap,
-  resolvePersonaSkillsForPromptContext,
-} from "../core/runtime/runtime_bootstrap.js";
+import type { RuntimePromptBootstrap } from "../core/runtime/runtime_bootstrap.js";
 import type { SessionPromptComposition } from "../core/runtime/session_prompt_composer.js";
 import type { CoreSession } from "../core/session/core_session.js";
 import type { SubagentUiEvent } from "../core/subagents/types.js";
@@ -56,6 +53,7 @@ import type {
   SessionProtocolResolvePromptResult,
   SessionProtocolRewindResult,
   SessionProtocolSessionSummary,
+  SessionProtocolSettingsUpdateResult,
   SessionProtocolSnapshot,
   SessionProtocolSubagentSnapshot,
   SessionProtocolTerminateSubagentResult,
@@ -655,21 +653,29 @@ class LocalHostedSessionHandle implements LocalHostedSession {
     return snapshot;
   }
 
-  async setReasoning(reasoning: ReasoningEffort): Promise<SessionProtocolSnapshot> {
+  async setReasoning(reasoning: ReasoningEffort): Promise<SessionProtocolSettingsUpdateResult> {
     this.assertActive();
-    const persona = clonePersona(this.runtime.persona);
-    persona.settings.reasoning = reasoning;
-    const skillsContext = resolvePersonaSkillsForPromptContext({
-      persona,
-      discoveredSkills: this.bootstrap.discoveredSkills,
-    });
-    this.runtime.setPersona(persona, {
-      skillsBlock: skillsContext.skillsBlock,
-    });
-    this.bootstrap.persona = clonePersona(persona);
+    const fromRevision = this.committedSnapshot?.revision;
+    this.runtime.setReasoning(reasoning);
+    this.bootstrap.persona.settings.reasoning = reasoning;
     const snapshot = await this.commitSnapshot();
-    this.emitSnapshotReset("configuration", snapshot);
-    return snapshot;
+    if (fromRevision === undefined) {
+      this.emitSnapshotReset("configuration", snapshot);
+    } else if (snapshot.revision !== fromRevision) {
+      this.emitDelta(
+        createSessionProtocolDeltaMessage({
+          sessionId: snapshot.sessionId,
+          fromRevision,
+          toRevision: snapshot.revision,
+          reason: "configuration",
+          delta: {
+            type: "snapshot.patch",
+            changes: [{ type: "settings.set", settings: snapshot.settings }],
+          },
+        }),
+      );
+    }
+    return { revision: snapshot.revision, settings: snapshot.settings };
   }
 
   async setPersona(personaId: string): Promise<SessionProtocolSnapshot> {

--- a/src/host/session_host.ts
+++ b/src/host/session_host.ts
@@ -27,6 +27,7 @@ import type {
   SessionProtocolSetPersonaParams,
   SessionProtocolSetReasoningParams,
   SessionProtocolSetRiskParams,
+  SessionProtocolSettingsUpdateResult,
   SessionProtocolSnapshot,
   SessionProtocolTerminateSubagentResult,
   SessionProtocolUserMessageTurnResult,
@@ -52,7 +53,7 @@ export type TauHostedSession = {
   setRiskLevel(level: SessionProtocolSetRiskParams["riskLevel"]): Promise<SessionProtocolSnapshot>;
   setReasoning(
     reasoning: SessionProtocolSetReasoningParams["reasoning"],
-  ): Promise<SessionProtocolSnapshot>;
+  ): Promise<SessionProtocolSettingsUpdateResult>;
   setPersona(
     personaId: SessionProtocolSetPersonaParams["personaId"],
   ): Promise<SessionProtocolSnapshot>;

--- a/src/host/session_protocol_handler.ts
+++ b/src/host/session_protocol_handler.ts
@@ -901,9 +901,9 @@ export class SessionProtocolHandler {
     request: Extract<SessionProtocolRequestMessage, { method: "session.setReasoning" }>,
   ): Promise<void> {
     await this.withSessionMutation(request, "session reasoning changed", async (state) => {
-      const snapshot = await state.session.setReasoning(request.params.reasoning);
+      const result = await state.session.setReasoning(request.params.reasoning);
       this.sendMessage(
-        createSessionProtocolSuccessResponse(request.id, "session.setReasoning", snapshot),
+        createSessionProtocolSuccessResponse(request.id, "session.setReasoning", result),
       );
     });
   }

--- a/src/protocol/session_protocol.ts
+++ b/src/protocol/session_protocol.ts
@@ -140,6 +140,10 @@ export type SessionProtocolSetReasoningParams = SessionProtocolSessionIdParams &
 export type SessionProtocolSetPersonaParams = SessionProtocolSessionIdParams & {
   personaId: string;
 };
+export type SessionProtocolSettingsUpdateResult = {
+  revision: number;
+  settings: SessionProtocolSettingsSnapshot;
+};
 export type SessionProtocolResolvePromptParams = SessionProtocolSessionIdParams & {
   promptId: string;
 };
@@ -582,7 +586,7 @@ export type SessionProtocolResultByMethod = {
   "session.interrupt": SessionProtocolInterruptResult;
   "session.snapshot": SessionProtocolSnapshot;
   "session.setRisk": SessionProtocolSnapshot;
-  "session.setReasoning": SessionProtocolSnapshot;
+  "session.setReasoning": SessionProtocolSettingsUpdateResult;
   "session.setPersona": SessionProtocolSnapshot;
   "session.resolvePrompt": SessionProtocolResolvePromptResult;
   "session.autocompletePaths": SessionProtocolAutocompletePathsResult;
@@ -657,6 +661,7 @@ export type SessionProtocolDeltaReason =
 
 export type SessionProtocolChange =
   | { type: "lifecycle.set"; lifecycle: SessionProtocolSessionLifecycle }
+  | { type: "settings.set"; settings: SessionProtocolSettingsSnapshot }
   | {
       type: "message.append";
       message: SessionProtocolMessage;
@@ -1427,6 +1432,12 @@ const sessionProtocolChangeSchema = z.discriminatedUnion("type", [
     .strict(),
   z
     .object({
+      type: z.literal("settings.set"),
+      settings: sessionProtocolSettingsSnapshotSchema,
+    })
+    .strict(),
+  z
+    .object({
       type: z.literal("message.append"),
       message: sessionProtocolMessageSchema,
       timelineItem: sessionProtocolTimelineItemSchema.optional(),
@@ -1895,6 +1906,9 @@ export function applySessionProtocolDelta(
     switch (change.type) {
       case "lifecycle.set":
         next.lifecycle = change.lifecycle;
+        break;
+      case "settings.set":
+        next.settings = structuredClone(change.settings);
         break;
       case "message.append":
         next.messages.push(structuredClone(change.message));

--- a/src/protocol/session_protocol.ts
+++ b/src/protocol/session_protocol.ts
@@ -1677,6 +1677,13 @@ const sessionProtocolInterruptResultSchema = z
   })
   .strict();
 
+const sessionProtocolSettingsUpdateResultSchema = z
+  .object({
+    revision: z.number().int().positive(),
+    settings: sessionProtocolSettingsSnapshotSchema,
+  })
+  .strict();
+
 const sessionProtocolCompactResultSchema = z
   .object({
     snapshot: sessionProtocolSnapshotSchema,
@@ -2604,9 +2611,10 @@ export function validateSessionProtocolResult(
     case "session.observe":
     case "session.snapshot":
     case "session.setRisk":
-    case "session.setReasoning":
     case "session.setPersona":
       return validateResult(method, result, sessionProtocolSnapshotSchema);
+    case "session.setReasoning":
+      return validateResult(method, result, sessionProtocolSettingsUpdateResultSchema);
     case "session.resolvePrompt":
       return validateResult(method, result, sessionProtocolResolvePromptResultSchema);
     case "session.autocompletePaths":

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -22,6 +22,7 @@ import type {
   SessionProtocolRetryResult,
   SessionProtocolRewindResult,
   SessionProtocolSessionSummary,
+  SessionProtocolSettingsUpdateResult,
   SessionProtocolSnapshot,
   SessionProtocolSteerResult,
   SessionProtocolSubmitResult,
@@ -46,7 +47,7 @@ export type TauSdkSessionInterruptResult = SessionProtocolInterruptResult;
 export type TauSdkSessionExecResult = SessionProtocolExecResult;
 export type TauSdkSessionSnapshotResult = SessionProtocolSnapshot;
 export type TauSdkSessionSetRiskResult = SessionProtocolSnapshot;
-export type TauSdkSessionSetReasoningResult = SessionProtocolSnapshot;
+export type TauSdkSessionSetReasoningResult = SessionProtocolSettingsUpdateResult;
 export type TauSdkSessionSetPersonaResult = SessionProtocolSnapshot;
 export type TauSdkSessionCompactResult = SessionProtocolCompactResult;
 export type TauSdkSessionPruneResult = SessionProtocolPruneResult;

--- a/src/tui/session_chat_controller.ts
+++ b/src/tui/session_chat_controller.ts
@@ -1560,7 +1560,12 @@ export class SessionChatController {
     }
 
     try {
-      this.snapshot = await this.session.setReasoning(next);
+      const result = await this.session.setReasoning(next);
+      this.snapshot = {
+        ...this.snapshot,
+        revision: result.revision,
+        settings: result.settings,
+      };
       this.refreshStatus();
     } catch (error) {
       this.view.addSystemMessage(`reasoning change failed: ${(error as Error).message}`, "error");

--- a/test/sdk_client.test.js
+++ b/test/sdk_client.test.js
@@ -171,16 +171,14 @@ class FakeSessionProtocolTransport {
             bootstrap: { ...bootstrap, riskLevel: params.riskLevel },
           });
         case "session.setReasoning":
-          return createProtocolSnapshot({
-            sessionId: params.sessionId,
-            bootstrap: {
-              ...bootstrap,
-              persona: {
-                ...bootstrap.persona,
-                settings: { ...bootstrap.persona.settings, reasoning: params.reasoning },
-              },
+          return {
+            revision: 2,
+            settings: {
+              personaId: bootstrap.persona.id,
+              riskLevel: "read-only",
+              reasoning: params.reasoning,
             },
-          });
+          };
         case "session.resolvePrompt":
           return { promptId: params.promptId, text: `prompt body for ${params.promptId}` };
         case "session.reload":

--- a/test/session_chat_controller.test.js
+++ b/test/session_chat_controller.test.js
@@ -296,7 +296,7 @@ class FakeSession {
       revision: this.snapshotValue.revision + 1,
       settings: { ...this.snapshotValue.settings, reasoning },
     });
-    return this.snapshotValue;
+    return { revision: this.snapshotValue.revision, settings: this.snapshotValue.settings };
   });
   setPersona = vi.fn(async (personaId) => {
     this.snapshotValue = updateSnapshot(this.snapshotValue, {

--- a/test/session_protocol.test.js
+++ b/test/session_protocol.test.js
@@ -1467,6 +1467,36 @@ describe("session_protocol", () => {
       message: delta,
     });
 
+    const settingsDelta = createSessionProtocolDeltaMessage({
+      sessionId: "session-1",
+      fromRevision: 2,
+      toRevision: 3,
+      reason: "configuration",
+      delta: {
+        type: "snapshot.patch",
+        changes: [
+          {
+            type: "settings.set",
+            settings: { personaId: "default", riskLevel: "read-only", reasoning: "high" },
+          },
+        ],
+      },
+    });
+    const settingsPatchedSnapshot = applySessionProtocolDelta(
+      createProtocolSnapshot({
+        sessionId: "session-1",
+        revision: 2,
+        settings: { personaId: "default", riskLevel: "read-only", reasoning: "medium" },
+      }),
+      settingsDelta,
+    );
+    expect(settingsPatchedSnapshot.revision).toBe(3);
+    expect(settingsPatchedSnapshot.settings).toEqual({
+      personaId: "default",
+      riskLevel: "read-only",
+      reasoning: "high",
+    });
+
     const ephemeral = createSessionProtocolEphemeralMessage({
       sessionId: "session-1",
       event: {

--- a/test/session_protocol.test.js
+++ b/test/session_protocol.test.js
@@ -1020,6 +1020,19 @@ describe("session_protocol", () => {
     });
 
     expect(
+      validateSessionProtocolResult("session.setReasoning", {
+        revision: 2,
+        settings: { personaId: "default", riskLevel: "read-only", reasoning: "high" },
+      }),
+    ).toEqual({
+      ok: true,
+      value: {
+        revision: 2,
+        settings: { personaId: "default", riskLevel: "read-only", reasoning: "high" },
+      },
+    });
+
+    expect(
       validateSessionProtocolResult(
         "session.snapshot",
         createProtocolSnapshot({ bootstrap, catalog }),


### PR DESCRIPTION
## why

Changing reasoning effort in a long TUI session should be a cheap settings mutation. The old path treated it like a full persona reconfiguration, which rebuilt prompt context and sent a full snapshot reset back through the protocol.

## what

This changes reasoning effort updates to use a dedicated runtime/session mutation and adds a general `settings.set` snapshot patch for settings changes. `session.setReasoning` now returns a lightweight `{ revision, settings }` result, while the TUI still waits for the normal round trip before updating its local status.

fixes #248
