### PR TITLE
fix diff review agents

### DIFF
--- a/src/core/diff_review/bridge.ts
+++ b/src/core/diff_review/bridge.ts
@@ -81,7 +81,7 @@ export type StartedDiffReviewBridge = {
   result: Promise<DiffReviewResult>;
 };
 
-export type DiffReviewAgentStatus = "running" | "idle";
+export type DiffReviewAgentStatus = "running" | "idle" | "failed";
 
 export type DiffReviewAgentActivity = {
   threadId: string;
@@ -517,6 +517,7 @@ export class DiffReviewBridge {
           forkFromThreadId?: string;
         }
       | undefined;
+    let failed = false;
     try {
       acquired = this.acquireThreadForSubmit(request.params);
       const result = await this.submitThreadMessage({
@@ -532,6 +533,11 @@ export class DiffReviewBridge {
         response: result.response,
       });
     } catch (error) {
+      const message = formatThreadSubmitError(error);
+      if (acquired) {
+        failed = true;
+        this.markReviewAgentFailed(acquired.threadId, message);
+      }
       if (this.completedResult || connection.socket.destroyed) {
         return;
       }
@@ -539,14 +545,9 @@ export class DiffReviewBridge {
         await this.sendError(connection, request.id, error.code, error.message);
         return;
       }
-      await this.sendError(
-        connection,
-        request.id,
-        "internalError",
-        error instanceof Error ? error.message : String(error),
-      );
+      await this.sendError(connection, request.id, "internalError", message);
     } finally {
-      if (acquired) {
+      if (acquired && !failed) {
         this.markReviewAgentIdle(acquired.threadId);
       }
     }
@@ -640,6 +641,14 @@ export class DiffReviewBridge {
       record.status = "idle";
       this.syncReviewAgents();
     }
+  }
+
+  private markReviewAgentFailed(threadId: string, message: string): void {
+    const record = this.ensureReviewAgentRecord(threadId);
+    record.activeRequestCount = 0;
+    record.status = "failed";
+    record.lastActivityText = `agent failed: ${message}`;
+    this.syncReviewAgents();
   }
 
   applyThreadUpdate(threadId: string, update: DiffReviewThreadUpdate): void {
@@ -948,6 +957,25 @@ export class DiffReviewBridge {
       }
     }
   }
+}
+
+function formatThreadSubmitError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  const data =
+    typeof error === "object" && error !== null ? (error as { data?: unknown }).data : undefined;
+  const cause =
+    typeof data === "object" &&
+    data !== null &&
+    "cause" in data &&
+    typeof data.cause === "string" &&
+    data.cause.trim()
+      ? data.cause.trim()
+      : undefined;
+
+  if (!cause || cause === message) {
+    return message;
+  }
+  return `${message}: ${cause}`;
 }
 
 function createEmptyReviewAgentUsage(contextWindow: number): DiffReviewAgentUsageSnapshot {

--- a/src/core/session/session_engine.ts
+++ b/src/core/session/session_engine.ts
@@ -694,10 +694,7 @@ export class SessionEngine {
     }
 
     const nook = this.toolRegistry.get(TOOL_NAME_NOOK);
-    if (!nook) {
-      throw new Error("nook tool is not registered");
-    }
-    return [nook];
+    return nook ? [nook] : [];
   }
 
   private createDispatchModelResolver(): ModelResolver {

--- a/src/host/session_protocol_handler.ts
+++ b/src/host/session_protocol_handler.ts
@@ -1133,17 +1133,27 @@ export class SessionProtocolHandler {
       return;
     }
 
-    const result = await state.session.submitEphemeralThread({
-      contextId: request.params.contextId,
-      threadId: request.params.threadId,
-      ...(request.params.forkFromThreadId !== undefined
-        ? { forkFromThreadId: request.params.forkFromThreadId }
-        : {}),
-      message: request.params.message,
-    });
-    this.sendMessage(
-      createSessionProtocolSuccessResponse(request.id, "session.ephemeral.submit", result),
-    );
+    try {
+      const result = await state.session.submitEphemeralThread({
+        contextId: request.params.contextId,
+        threadId: request.params.threadId,
+        ...(request.params.forkFromThreadId !== undefined
+          ? { forkFromThreadId: request.params.forkFromThreadId }
+          : {}),
+        message: request.params.message,
+      });
+      this.sendMessage(
+        createSessionProtocolSuccessResponse(request.id, "session.ephemeral.submit", result),
+      );
+    } catch (error) {
+      this.sendMessage(
+        createSessionProtocolErrorResponse(
+          request.id,
+          SESSION_PROTOCOL_ERROR_CODES.internalError,
+          error instanceof Error ? error.message : String(error),
+        ),
+      );
+    }
   }
 
   private async handleEphemeralClose(

--- a/src/tui/ui/agent_activity_format.ts
+++ b/src/tui/ui/agent_activity_format.ts
@@ -76,6 +76,11 @@ export function formatAgentActivityText(text: string): string | undefined {
   const trimmed = text.trim();
   if (!trimmed) return undefined;
 
+  if (trimmed.startsWith("agent failed: ")) {
+    const line = trimmed.slice("agent failed: ".length).trim();
+    return line ? `agent failed: ${line}` : "agent failed";
+  }
+
   if (trimmed.startsWith("agent: ")) {
     const line = trimmed.slice("agent: ".length).trim();
     return line ? `> ${line}` : undefined;

--- a/src/tui/ui/diff_review_message.ts
+++ b/src/tui/ui/diff_review_message.ts
@@ -2,7 +2,7 @@ import type { Component } from "@earendil-works/pi-tui";
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import type { DiffReviewAgentActivity } from "../../core/diff_review/index.js";
 import { formatUsageSnapshot, formatUsdCost } from "../../core/utils/format.js";
-import { formatToolActivityText } from "./agent_activity_format.js";
+import { formatAgentActivityText } from "./agent_activity_format.js";
 import {
   type OneLineSegment,
   truncateFromEndByWidthPreserveAnsi,
@@ -120,7 +120,7 @@ function buildReviewAgentLines(
   reviewAgents.forEach((agent, index) => {
     lines.push([reviewMain(theme, agent.threadId), reviewMuted(theme, ` (${agent.status})`)]);
 
-    const activityText = formatToolActivityText(agent.lastActivityText ?? "");
+    const activityText = formatAgentActivityText(agent.lastActivityText ?? "");
     if (activityText) {
       lines.push([reviewDim(theme, activityText)]);
     }

--- a/test/core_runtime.test.js
+++ b/test/core_runtime.test.js
@@ -275,6 +275,45 @@ describe("core session rewind APIs", () => {
     expect(session.rawHistoryEntries[0].message.content[0].text).toBe("original");
   });
 
+  it("does not require nook in restricted registries when nook is configured", async () => {
+    const faux = fauxProvider({
+      provider: "faux-restricted-nook",
+      models: [{ id: "faux-restricted-nook-model" }],
+    });
+    const unregisterFauxProvider = registerModelRuntimeProvider(faux.provider);
+
+    try {
+      faux.setResponses([fauxAssistantMessage("done")]);
+      const persona = {
+        id: "faux-restricted-nook",
+        label: "faux restricted nook",
+        model: faux.getModel(),
+        systemPrompt: "system",
+        settings: { reasoning: "none" },
+        skills: "*",
+        source: "builtin",
+      };
+      const session = new CoreSession({
+        persona,
+        systemPrompt: "system",
+        subagentPrompts: {},
+        riskLevel: "read-only",
+        toolRegistry: new ToolRegistry([]),
+        config: { nook: { domain: "nook.example.com" } },
+      });
+
+      session.addUserText("hello");
+      const events = [];
+      for await (const event of session.events(new AbortController().signal)) {
+        events.push(event);
+      }
+
+      expect(events).toContainEqual(expect.objectContaining({ type: "assistant_final" }));
+    } finally {
+      unregisterFauxProvider();
+    }
+  });
+
   it("preserves the session id when compacting manually", async () => {
     const faux = fauxProvider({
       provider: "faux-manual-compact-session-id",

--- a/test/diff_review_bridge.test.js
+++ b/test/diff_review_bridge.test.js
@@ -738,6 +738,59 @@ describe("diff review bridge", () => {
     }
   });
 
+  it("keeps failed review agents visible after wrapped thread submit errors", async () => {
+    const bridge = createDiffReviewBridge({
+      snapshot: createSnapshot(),
+      persona: personas[0],
+      config: {},
+      createThread: () =>
+        createThreadSession({
+          async submitMessage() {
+            throw Object.assign(new Error("session protocol request failed"), {
+              data: { cause: "model provider rejected the request" },
+            });
+          },
+        }),
+    });
+
+    await bridge.start();
+    const client = await connectClient(bridge);
+
+    try {
+      await client.send("init", "initialize", {
+        token: bridge.launchEnvironment.TAU_DIFF_TOKEN,
+      });
+
+      const result = await client.send("thread", "thread.submit_message", {
+        message: "What changed?",
+      });
+      expect(result).toEqual({
+        version: DIFF_REVIEW_PROTOCOL_VERSION,
+        type: "response",
+        id: "thread",
+        ok: false,
+        error: {
+          code: "internal_error",
+          message: "session protocol request failed: model provider rejected the request",
+        },
+      });
+      expect(bridge.getUiState().reviewAgents).toEqual([
+        {
+          threadId: expect.stringMatching(/^[0-9a-f-]{36}$/),
+          status: "failed",
+          costTotal: 0,
+          usage: createEmptyUsage(personas[0].model.contextWindow),
+          lastActivityText:
+            "agent failed: session protocol request failed: model provider rejected the request",
+        },
+      ]);
+    } finally {
+      client.rl.close();
+      client.socket.destroy();
+      await bridge.close();
+    }
+  });
+
   it("preserves exact file paths when serving per-file diffs", async () => {
     const exactPath = " src/\todd name .ts ";
     const patch = [

--- a/test/in_process_session_transport.test.js
+++ b/test/in_process_session_transport.test.js
@@ -126,6 +126,18 @@ function createHostedSession(sessionId, sessions, options = {}) {
         output: "/repo\n",
       });
     },
+    async createEphemeralContext() {
+      return { contextId: "ephemeral-1" };
+    },
+    async submitEphemeralThread() {
+      if (options.ephemeralSubmitError) {
+        throw options.ephemeralSubmitError;
+      }
+      return { threadId: "thread-1", response: "ephemeral response" };
+    },
+    async closeEphemeralContext() {
+      return { closed: true };
+    },
     setRiskLevel(nextRiskLevel) {
       riskLevel = nextRiskLevel;
     },
@@ -331,6 +343,29 @@ describe("InProcessSessionProtocolTransport", () => {
     await reconnectedSession.unobserve();
     await reconnectedClient.close();
     expect(sessions.size).toBe(1);
+  });
+
+  it("returns ephemeral submit failures without handler-level wrapping", async () => {
+    const { createSession, host } = createHost();
+    const hostedSession = createSession({
+      ephemeralSubmitError: new Error("model provider rejected the request"),
+    });
+    const transport = new InProcessSessionProtocolTransport({ host });
+    const client = await createTauSdkClientFromTransport(transport);
+    const session = await client.sessions.observe(hostedSession.sessionId);
+
+    await expect(
+      session.submitEphemeralThread({
+        contextId: "ephemeral-1",
+        threadId: "thread-1",
+        message: "review this",
+      }),
+    ).rejects.toMatchObject({
+      code: "internal_error",
+      message: "model provider rejected the request",
+    });
+
+    await client.close();
   });
 
   it("can shut down an owned host on close", async () => {

--- a/test/ui_components.test.js
+++ b/test/ui_components.test.js
@@ -171,7 +171,7 @@ test("renderChatMessage renders diff review status with review styling", () => {
   expect(plainText).toContain("$0.12");
   expect(plainText).toContain("$ git diff --staged");
   expect(plainText).toContain("$ (error): permission denied");
-  expect(plainText).not.toContain("reviewer brief ready");
+  expect(plainText).toContain("> reviewer brief ready");
 });
 
 test("AssistantMessageComponent toggles thinking visibility", () => {


### PR DESCRIPTION
## why

Diff-review thread agents could appear to sit idle forever when their underlying ephemeral request failed. In Nook-configured sessions, restricted diff-review agents failed before the model turn started because the session engine tried to inject the Nook tool into a registry that intentionally did not expose it.

## what

This makes configured Nook injection conditional on the active registry exposing the Nook tool, so restricted ephemeral agents can run without Nook. It also keeps failed diff-review agents visible in the TUI with the underlying failure text, and avoids wrapping ephemeral submit failures in a generic session protocol error.

fixes #266
