### PR TITLE
use path-based Nook sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ tau tool pdf-unpack ./docs/spec.pdf
 
 ## Nook static mini-apps
 
-Nook is Tau's bundled Cloudflare-backed static mini-app platform. It deploys static directories to wildcard subdomains and gives each site same-origin JSON KV through an injected `window.nook` browser SDK.
+Nook is Tau's bundled Cloudflare-backed static mini-app platform. It deploys static directories to path-based site URLs and gives each site same-origin JSON KV through an injected `window.nook` browser SDK.
 
 ```sh
 tau nook setup \

--- a/src/core/nook/client.ts
+++ b/src/core/nook/client.ts
@@ -76,7 +76,7 @@ export class NookClient {
     if (!validation.ok) {
       throw new Error(validation.message);
     }
-    return `https://${site}.${this.config.domain}`;
+    return `https://${this.config.domain}/${site}`;
   }
 
   private authHeaders(): Record<string, string> {

--- a/src/core/nook/setup.ts
+++ b/src/core/nook/setup.ts
@@ -149,10 +149,7 @@ function writeWranglerProject(args: {
     main: "worker/index.js",
     compatibility_date: "2026-07-06",
     workers_dev: false,
-    routes: [
-      { pattern: `${args.domain}/*`, zone_name: args.zoneName },
-      { pattern: `*.${args.domain}/*`, zone_name: args.zoneName },
-    ],
+    routes: [{ pattern: `${args.domain}/*`, zone_name: args.zoneName }],
     vars: {
       NOOK_DOMAIN: args.domain,
       NOOK_ACCESS_TEAM_DOMAIN: args.accessTeamDomain,
@@ -213,9 +210,8 @@ export async function runNookSetup(args: NookSetupArgs): Promise<void> {
     stdout("");
     stdout("Configure DNS for:");
     stdout(`  ${args.domain}`);
-    stdout(`  *.${args.domain}`);
     stdout("");
-    stdout("Configure Cloudflare Access for both hostnames with application audience:");
+    stdout("Configure Cloudflare Access for this hostname with application audience:");
     stdout(`  ${args.accessAud}`);
     stdout("");
     stdout("Add this to Tau config after creating a Cloudflare Access service token:");

--- a/src/core/tools/nook.ts
+++ b/src/core/tools/nook.ts
@@ -16,7 +16,7 @@ import type {
 import { TOOL_NAME_NOOK } from "./tool_names.js";
 
 const NOOK_DESCRIPTION = [
-  "Operate the configured Nook platform: Tau's Cloudflare-backed static mini-app host for publishing built front-end artifacts to https://<site>.<nook-domain>/ with optional per-site same-origin JSON KV.",
+  "Operate the configured Nook platform: Tau's Cloudflare-backed static mini-app host for publishing built front-end artifacts to https://<nook-domain>/<site>/ with optional per-site same-origin JSON KV.",
   "Do not use this tool autonomously; use it only when the user asks to manage Nook, deploy/publish/host an app or artifact, inspect Nook state, or manage Nook KV.",
   "If the user asks to deploy a static artifact or mini-app, this is usually the right deployment target.",
   "All operations require read-write risk.",

--- a/src/nook/AGENTS.md
+++ b/src/nook/AGENTS.md
@@ -1,11 +1,11 @@
 # Nook
 
-Tau's Nook subtree contains the bundled Cloudflare-only static mini-app platform. Keep V0 narrow and explicit: static assets are deployed to wildcard subdomains, each site gets small same-origin JSON KV, and all infrastructure assumptions are Cloudflare Worker/R2/Durable Object based.
+Tau's Nook subtree contains the bundled Cloudflare-only static mini-app platform. Keep V0 narrow and explicit: static assets are deployed to path-based site URLs, each site gets small same-origin JSON KV, and all infrastructure assumptions are Cloudflare Worker/R2/Durable Object based.
 
 ## Scope
 
 - Supported: static asset hosting, per-site JSON KV, private/public active deployments, CLI setup/destroy/deploy/list/delete/KV operations, and the configured `nook` model tool.
-- Unsupported in V0: provider abstraction, dashboards, path-based app URLs, rollback/history, per-site server code, realtime, AI proxy APIs, ownership/roles, audit logs, `.gitignore`/`.nookignore`, and automatic DNS or Cloudflare Access setup.
+- Unsupported in V0: provider abstraction, dashboards, wildcard subdomain app URLs, rollback/history, per-site server code, realtime, AI proxy APIs, ownership/roles, audit logs, `.gitignore`/`.nookignore`, and automatic DNS or Cloudflare Access setup.
 - Build app artifacts outside Nook, then deploy the output directory. Do not add bundler-specific behavior to the Worker.
 
 ## Architecture
@@ -17,7 +17,7 @@ Tau's Nook subtree contains the bundled Cloudflare-only static mini-app platform
 
 ## Security and tenancy
 
-- The Worker must derive site scope from the hostname. Browser, CLI, and tool payloads must not be trusted to select another site's KV scope.
+- The Worker must derive site scope from the first URL path segment. Browser, CLI, and tool payloads must not be trusted to select another site's KV scope.
 - `/__nook/*` is reserved for platform endpoints and must never be served from user assets.
 - Setup and destroy are CLI-only infrastructure flows. The model tool must operate only an already configured Nook target.
 - Cloudflare Access service-token headers are only for passing Access. Worker authorization must rely on validated Access JWT claims, not raw service-token headers.

--- a/src/nook/README.md
+++ b/src/nook/README.md
@@ -1,12 +1,12 @@
 # Nook
 
-Nook is Tau's bundled Cloudflare-backed static mini-app platform. It deploys static directories to wildcard subdomains and gives each site a small same-origin JSON KV API exposed through `window.nook`.
+Nook is Tau's bundled Cloudflare-backed static mini-app platform. It deploys static directories to path-based site URLs and gives each site a small same-origin JSON KV API exposed through `window.nook`.
 
 V0 scope is intentionally narrow:
 
 - Cloudflare only: one Worker, R2 assets, a global Registry Durable Object, and one Site Durable Object per site.
 - Static assets only. Build locally first, then deploy the output directory.
-- Sites live at `https://<site>.<nook-domain>/`; there are no path-based app URLs or `workers.dev` fallback.
+- Sites live at `https://<nook-domain>/<site>/`; there are no wildcard subdomain app URLs or `workers.dev` fallback.
 - Deploys are private by default. `--public` makes the active deployment public; omitting it on the next deploy makes the active deployment private again.
 - Browser KV is per-site JSON state. It survives redeploys and is public-writable when the active deployment is public.
 
@@ -34,7 +34,7 @@ Setup deploys the bundled Worker as `tau-nook`, creates the `tau-nook-assets` R2
 }
 ```
 
-DNS and Cloudflare Access applications/policies are external V0 setup steps. Setup configures Worker routes for both `nook.example.com` and `*.nook.example.com` in the supplied Cloudflare zone. Configure DNS and Access according to your organization policy and service-token needs.
+DNS and Cloudflare Access applications/policies are external V0 setup steps. Setup configures a Worker route for `nook.example.com` in the supplied Cloudflare zone. Configure DNS and Access according to your organization policy and service-token needs.
 
 The setup command writes the Access team domain and application audience into the Worker environment. The Worker validates Cloudflare Access JWTs by loading the Access JWKS from that team domain and checking the token issuer, audience, expiry, and signature. Tau sends service-token headers to Cloudflare Access for CLI/API calls, but the Worker never treats raw service-token headers as authentication.
 
@@ -63,7 +63,8 @@ Deploy requirements:
 - Hidden files and directories are rejected, including `.env`, `.git`, and `.DS_Store`.
 - Symlinks are rejected.
 - `/__nook/*` is reserved and cannot be deployed.
-- Site slugs are lowercase subdomain labels with letters, numbers, and hyphens.
+- Site slugs are lowercase path labels with letters, numbers, and hyphens.
+- Apps should use relative asset URLs or be built with a base path of `/<site>/`.
 - Successful deploys exactly replace the active static asset set. KV data survives.
 - Uploads are checked against the manifest byte size and SHA-256 digest.
 - Each site can have at most three non-expired pending deploy sessions.
@@ -71,7 +72,7 @@ Deploy requirements:
 
 ## browser SDK
 
-The Worker injects `/__nook/client.js` into served HTML. App code can use:
+The Worker injects `/<site>/__nook/client.js` into served HTML. App code can use:
 
 ```js
 await window.nook.kv.put("settings", { theme: "dark" });

--- a/src/nook/worker/index.ts
+++ b/src/nook/worker/index.ts
@@ -143,20 +143,19 @@ const MAX_KV_KEY_LENGTH = 256;
 const MAX_KV_VALUE_BYTES = 64 * 1024;
 const MAX_KV_KEYS = 1_000;
 const MAX_KV_TOTAL_BYTES = 5 * 1024 * 1024;
-const NOOK_CLIENT_SCRIPT = '<script src="/__nook/client.js"></script>';
 const DEPLOYED_ASSET_CACHE_CONTROL = "public, no-cache, must-revalidate";
 
 const accessJwksCache = new Map<string, ReturnType<typeof createRemoteJWKSet>>();
 
 const SKILL_MARKDOWN = `# Nook
 
-Nook deploys static mini-apps to wildcard subdomains and gives each site same-origin JSON KV through window.nook.
+Nook deploys static mini-apps to path-based site URLs and gives each site same-origin JSON KV through window.nook.
 
 Deploy a finished static directory only. The directory must contain /index.html, must not contain hidden files or symlinks, and must not contain files under /__nook/.
 
-Sites are served at https://<site>.<nook-domain>/. App URLs are subdomains only.
+Sites are served at https://<nook-domain>/<site>/.
 
-The Worker injects /__nook/client.js into HTML. Browser code can use:
+The Worker injects /<site>/__nook/client.js into HTML. Browser code can use:
 
 \`\`\`js
 await window.nook.kv.put("settings", { theme: "dark" });
@@ -169,6 +168,14 @@ KV is per-site, JSON-only, and survives redeploys. Public deployments expose pub
 `;
 
 const CLIENT_JS = `(() => {
+  const script = document.currentScript;
+  const scriptUrl = script && script.src
+    ? new URL(script.src)
+    : new URL("/__nook/client.js", window.location.origin);
+  const basePath = scriptUrl.pathname.replace(/\\/__nook\\/client\\.js$/, "");
+  function apiPath(path) {
+    return basePath + path;
+  }
   async function request(path, options = {}) {
     const response = await fetch(path, {
       ...options,
@@ -191,20 +198,20 @@ const CLIENT_JS = `(() => {
   window.nook = {
     kv: {
       async get(key) {
-        const payload = await request("/__nook/kv/" + encodeURIComponent(key));
+        const payload = await request(apiPath("/__nook/kv/" + encodeURIComponent(key)));
         return payload.value;
       },
       async put(key, value) {
-        await request("/__nook/kv/" + encodeURIComponent(key), {
+        await request(apiPath("/__nook/kv/" + encodeURIComponent(key)), {
           method: "PUT",
           body: JSON.stringify(value)
         });
       },
       async delete(key) {
-        await request("/__nook/kv/" + encodeURIComponent(key), { method: "DELETE" });
+        await request(apiPath("/__nook/kv/" + encodeURIComponent(key)), { method: "DELETE" });
       },
       async list(options = {}) {
-        const url = new URL("/__nook/kv", window.location.origin);
+        const url = new URL(apiPath("/__nook/kv"), window.location.origin);
         if (options.prefix) url.searchParams.set("prefix", options.prefix);
         const payload = await request(url.pathname + url.search);
         return payload.keys;
@@ -371,18 +378,38 @@ function validateManifest(files: ManifestFile[]): string | undefined {
   return undefined;
 }
 
-function parseHost(
-  url: URL,
-  env: Env,
-): { kind: "base" } | { kind: "site"; slug: string } | undefined {
+function parseHost(url: URL, env: Env): { kind: "base" } | undefined {
   const domain = env.NOOK_DOMAIN.toLowerCase();
   const host = url.hostname.toLowerCase();
   if (host === domain) return { kind: "base" };
-  if (host.endsWith(`.${domain}`)) {
-    const slug = host.slice(0, -(domain.length + 1));
-    if (!slug.includes(".") && !validateSlug(slug)) return { kind: "site", slug };
-  }
   return undefined;
+}
+
+type SitePath = {
+  slug: string;
+  sitePath: string;
+  needsSlashRedirect: boolean;
+};
+
+function parseSitePath(pathname: string): SitePath | undefined {
+  const match = pathname.match(/^\/([^/]+)(\/.*)?$/);
+  if (!match) return undefined;
+
+  let slug: string;
+  try {
+    slug = decodeURIComponent(match[1]!);
+  } catch {
+    return undefined;
+  }
+  const slugError = validateSlug(slug);
+  if (slugError) return undefined;
+
+  const rest = match[2];
+  return {
+    slug,
+    sitePath: rest && rest !== "/" ? rest : "/index.html",
+    needsSlashRedirect: rest === undefined,
+  };
 }
 
 async function readJson(request: Request): Promise<unknown> {
@@ -412,6 +439,10 @@ async function siteFetch(
 
 function assetKey(site: string, deploymentId: string, path: string): string {
   return `sites/${site}/deployments/${deploymentId}${path}`;
+}
+
+function siteUrl(domain: string, site: string): string {
+  return `https://${domain}/${site}/`;
 }
 
 async function sha256Hex(bytes: ArrayBuffer): Promise<string> {
@@ -545,7 +576,7 @@ async function handleBaseApi(
     const result = {
       ...rawResult,
       site,
-      url: `https://${site}.${env.NOOK_DOMAIN}`,
+      url: siteUrl(env.NOOK_DOMAIN, site),
     };
     await registryFetch(env, `/sites/${encodeURIComponent(site)}/deploy`, {
       method: "POST",
@@ -568,11 +599,12 @@ async function handleKv(
   env: Env,
   site: string,
   identity: Identity,
+  sitePath: string,
 ): Promise<Response> {
   return await siteFetch(
     env,
     site,
-    `/kv${new URL(request.url).pathname.slice("/__nook/kv".length)}${new URL(request.url).search}`,
+    `/kv${sitePath.slice("/__nook/kv".length)}${new URL(request.url).search}`,
     {
       method: request.method,
       headers: { "x-nook-actor": identity.actor },
@@ -590,21 +622,31 @@ export function cacheControlForDeployedAsset(): string {
   return DEPLOYED_ASSET_CACHE_CONTROL;
 }
 
-function injectNookClientScript(response: Response): Response {
+function nookClientScriptTag(site: string): string {
+  return `<script src="/${site}/__nook/client.js"></script>`;
+}
+
+function injectNookClientScript(response: Response, site: string): Response {
+  const scriptTag = nookClientScriptTag(site);
   const injector: HtmlRewriterHandler = {
     element(element) {
-      element.onEndTag((endTag) => endTag.before(NOOK_CLIENT_SCRIPT, { html: true }));
+      element.onEndTag((endTag) => endTag.before(scriptTag, { html: true }));
       delete injector.end;
     },
     end(end) {
-      end.append(NOOK_CLIENT_SCRIPT, { html: true });
+      end.append(scriptTag, { html: true });
     },
   };
 
   return new HTMLRewriter().on("body", injector).onDocument(injector).transform(response);
 }
 
-async function serveAsset(request: Request, env: Env, site: string, url: URL): Promise<Response> {
+async function serveAsset(
+  request: Request,
+  env: Env,
+  site: string,
+  sitePath: string,
+): Promise<Response> {
   const activeResponse = await siteFetch(env, site, "/active");
   if (!activeResponse.ok) return error("site_not_found", "Site has no active deployment", 404);
   const active = (await activeResponse.json()) as {
@@ -616,19 +658,19 @@ async function serveAsset(request: Request, env: Env, site: string, url: URL): P
     ? await optionalAccessIdentity(request, env)
     : await requireAccessIdentity(request, env);
 
-  if (url.pathname === "/__nook/client.js") {
+  if (sitePath === "/__nook/client.js") {
     return new Response(CLIENT_JS, {
       headers: { "content-type": "application/javascript; charset=utf-8" },
     });
   }
-  if (url.pathname === "/__nook/kv" || url.pathname.startsWith("/__nook/kv/")) {
-    return await handleKv(request, env, site, identity);
+  if (sitePath === "/__nook/kv" || sitePath.startsWith("/__nook/kv/")) {
+    return await handleKv(request, env, site, identity, sitePath);
   }
-  if (url.pathname === RESERVED_PREFIX || url.pathname.startsWith(`${RESERVED_PREFIX}/`)) {
+  if (sitePath === RESERVED_PREFIX || sitePath.startsWith(`${RESERVED_PREFIX}/`)) {
     return error("not_found", "Unknown Nook route", 404);
   }
 
-  const normalized = normalizeAssetPath(url.pathname === "/" ? "/index.html" : url.pathname);
+  const normalized = normalizeAssetPath(sitePath);
   if (!normalized) return error("invalid_path", "Invalid path", 400);
 
   let object = await env.ASSETS.get(assetKey(site, active.deploymentId, normalized));
@@ -648,7 +690,7 @@ async function serveAsset(request: Request, env: Env, site: string, url: URL): P
   });
 
   if (contentType.startsWith("text/html")) {
-    return injectNookClientScript(new Response(object.body ?? "", { headers }));
+    return injectNookClientScript(new Response(object.body ?? "", { headers }), site);
   }
 
   return new Response(object.body, { headers });
@@ -667,15 +709,19 @@ export default {
         });
       }
 
-      if (parsedHost.kind === "base") {
-        if (url.pathname.startsWith("/__nook/api/")) {
-          const identity = await requireAccessIdentity(request, env);
-          return await handleBaseApi(request, env, url, identity);
-        }
-        return error("not_found", "Nook base domain only serves platform APIs", 404);
+      if (url.pathname.startsWith("/__nook/api/")) {
+        const identity = await requireAccessIdentity(request, env);
+        return await handleBaseApi(request, env, url, identity);
       }
 
-      return await serveAsset(request, env, parsedHost.slug, url);
+      const sitePath = parseSitePath(url.pathname);
+      if (!sitePath) return error("not_found", "Unknown Nook route", 404);
+      if (sitePath.needsSlashRedirect) {
+        const redirectUrl = new URL(request.url);
+        redirectUrl.pathname = `${redirectUrl.pathname}/`;
+        return Response.redirect(redirectUrl.toString(), 308);
+      }
+      return await serveAsset(request, env, sitePath.slug, sitePath.sitePath);
     } catch (err) {
       if (err instanceof ErrorResponse) return err.toResponse();
       return error("internal_error", err instanceof Error ? err.message : String(err), 500);
@@ -703,7 +749,7 @@ export class RegistryDO {
       return json({
         sites: [...records.values()].map((site) => ({
           ...site,
-          url: `https://${site.slug}.${domain}`,
+          url: siteUrl(domain, site.slug),
         })),
       });
     }
@@ -716,7 +762,7 @@ export class RegistryDO {
       const timestamp = now();
       const site: SiteSummary = {
         slug: body.slug,
-        url: `https://${body.slug}.${body.domain}`,
+        url: siteUrl(body.domain, body.slug),
         createdAt: timestamp,
         updatedAt: timestamp,
       };

--- a/test/nook.test.js
+++ b/test/nook.test.js
@@ -25,7 +25,7 @@ afterEach(() => {
 });
 
 describe("nook validation", () => {
-  it("accepts subdomain-safe slugs and rejects reserved or malformed slugs", () => {
+  it("accepts path-safe slugs and rejects reserved or malformed slugs", () => {
     expect(validateNookSiteSlug("demo-app").ok).toBe(true);
     expect(validateNookSiteSlug("Demo").ok).toBe(false);
     expect(validateNookSiteSlug("api").ok).toBe(false);
@@ -155,6 +155,70 @@ describe("nook worker", () => {
     expect(await response.json()).toEqual({ sites: [] });
     expect(registryFetch).toHaveBeenCalledOnce();
   });
+
+  it("serves sites from the first path segment", async () => {
+    const response = await worker.fetch(
+      new Request("https://nook.example.com/demo", { redirect: "manual" }),
+      {
+        ASSETS: {},
+        REGISTRY_DO: {
+          idFromName: (name) => name,
+          get: () => ({ fetch: vi.fn() }),
+        },
+        SITE_DO: {
+          idFromName: (name) => name,
+          get: () => ({ fetch: vi.fn() }),
+        },
+        NOOK_DOMAIN: "nook.example.com",
+        NOOK_ACCESS_TEAM_DOMAIN: "https://team.cloudflareaccess.com",
+        NOOK_ACCESS_AUD: "aud",
+      },
+    );
+
+    expect(response.status).toBe(308);
+    expect(response.headers.get("location")).toBe("https://nook.example.com/demo/");
+  });
+
+  it("routes browser KV through the path-scoped site Durable Object", async () => {
+    const siteFetch = vi.fn(async (request) => {
+      const url = new URL(request.url);
+      if (url.pathname === "/active") {
+        return Response.json({
+          deploymentId: "dep_1",
+          public: true,
+          files: [{ path: "/index.html", contentType: "text/html; charset=utf-8" }],
+        });
+      }
+      if (url.pathname === "/kv/settings") {
+        return Response.json({ value: { theme: "dark" } });
+      }
+      return Response.json({ error: { message: "unexpected" } }, { status: 404 });
+    });
+
+    const response = await worker.fetch(
+      new Request("https://nook.example.com/demo/__nook/kv/settings"),
+      {
+        ASSETS: {},
+        REGISTRY_DO: {
+          idFromName: (name) => name,
+          get: () => ({ fetch: vi.fn() }),
+        },
+        SITE_DO: {
+          idFromName: (name) => name,
+          get: () => ({ fetch: siteFetch }),
+        },
+        NOOK_DOMAIN: "nook.example.com",
+        NOOK_ACCESS_TEAM_DOMAIN: "https://team.cloudflareaccess.com",
+        NOOK_ACCESS_AUD: "aud",
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ value: { theme: "dark" } });
+    expect(siteFetch).toHaveBeenCalledWith(
+      expect.objectContaining({ url: "https://site.local/kv/settings" }),
+    );
+  });
 });
 
 describe("nook setup cli parsing", () => {
@@ -238,7 +302,7 @@ describe("nook setup cli parsing", () => {
         'if (args[0] === "deploy") {',
         '  const config = JSON.parse(readFileSync(join(process.cwd(), "wrangler.json"), "utf-8"));',
         '  if (config.main !== "worker/index.js") process.exit(31);',
-        '  if (JSON.stringify(config.routes) !== JSON.stringify([{ pattern: "nook.example.com/*", zone_name: "example.com" }, { pattern: "*.nook.example.com/*", zone_name: "example.com" }])) process.exit(34);',
+        '  if (JSON.stringify(config.routes) !== JSON.stringify([{ pattern: "nook.example.com/*", zone_name: "example.com" }])) process.exit(34);',
         '  if (!existsSync(join(process.cwd(), "worker", "index.js"))) process.exit(32);',
         '  if (!existsSync(join(process.cwd(), "node_modules", "jose", "package.json"))) process.exit(33);',
         "}",


### PR DESCRIPTION
## why

Wildcard subdomains have been unreliable for Nook deployments. Nook should use a single configured domain and route each site through a stable path-based URL instead.

## what

This changes Nook site URLs to `https://<nook-domain>/<site>/`, updates Worker routing to derive site scope from the first path segment, and keeps platform APIs at the root `__nook` API namespace. The injected browser SDK now lives under the site path and derives its KV API base from its own script URL.

The Tau client, setup flow, assistant tool description, Nook docs, and tests now describe and verify the path-based contract.
