### PR TITLE
freeze reasoning per turn

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,6 +313,8 @@ RPC mode command surface is protocol-based (`initialize`, `session.create`, `ses
 
 **Keybindings**: `Shift+Tab` (cycle reasoning), `Ctrl+R` (cycle risk level), `Ctrl+P` (cycle personality), `Ctrl+T` (toggle thinking), `Ctrl+O` (compact UI), `Ctrl+S` (stash input to clipboard), `Ctrl+Y` (toggle voice recording for `/listen`), `Ctrl+G` (terminate selected subagent), `Ctrl+Enter` (steer running assistant with editor input), `Alt+S` (steer running assistant with queued messages), `Enter x2` (retry last response on empty input), `Escape x2` (clear current prompt), `Alt+Up` (pop queued message), `Alt+C` (collapse queued messages into one), `Alt+Down` (cycle active subagents), `Escape` (interrupt active work), `Ctrl+C` (press twice to exit)
 
+Reasoning changes are allowed while a turn is running. The active user-message turn keeps the reasoning captured when that turn started, including all tool-call subturns; the new reasoning applies to the next submitted, queued, or steering user-message turn when it actually starts.
+
 ## Development
 
 - `npm run check` - Apply repository formatting, then typecheck, including `src/diff_tool/app`

--- a/README.md
+++ b/README.md
@@ -373,6 +373,8 @@ some models support extended thinking, where they reason through problems before
 tau --persona opus-4.8-chat:high
 ```
 
+reasoning changes made while the assistant is working apply to the next user-message turn. the active turn keeps the reasoning level it captured when that user message started, including any tool-call subturns.
+
 toggle visibility of the model's thinking with `ctrl+t`.
 
 ## working with files

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -661,7 +661,7 @@ params (required):
 { "sessionId": "0195d6e4-4cf9-7f44-a2d8-f8f7f49ee9d3", "reasoning": "high" }
 ```
 
-sets the session reasoning effort to `"none"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, or `"xhigh"` and returns `{ "revision": number, "settings": { ... } }` with the authoritative updated settings. Observed clients receive a `settings.set` snapshot patch for the same revision. The host applies the change through the session mutation queue so it does not race another mutating request or an active turn.
+sets the session reasoning effort to `"none"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, or `"xhigh"` and returns `{ "revision": number, "settings": { ... } }` with the authoritative updated settings. Observed clients receive a `settings.set` snapshot patch for the same revision. The host applies the settings update through the session mutation queue, but it does not interrupt an active turn or reject queued/steering messages. If a turn is already running, the new reasoning applies to the next user-message turn.
 
 #### session.setPersona
 
@@ -962,6 +962,7 @@ for lines that cannot produce a valid request id (for example malformed json), `
 
 - multiple requests can be accepted before earlier ones complete
 - `session.record`, `session.setRisk`, `session.setReasoning`, `session.setPersona`, `session.reload`, `session.compact`, `session.prune`, `session.rewind`, `session.terminateSubagent`, `session.ephemeral.create`, and `session.ephemeral.close` run through a session-owned mutation queue (arrival order across clients observed to the same live session)
+- `session.setReasoning` updates settings immediately without interrupting an active turn; active turns keep their captured reasoning and the new setting applies to the next user-message turn
 - only one idle-only `session.submit`, `session.retry`, or `session.exec` can run at once (`busy` otherwise)
 - `session.queue` can be accepted during active work and runs after the active turn settles
 - `session.steer` can be accepted during an active turn and runs at the next safe boundary after requesting the active turn to stop

--- a/src/core/session/session_engine.ts
+++ b/src/core/session/session_engine.ts
@@ -116,6 +116,12 @@ export type RewindResult = {
   removedEntryIds: string[];
 };
 
+type SessionTurnSettings = {
+  persona: Persona;
+  streamOptions: TauStreamOptions;
+  reasoningEffort: ReasoningEffort | "none";
+};
+
 export class SessionEngine {
   private persona: Persona;
   private systemPrompt: string;
@@ -653,8 +659,20 @@ export class SessionEngine {
     return parseStreamingSettings(merged);
   }
 
-  private getEnabledToolSchemas() {
-    return this.toolRegistry.getEnabledToolSchemas(this.persona.tools);
+  private captureTurnSettings(): SessionTurnSettings {
+    const persona = {
+      ...this.persona,
+      settings: { ...this.persona.settings },
+    };
+    return {
+      persona,
+      streamOptions: this.getStreamingSettings(persona),
+      reasoningEffort: persona.settings.reasoning ?? "none",
+    };
+  }
+
+  private getEnabledToolSchemas(persona: Persona = this.persona) {
+    return this.toolRegistry.getEnabledToolSchemas(persona.tools);
   }
 
   private createDispatchModelResolver(): ModelResolver {
@@ -686,6 +704,7 @@ export class SessionEngine {
     let subturns = 0;
     let autoCompactionAttempted = false;
     const originHistoryEntryId = this.getCurrentTurnUserHistoryEntryId();
+    const turnSettings = this.captureTurnSettings();
 
     while (subturns < MAX_ASSISTANT_SUBTURNS && !signal.aborted) {
       if (!autoCompactionAttempted && this.shouldRunAutoCompaction()) {
@@ -697,7 +716,7 @@ export class SessionEngine {
       }
 
       subturns += 1;
-      const { finalMessage } = yield* this.runSingleSubturn(signal);
+      const { finalMessage } = yield* this.runSingleSubturn(signal, turnSettings);
 
       if (signal.aborted) {
         break;
@@ -712,10 +731,10 @@ export class SessionEngine {
         break;
       }
 
-      const enabledTools = this.getEnabledToolSchemas();
+      const enabledTools = this.getEnabledToolSchemas(turnSettings.persona);
       const dispatchContext: ToolDispatchContext = {
         scope: "main",
-        persona: this.persona,
+        persona: turnSettings.persona,
         config: this.config,
         originHistoryEntryId,
         cwd: this.cwd,
@@ -986,12 +1005,13 @@ export class SessionEngine {
 
   private async *runSingleSubturn(
     signal: AbortSignal,
+    turnSettings: SessionTurnSettings,
   ): AsyncGenerator<CoreEvent, { finalMessage?: AssistantMessage }, void> {
     const historyEntryId = this.createHistoryEntryId();
     const startEvent: CoreEvent = { type: "assistant_start", historyEntryId };
     this.emitEvent(startEvent);
     yield startEvent;
-    const tools = this.getEnabledToolSchemas();
+    const tools = this.getEnabledToolSchemas(turnSettings.persona);
 
     const context: Context = {
       systemPrompt: this.systemPrompt,
@@ -1000,12 +1020,12 @@ export class SessionEngine {
     };
 
     const baseOptions: TauStreamOptions = {
-      ...this.getStreamingSettings(this.persona),
+      ...turnSettings.streamOptions,
       signal,
       sessionId: this.sessionId,
     };
 
-    if (this.persona.model.provider === "openai-codex") {
+    if (turnSettings.persona.model.provider === "openai-codex") {
       baseOptions.headers = {
         ...baseOptions.headers,
         originator: CODEX_ORIGINATOR,
@@ -1015,7 +1035,7 @@ export class SessionEngine {
 
     try {
       const stream = runModelSubturn({
-        model: this.persona.model,
+        model: turnSettings.persona.model,
         modelRuntime: this.modelRuntime,
         context,
         streamOptions: baseOptions,
@@ -1064,11 +1084,11 @@ export class SessionEngine {
       appendUsageLogEntry({
         timestamp: finalMessage.timestamp,
         sessionId: this.sessionId,
-        personaId: this.persona.id,
+        personaId: turnSettings.persona.id,
         provider: finalMessage.provider,
         model: finalMessage.model,
         api: finalMessage.api,
-        reasoningEffort: this.persona.settings.reasoning ?? "none",
+        reasoningEffort: turnSettings.reasoningEffort,
         usage: getUsageTotals(finalMessage.usage),
         cost: { total: getUsageCostTotal(finalMessage.usage) },
         agent: { type: "main" },

--- a/src/host/session_protocol_handler.ts
+++ b/src/host/session_protocol_handler.ts
@@ -63,7 +63,6 @@ type SessionProtocolMutationRequest = Extract<
     method:
       | "session.record"
       | "session.setRisk"
-      | "session.setReasoning"
       | "session.setPersona"
       | "session.reload"
       | "session.compact"
@@ -900,7 +899,17 @@ export class SessionProtocolHandler {
   private async handleSetReasoning(
     request: Extract<SessionProtocolRequestMessage, { method: "session.setReasoning" }>,
   ): Promise<void> {
-    await this.withSessionMutation(request, "session reasoning changed", async (state) => {
+    const state = await this.getSessionState(request.params.sessionId);
+    if (!state) {
+      this.sendSessionNotFound(request.id, request.params.sessionId);
+      return;
+    }
+
+    await this.runSessionMutation(state, async () => {
+      if (state.session.sessionId !== request.params.sessionId) {
+        this.sendSessionNotFound(request.id, request.params.sessionId);
+        return;
+      }
       const result = await state.session.setReasoning(request.params.reasoning);
       this.sendMessage(
         createSessionProtocolSuccessResponse(request.id, "session.setReasoning", result),

--- a/src/tui/session_chat_controller.ts
+++ b/src/tui/session_chat_controller.ts
@@ -1554,11 +1554,6 @@ export class SessionChatController {
     const index = allowed.indexOf(current);
     const next = allowed[(index + 1) % allowed.length] ?? allowed[0]!;
 
-    if (this.isSessionOperationActive()) {
-      this.view.addSystemMessage("cannot change reasoning while a session turn is running", "warn");
-      return;
-    }
-
     try {
       const result = await this.session.setReasoning(next);
       this.snapshot = {

--- a/test/core_runtime.test.js
+++ b/test/core_runtime.test.js
@@ -342,6 +342,87 @@ describe("core session rewind APIs", () => {
     }
   });
 
+  it("keeps reasoning frozen across all subturns in an agent turn", async () => {
+    const requestedReasoning = [];
+    const toolContextReasoning = [];
+    let session;
+    const toolRegistry = new ToolRegistry([
+      {
+        schema: {
+          name: "fake_tool",
+          description: "test tool",
+          parameters: {
+            type: "object",
+            properties: {},
+            additionalProperties: false,
+          },
+        },
+        async dispatch(_toolCall, _riskLevel, _signal, context) {
+          toolContextReasoning.push(context.persona.settings.reasoning);
+          session.setReasoning("high");
+          return {
+            kind: "single",
+            toolResult: {
+              role: "toolResult",
+              toolCallId: "fake-call",
+              toolName: "fake_tool",
+              content: [{ type: "text", text: "ok" }],
+              isError: false,
+              timestamp: 2,
+            },
+          };
+        },
+      },
+    ]);
+    const persona = {
+      id: "frozen-reasoning",
+      label: "frozen reasoning",
+      model: personas[0].model,
+      systemPrompt: "system",
+      settings: { reasoning: "low" },
+      tools: ["fake_tool"],
+      skills: "*",
+      source: "builtin",
+    };
+    session = new CoreSession({
+      persona,
+      systemPrompt: "system",
+      subagentPrompts: {},
+      riskLevel: "read-only",
+      toolRegistry,
+    });
+    const responses = [
+      fauxAssistantMessage([fauxToolCall("fake_tool", {}, { id: "fake-call" })], {
+        stopReason: "toolUse",
+      }),
+      fauxAssistantMessage("done"),
+    ];
+    session.engine.modelRuntime.streamModel = (_model, _context, options) => {
+      requestedReasoning.push(options.reasoning);
+      const response = responses.shift();
+      return {
+        async *[Symbol.asyncIterator]() {},
+        async result() {
+          return response;
+        },
+      };
+    };
+
+    session.addUserText("use a tool");
+    for await (const _event of session.events(new AbortController().signal)) {
+    }
+
+    expect(requestedReasoning).toEqual(["low", "low"]);
+    expect(toolContextReasoning).toEqual(["low"]);
+
+    session.addUserText("next turn");
+    responses.push(fauxAssistantMessage("next done"));
+    for await (const _event of session.events(new AbortController().signal)) {
+    }
+
+    expect(requestedReasoning).toEqual(["low", "low", "high"]);
+  });
+
   it("keeps tool dispatch origin tied to the submitted user after auto-compaction", async () => {
     const faux = fauxProvider({
       provider: "faux-auto-origin",

--- a/test/rpc_server.test.js
+++ b/test/rpc_server.test.js
@@ -120,6 +120,7 @@ function createHarness(options = {}) {
     let pendingTurnResult = { aborted: false };
     let pendingTurn = null;
     let riskLevel = bootstrap.riskLevel;
+    let reasoning = bootstrap.persona.settings.reasoning;
 
     const emitDelta = (delta) => {
       for (const handler of deltaHandlers) {
@@ -164,7 +165,14 @@ function createHarness(options = {}) {
           sessionId,
           revision: historyEntries.length + 1,
           lifecycle: running ? "running" : "idle",
-          bootstrap: { ...bootstrap, riskLevel },
+          bootstrap: {
+            ...bootstrap,
+            riskLevel,
+            persona: {
+              ...bootstrap.persona,
+              settings: { ...bootstrap.persona.settings, reasoning },
+            },
+          },
           executionEnvironment: { kind: "local", cwd: "/repo", home: "/home/user" },
           historyEntries: historyEntries.map((entry) => ({
             id: entry.id,
@@ -246,7 +254,14 @@ function createHarness(options = {}) {
           sessionId,
           revision: historyEntries.length + 2,
           lifecycle: running ? "running" : "idle",
-          bootstrap: { ...bootstrap, riskLevel },
+          bootstrap: {
+            ...bootstrap,
+            riskLevel,
+            persona: {
+              ...bootstrap.persona,
+              settings: { ...bootstrap.persona.settings, reasoning },
+            },
+          },
           executionEnvironment: { kind: "local", cwd: "/repo", home: "/home/user" },
           historyEntries: historyEntries.map((entry) => ({
             id: entry.id,
@@ -255,6 +270,24 @@ function createHarness(options = {}) {
         });
         emitDelta(createResetDelta(sessionId, historyEntries.length + 1, snapshot));
         return snapshot;
+      },
+      async setReasoning(nextReasoning) {
+        reasoning = nextReasoning;
+        const snapshot = await hostedSession.snapshot();
+        const fromRevision = Math.max(1, snapshot.revision - 1);
+        emitDelta({
+          version: SESSION_PROTOCOL_VERSION,
+          type: "session.delta",
+          sessionId,
+          fromRevision,
+          toRevision: snapshot.revision,
+          reason: "configuration",
+          delta: {
+            type: "snapshot.patch",
+            changes: [{ type: "settings.set", settings: snapshot.settings }],
+          },
+        });
+        return { revision: snapshot.revision, settings: snapshot.settings };
       },
       async compact(compactOptions) {
         const compactionMessage = `compacted with ${compactOptions.mode}`;
@@ -976,6 +1009,71 @@ describe("rpc_server", () => {
     );
 
     expect(harness.lines).toHaveLength(lineCount);
+  });
+
+  it("changes reasoning during an active turn without interrupting or rejecting queued submits", async () => {
+    const harness = createHarness();
+
+    const firstSubmit = harness.server.handleLine(
+      request("submit-1", "session.submit", {
+        sessionId: "session-1",
+        text: "first turn",
+      }),
+    );
+    await waitFor(() => harness.seededSession.canReleaseTurn());
+
+    const queuedSubmit = harness.server.handleLine(
+      request("queue-1", "session.queue", {
+        sessionId: "session-1",
+        text: "queued turn",
+      }),
+    );
+    await harness.server.handleLine(
+      request("reasoning-1", "session.setReasoning", {
+        sessionId: "session-1",
+        reasoning: "high",
+      }),
+    );
+
+    const reasoningChanged = harness.lines.find(
+      (line) => line.type === "response" && line.id === "reasoning-1",
+    );
+    expect(reasoningChanged).toEqual(
+      expect.objectContaining({
+        ok: true,
+        result: expect.objectContaining({
+          settings: expect.objectContaining({ reasoning: "high" }),
+        }),
+      }),
+    );
+    expect(harness.seededSession.isTurnRunning).toBe(true);
+    expect(
+      harness.lines.find((line) => line.type === "response" && line.id === "queue-1"),
+    ).toBeUndefined();
+
+    harness.releaseTurn();
+    await firstSubmit;
+    await waitFor(
+      () => harness.lines.filter((line) => deltaHasNotice(line, "streaming")).length === 2,
+    );
+    harness.releaseTurn();
+    await waitFor(() =>
+      harness.lines.some((line) => line.type === "response" && line.id === "queue-1"),
+    );
+    await queuedSubmit;
+
+    const queuedResult = harness.lines.find(
+      (line) => line.type === "response" && line.id === "queue-1",
+    );
+    expect(queuedResult).toEqual(
+      expect.objectContaining({
+        ok: true,
+        result: expect.objectContaining({
+          userHistoryEntryId: expect.any(String),
+          turn: { aborted: false },
+        }),
+      }),
+    );
   });
 
   it("batches steering submits while a turn is running", async () => {

--- a/test/session_chat_controller.test.js
+++ b/test/session_chat_controller.test.js
@@ -2710,7 +2710,7 @@ describe("SessionChatController", () => {
     expect(view.status.editor.reasoning).toBe("minimal");
   });
 
-  it("does not change session reasoning while a turn is running", async () => {
+  it("changes session reasoning while a turn is running", async () => {
     const session = new FakeSession();
     const view = new FakeView();
     const controller = new SessionChatController({
@@ -2725,8 +2725,9 @@ describe("SessionChatController", () => {
     controller.getInputHandlers().onShiftTab();
     await flush();
 
-    expect(session.setReasoning).not.toHaveBeenCalled();
-    expect(view.systems).toContainEqual({
+    expect(session.setReasoning).toHaveBeenCalledWith("minimal");
+    expect(view.status.editor.reasoningLabel).toBe("minimal");
+    expect(view.systems).not.toContainEqual({
       text: "cannot change reasoning while a session turn is running",
       kind: "warn",
       options: undefined,


### PR DESCRIPTION
## why

Reasoning changes should be safe while the assistant is working. The active user-message turn should keep the model settings it started with, while any newly selected reasoning applies to the next submitted, queued, or steering turn.

## what

This captures turn settings once at the start of a user-message turn and reuses them across all assistant subturns and tool dispatch for that turn. `session.setReasoning` now updates session settings without interrupting active work or rejecting pending queued messages, and the TUI allows cycling reasoning while a turn is running. Docs and regressions cover the new behavior.

fixes #249
