### PR TITLE
preserve session id after compact

### DIFF
--- a/src/core/session/session_engine.ts
+++ b/src/core/session/session_engine.ts
@@ -190,7 +190,6 @@ export class SessionEngine {
       id: entry.id,
       message: structuredClone(entry.message),
     }));
-    this.sessionId = randomUUID();
   }
 
   dispose(): void {

--- a/src/host/local_session_host.ts
+++ b/src/host/local_session_host.ts
@@ -1158,6 +1158,19 @@ class LocalHostedSessionHandle implements LocalHostedSession {
     );
   }
 
+  private clearRunningAutoCompactionOperations(): void {
+    this.timelineExtras.splice(
+      0,
+      this.timelineExtras.length,
+      ...this.timelineExtras.filter(
+        (item) =>
+          item.type !== "operation" ||
+          item.operation.kind !== "auto-compaction" ||
+          item.operation.status !== "running",
+      ),
+    );
+  }
+
   private restoreProtocolState(snapshot: SessionProtocolSnapshot | undefined): void {
     if (!snapshot) {
       return;
@@ -1370,6 +1383,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
         return;
       }
       case "compaction_end":
+        this.clearRunningAutoCompactionOperations();
         await this.emitSnapshotReset("maintenance", await this.commitSnapshot());
         return;
       case "tool_ui":

--- a/src/tui/session_chat_controller.ts
+++ b/src/tui/session_chat_controller.ts
@@ -131,6 +131,7 @@ export class SessionChatController {
   private readonly snapshotRecoveryDeltas: SessionProtocolDeltaMessage[] = [];
   private isStreaming = false;
   private submittedTurnInProgress = false;
+  private manualCompactionInProgress = false;
   private isBashMode = false;
   private isBashIncognito = false;
   private isMemoryMode = false;
@@ -1439,7 +1440,7 @@ export class SessionChatController {
   }
 
   private isSessionOperationActive(): boolean {
-    return this.isStreaming || this.submittedTurnInProgress;
+    return this.isStreaming || this.submittedTurnInProgress || this.manualCompactionInProgress;
   }
 
   private async recoverFromRevisionGap(): Promise<void> {
@@ -1713,6 +1714,8 @@ export class SessionChatController {
     }
 
     const guidance = guidanceText?.trim() ?? "";
+    this.manualCompactionInProgress = true;
+    this.refreshStatus();
     this.view.addSystemMessage("summarizing session...", "success");
 
     try {
@@ -1720,7 +1723,6 @@ export class SessionChatController {
         ...(guidance ? { guidance } : {}),
       });
       this.renderCompactedSnapshot(result.snapshot);
-      this.refreshStatus();
       const message =
         mode === "summary-and-last" && result.includedLastAssistant
           ? "session compacted. previous context and last assistant message have been included."
@@ -1730,6 +1732,9 @@ export class SessionChatController {
       const message = (error as Error).message || "compaction failed";
       const kind = message === "no conversation to compact." ? "warn" : "error";
       this.view.addSystemMessage(kind === "warn" ? message : `compact failed: ${message}`, kind);
+    } finally {
+      this.manualCompactionInProgress = false;
+      this.refreshStatus();
     }
   }
 
@@ -1869,7 +1874,7 @@ export class SessionChatController {
         duration: this.getTurnDurationString(),
         riskLevel: this.snapshot.settings.riskLevel,
         commandHint: this.diffReviewService.getCommandHint(
-          this.getSnapshotOperationStatusHint() ?? this.speechStatusHint ?? this.commandHint,
+          this.getSessionOperationStatusHint() ?? this.speechStatusHint ?? this.commandHint,
         ),
       },
       editor: {
@@ -1894,7 +1899,10 @@ export class SessionChatController {
     return "normal";
   }
 
-  private getSnapshotOperationStatusHint(): string | undefined {
+  private getSessionOperationStatusHint(): string | undefined {
+    if (this.manualCompactionInProgress) {
+      return "compacting context...";
+    }
     const hasRunningAutoCompaction = this.hasRunningAutoCompactionOperation(this.snapshot);
     return hasRunningAutoCompaction ? "compacting context..." : undefined;
   }

--- a/test/core_runtime.test.js
+++ b/test/core_runtime.test.js
@@ -275,6 +275,44 @@ describe("core session rewind APIs", () => {
     expect(session.rawHistoryEntries[0].message.content[0].text).toBe("original");
   });
 
+  it("preserves the session id when compacting manually", async () => {
+    const faux = fauxProvider({
+      provider: "faux-manual-compact-session-id",
+      models: [{ id: "faux-manual-compact-session-id-model" }],
+    });
+    const unregisterFauxProvider = registerModelRuntimeProvider(faux.provider);
+
+    try {
+      faux.setResponses([fauxAssistantMessage(compactionSummary("## Goal\nContinue"))]);
+      const persona = {
+        id: "faux-manual-compact-session-id",
+        label: "faux manual compact session id",
+        model: faux.getModel(),
+        systemPrompt: "system",
+        settings: { reasoning: "none" },
+        skills: "*",
+        source: "builtin",
+      };
+      const session = new CoreSession({
+        persona,
+        systemPrompt: "system",
+        subagentPrompts: {},
+        riskLevel: "read-only",
+        toolRegistry: new ToolRegistry([]),
+      });
+
+      const sessionId = session.sessionId;
+      session.addUserText("remember this");
+      session.addMessage(fauxAssistantMessage("remembered"));
+
+      await session.compact({ mode: "only-summary" });
+
+      expect(session.sessionId).toBe(sessionId);
+    } finally {
+      unregisterFauxProvider();
+    }
+  });
+
   it("clamps auto-compaction retention to the threshold budget", async () => {
     const faux = fauxProvider({
       provider: "faux-auto-clamp",
@@ -320,11 +358,14 @@ describe("core session rewind APIs", () => {
       });
       session.addMessage(assistantMessageWithUsage("middle answer", 1000));
       session.addUserText("current request", { historyEntryId: "current-request" });
+      const sessionId = session.sessionId;
 
       const events = [];
       for await (const event of session.events(new AbortController().signal)) {
         events.push(event);
       }
+
+      expect(session.sessionId).toBe(sessionId);
 
       const compactionEnd = events.find(
         (event) => event.type === "compaction_end" && event.outcome === "compacted",

--- a/test/local_session_host.test.js
+++ b/test/local_session_host.test.js
@@ -463,6 +463,55 @@ describe("LocalSessionHost", () => {
     );
   });
 
+  it("clears running auto-compaction operations on compaction end", async () => {
+    const store = new MemorySessionStore();
+    const host = createHost(store);
+    const hostedSession = await host.createSession(localCreateInput);
+    await hostedSession.snapshot();
+
+    const deltas = [];
+    hostedSession.onDelta((delta) => deltas.push(delta));
+
+    await hostedSession.enqueueRuntimeEvent({ type: "compaction_start", reason: "threshold" });
+    expect(deltas.at(-1).delta.changes).toEqual([
+      expect.objectContaining({
+        type: "timeline.append",
+        item: expect.objectContaining({
+          type: "operation",
+          operation: expect.objectContaining({
+            kind: "auto-compaction",
+            status: "running",
+          }),
+        }),
+      }),
+    ]);
+
+    await hostedSession.enqueueRuntimeEvent({
+      type: "compaction_end",
+      reason: "threshold",
+      outcome: "compacted",
+      result: {
+        summaryHistoryEntryId: "summary-entry",
+        continuationHistoryEntryId: "continuation-entry",
+        compactionMessage: "compacted summary",
+        cutType: "turn-boundary",
+        retainedMessageCount: 1,
+      },
+    });
+
+    const reset = deltas.at(-1);
+    expect(reset.delta.type).toBe("snapshot.reset");
+    expect(reset.delta.snapshot.timeline).not.toContainEqual(
+      expect.objectContaining({
+        type: "operation",
+        operation: expect.objectContaining({
+          kind: "auto-compaction",
+          status: "running",
+        }),
+      }),
+    );
+  });
+
   it("streams assistant partials as content appends without persisting every frame", async () => {
     const store = new MemorySessionStore();
     const originalCommit = store.commitSessionSnapshot.bind(store);

--- a/test/session_chat_controller.test.js
+++ b/test/session_chat_controller.test.js
@@ -2648,6 +2648,52 @@ describe("SessionChatController", () => {
     );
   });
 
+  it("shows manual compaction status until the compact request finishes", async () => {
+    const session = new FakeSession();
+    const pendingCompact = deferred();
+    session.compact = vi.fn(async () => {
+      await pendingCompact.promise;
+      session.snapshotValue = updateSnapshot(session.snapshotValue, {
+        revision: session.snapshotValue.revision + 1,
+        historyEntries: [
+          {
+            id: "summary-entry",
+            message: {
+              role: "user",
+              content: [{ type: "text", text: "compacted summary" }],
+            },
+          },
+        ],
+      });
+      return {
+        snapshot: session.snapshotValue,
+        compactionMessage: "compacted summary",
+        includedLastAssistant: false,
+      };
+    });
+    const view = new FakeView();
+    const controller = new SessionChatController({
+      view,
+      session,
+      snapshot: await session.snapshot(),
+      targetLabel: "ssh host tau rpc",
+    });
+    controller.start();
+
+    controller.getInputHandlers().onSubmit("/compact:summary-only");
+    await flush();
+
+    expect(view.status.footer.commandHint).toBe("compacting context...");
+    controller.getInputHandlers().onSubmit("/risk:read-write");
+    await flush();
+    expect(session.setRiskLevel).not.toHaveBeenCalled();
+
+    pendingCompact.resolve();
+    await flush();
+
+    expect(view.status.footer.commandHint).toBeUndefined();
+  });
+
   it("uses the shared slash command parser for session command dispatch", async () => {
     const session = new FakeSession();
     const view = new FakeView();


### PR DESCRIPTION
## why

Compacting a session could make the active runtime generate a new session id while the TUI and SDK continued using the original id. Follow-up requests then failed with `session not found`, and the UI looked like it had drifted into a different session.

The compacting status also was not reliable across both compaction paths: manual compaction did not keep a persistent running footer status, and auto-compaction could leave the running operation in the final snapshot after completion.

## what

Keep the existing session id when replacing history during manual or automatic compaction.

Manual `/compact` now sets `compacting context...` while the request is in flight, blocks other session operations during that window, and clears the status when the request resolves or fails.

Auto-compaction now clears running auto-compaction operation timeline items before emitting the final snapshot reset on `compaction_end`, so the TUI footer clears when compaction finishes.

Added regressions for manual compaction, auto-compaction session-id stability, manual compact UI status, and auto-compact operation cleanup.

fixes #257
