### PR TITLE
add speech transcription context

### DIFF
--- a/src/core/telegram/adapter.ts
+++ b/src/core/telegram/adapter.ts
@@ -7,6 +7,10 @@ import type { SessionProtocolSnapshot } from "../../protocol/session_protocol.js
 import type { SpeechToTextProvider, TelegramProjectConfig } from "../config/schema.js";
 import { formatAdaptiveNumber, formatTokenWindow } from "../utils/format.js";
 import { transcribeAudio } from "../utils/speech_to_text.js";
+import {
+  collectSpeechToTextContext,
+  type SpeechToTextContext,
+} from "../utils/speech_to_text_context.js";
 import { formatTauUserText, splitTauUserText } from "../utils/user_metadata.js";
 import { formatZodError } from "../utils/zod.js";
 import {
@@ -2219,6 +2223,22 @@ class TelegramAdapterImpl {
     }
   }
 
+  private async resolveSpeechToTextContext(
+    chatId: number,
+  ): Promise<SpeechToTextContext | undefined> {
+    const session = this.getActiveSession(chatId);
+    if (!session) {
+      return undefined;
+    }
+
+    try {
+      const snapshot = await this.getSessionManagerForChat(chatId).getSessionSnapshot(session.id);
+      return snapshot ? collectSpeechToTextContext(snapshot) : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
   private getSpeechToTextApiKey(): string | undefined {
     return this.speechToTextProvider === "gemini" ? this.geminiApiKey : this.mistralApiKey;
   }
@@ -2253,6 +2273,7 @@ class TelegramAdapterImpl {
           audio,
           fileName: message.fileName,
           mimeType: message.mimeType,
+          context: await this.resolveSpeechToTextContext(chatId),
           fetchImpl: this.fetchImpl,
         })
       ).trim();

--- a/src/core/utils/gemini_transcription.ts
+++ b/src/core/utils/gemini_transcription.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { formatSpeechToTextContext, type SpeechToTextContext } from "./speech_to_text_context.js";
 
 const GEMINI_GENERATE_CONTENT_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/models";
 const DEFAULT_GEMINI_TRANSCRIPTION_MODEL = "gemini-3.5-flash";
@@ -44,6 +45,7 @@ export type GeminiTranscriptionOptions = {
   audio: Buffer;
   model?: string;
   mimeType?: string;
+  context?: SpeechToTextContext;
   fetchImpl?: typeof fetch;
 };
 
@@ -75,7 +77,7 @@ export async function transcribeGeminiAudio(options: GeminiTranscriptionOptions)
           {
             parts: [
               {
-                text: buildTranscriptionPrompt(),
+                text: buildTranscriptionPrompt(options.context),
               },
               {
                 inlineData: {
@@ -128,11 +130,24 @@ function buildTranscriptionSystemInstruction(): string {
   ].join("\n");
 }
 
-function buildTranscriptionPrompt(): string {
+function buildTranscriptionPrompt(context: SpeechToTextContext | undefined): string {
+  const formattedContext = formatSpeechToTextContext(context);
   return [
     "Transcribe the attached audio into the transcription field.",
     "Return only the lightly cleaned transcript text, with no timestamps or commentary.",
-  ].join("\n");
+    formattedContext
+      ? [
+          "Use the recent conversation context below only to resolve likely words, names, acronyms, terminology, and references in the audio.",
+          "Do not transcribe the context itself, and do not add words from the context that were not spoken.",
+          "If the audio is ambiguous, prefer the transcription that best fits this context.",
+          "",
+          "Recent conversation context:",
+          formattedContext,
+        ].join("\n")
+      : undefined,
+  ]
+    .filter((line): line is string => line !== undefined)
+    .join("\n");
 }
 
 function extractGeminiText(payload: unknown): string {

--- a/src/core/utils/messages.ts
+++ b/src/core/utils/messages.ts
@@ -1,4 +1,5 @@
-import type { AssistantMessage, ToolCall, ToolResultMessage } from "@earendil-works/pi-ai";
+import type { AssistantMessage, Message, ToolCall, ToolResultMessage } from "@earendil-works/pi-ai";
+import { stripTauUserDisplayText } from "./user_metadata.js";
 
 export function extractAssistantText(message: AssistantMessage): string {
   return message.content
@@ -6,6 +7,23 @@ export function extractAssistantText(message: AssistantMessage): string {
     .map((c) => c.text)
     .join("\n")
     .trim();
+}
+
+export function extractUserText(message: Message): string {
+  if (message.role !== "user") {
+    return "";
+  }
+
+  if (typeof message.content === "string") {
+    return stripTauUserDisplayText(message.content);
+  }
+
+  return stripTauUserDisplayText(
+    message.content
+      .filter((block) => block.type === "text")
+      .map((block) => block.text)
+      .join("\n"),
+  );
 }
 
 export function createToolResult(

--- a/src/core/utils/speech_to_text.ts
+++ b/src/core/utils/speech_to_text.ts
@@ -1,6 +1,7 @@
 import type { SpeechToTextProvider } from "../config/schema.js";
 import { transcribeGeminiAudio } from "./gemini_transcription.js";
 import { transcribeMistralAudio } from "./mistral_transcription.js";
+import type { SpeechToTextContext } from "./speech_to_text_context.js";
 
 export type SpeechToTextOptions = {
   provider: SpeechToTextProvider;
@@ -9,6 +10,7 @@ export type SpeechToTextOptions = {
   mimeType?: string;
   fileName?: string;
   language?: string;
+  context?: SpeechToTextContext;
   fetchImpl?: typeof fetch;
 };
 
@@ -19,6 +21,7 @@ export async function transcribeAudio(options: SpeechToTextOptions): Promise<str
         apiKey: options.apiKey,
         audio: options.audio,
         mimeType: options.mimeType,
+        context: options.context,
         fetchImpl: options.fetchImpl,
       });
     case "mistral":

--- a/src/core/utils/speech_to_text_context.ts
+++ b/src/core/utils/speech_to_text_context.ts
@@ -54,12 +54,19 @@ export function formatSpeechToTextContext(context: SpeechToTextContext | undefin
     return "";
   }
 
-  return messages
-    .map((message, index) => {
-      const label = message.role === "user" ? "User" : "Assistant";
-      return `${index + 1}. ${label}: ${message.text.trim()}`;
-    })
-    .join("\n\n");
+  return [
+    "<speech-to-text-context>",
+    ...messages.flatMap((message, index) => [
+      `  <message index="${index + 1}" role="${message.role}">`,
+      escapeXml(message.text.trim()),
+      "  </message>",
+    ]),
+    "</speech-to-text-context>",
+  ].join("\n");
+}
+
+function escapeXml(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
 function findContextStartIndex(snapshot: SessionProtocolSnapshot): number | undefined {

--- a/src/core/utils/speech_to_text_context.ts
+++ b/src/core/utils/speech_to_text_context.ts
@@ -1,0 +1,79 @@
+import type { AssistantMessage, Message } from "@earendil-works/pi-ai";
+import type { SessionProtocolSnapshot } from "../../protocol/session_protocol.js";
+import { extractAssistantText, extractUserText } from "./messages.js";
+
+const MAX_SPEECH_TO_TEXT_CONTEXT_MESSAGES_PER_ROLE = 2;
+const MAX_SPEECH_TO_TEXT_CONTEXT_MESSAGE_CHARS = 2_000;
+
+export type SpeechToTextContextMessage = {
+  role: "user" | "assistant";
+  text: string;
+};
+
+export type SpeechToTextContext = {
+  messages: SpeechToTextContextMessage[];
+};
+
+export function collectSpeechToTextContext(snapshot: SessionProtocolSnapshot): SpeechToTextContext {
+  const selected: SpeechToTextContextMessage[] = [];
+  let userMessages = 0;
+  let assistantMessages = 0;
+
+  for (let index = snapshot.messages.length - 1; index >= 0; index -= 1) {
+    const entry = snapshot.messages[index];
+    if (entry?.state !== "committed") {
+      continue;
+    }
+
+    const message = entry.message;
+    if (message.role === "user") {
+      if (userMessages >= MAX_SPEECH_TO_TEXT_CONTEXT_MESSAGES_PER_ROLE) {
+        continue;
+      }
+      const text = truncateContextMessage(extractUserText(message as Message));
+      if (!text) {
+        continue;
+      }
+      selected.push({ role: "user", text });
+      userMessages += 1;
+      continue;
+    }
+
+    if (message.role === "assistant") {
+      if (assistantMessages >= MAX_SPEECH_TO_TEXT_CONTEXT_MESSAGES_PER_ROLE) {
+        continue;
+      }
+      const text = truncateContextMessage(extractAssistantText(message as AssistantMessage));
+      if (!text) {
+        continue;
+      }
+      selected.push({ role: "assistant", text });
+      assistantMessages += 1;
+    }
+  }
+
+  selected.reverse();
+  return { messages: selected };
+}
+
+export function formatSpeechToTextContext(context: SpeechToTextContext | undefined): string {
+  const messages = context?.messages.filter((message) => message.text.trim()) ?? [];
+  if (messages.length === 0) {
+    return "";
+  }
+
+  return messages
+    .map((message, index) => {
+      const label = message.role === "user" ? "User" : "Assistant";
+      return `${index + 1}. ${label}: ${message.text.trim()}`;
+    })
+    .join("\n\n");
+}
+
+function truncateContextMessage(text: string): string {
+  const trimmed = text.trim();
+  if (trimmed.length <= MAX_SPEECH_TO_TEXT_CONTEXT_MESSAGE_CHARS) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, MAX_SPEECH_TO_TEXT_CONTEXT_MESSAGE_CHARS).trimEnd()}…`;
+}

--- a/src/core/utils/speech_to_text_context.ts
+++ b/src/core/utils/speech_to_text_context.ts
@@ -1,9 +1,10 @@
 import type { AssistantMessage, Message } from "@earendil-works/pi-ai";
 import type { SessionProtocolSnapshot } from "../../protocol/session_protocol.js";
 import { extractAssistantText, extractUserText } from "./messages.js";
+import { truncateForTokens } from "./truncate.js";
 
-const MAX_SPEECH_TO_TEXT_CONTEXT_MESSAGES_PER_ROLE = 2;
-const MAX_SPEECH_TO_TEXT_CONTEXT_MESSAGE_CHARS = 2_000;
+const MAX_SPEECH_TO_TEXT_CONTEXT_TURNS = 2;
+const MAX_SPEECH_TO_TEXT_CONTEXT_MESSAGE_TOKENS = 4_096;
 
 export type SpeechToTextContextMessage = {
   role: "user" | "assistant";
@@ -15,11 +16,13 @@ export type SpeechToTextContext = {
 };
 
 export function collectSpeechToTextContext(snapshot: SessionProtocolSnapshot): SpeechToTextContext {
-  const selected: SpeechToTextContextMessage[] = [];
-  let userMessages = 0;
-  let assistantMessages = 0;
+  const startIndex = findContextStartIndex(snapshot);
+  if (startIndex === undefined) {
+    return { messages: [] };
+  }
 
-  for (let index = snapshot.messages.length - 1; index >= 0; index -= 1) {
+  const messages: SpeechToTextContextMessage[] = [];
+  for (let index = startIndex; index < snapshot.messages.length; index += 1) {
     const entry = snapshot.messages[index];
     if (entry?.state !== "committed") {
       continue;
@@ -27,33 +30,22 @@ export function collectSpeechToTextContext(snapshot: SessionProtocolSnapshot): S
 
     const message = entry.message;
     if (message.role === "user") {
-      if (userMessages >= MAX_SPEECH_TO_TEXT_CONTEXT_MESSAGES_PER_ROLE) {
-        continue;
-      }
       const text = truncateContextMessage(extractUserText(message as Message));
-      if (!text) {
-        continue;
+      if (text) {
+        messages.push({ role: "user", text });
       }
-      selected.push({ role: "user", text });
-      userMessages += 1;
       continue;
     }
 
-    if (message.role === "assistant") {
-      if (assistantMessages >= MAX_SPEECH_TO_TEXT_CONTEXT_MESSAGES_PER_ROLE) {
-        continue;
-      }
+    if (message.role === "assistant" && isAssistantFinalResponse(message as AssistantMessage)) {
       const text = truncateContextMessage(extractAssistantText(message as AssistantMessage));
-      if (!text) {
-        continue;
+      if (text) {
+        messages.push({ role: "assistant", text });
       }
-      selected.push({ role: "assistant", text });
-      assistantMessages += 1;
     }
   }
 
-  selected.reverse();
-  return { messages: selected };
+  return { messages };
 }
 
 export function formatSpeechToTextContext(context: SpeechToTextContext | undefined): string {
@@ -70,10 +62,35 @@ export function formatSpeechToTextContext(context: SpeechToTextContext | undefin
     .join("\n\n");
 }
 
-function truncateContextMessage(text: string): string {
-  const trimmed = text.trim();
-  if (trimmed.length <= MAX_SPEECH_TO_TEXT_CONTEXT_MESSAGE_CHARS) {
-    return trimmed;
+function findContextStartIndex(snapshot: SessionProtocolSnapshot): number | undefined {
+  let turns = 0;
+
+  for (let index = snapshot.messages.length - 1; index >= 0; index -= 1) {
+    const entry = snapshot.messages[index];
+    if (entry?.state !== "committed" || entry.message.role !== "user") {
+      continue;
+    }
+
+    turns += 1;
+    if (turns >= MAX_SPEECH_TO_TEXT_CONTEXT_TURNS) {
+      return index;
+    }
   }
-  return `${trimmed.slice(0, MAX_SPEECH_TO_TEXT_CONTEXT_MESSAGE_CHARS).trimEnd()}…`;
+
+  return turns > 0
+    ? snapshot.messages.findIndex(
+        (entry) => entry.state === "committed" && entry.message.role === "user",
+      )
+    : undefined;
+}
+
+function isAssistantFinalResponse(message: AssistantMessage): boolean {
+  return message.content.every((part) => part.type !== "toolCall");
+}
+
+function truncateContextMessage(text: string): string {
+  return truncateForTokens(text.trim(), {
+    maxTokens: MAX_SPEECH_TO_TEXT_CONTEXT_MESSAGE_TOKENS,
+    strategy: "middle",
+  }).content.trim();
 }

--- a/src/tui/chat_controller/history_message_model.ts
+++ b/src/tui/chat_controller/history_message_model.ts
@@ -1,5 +1,5 @@
 import type { AssistantMessage, Message, ToolResultMessage } from "@earendil-works/pi-ai";
-import { stripTauUserDisplayText } from "../../core/utils/user_metadata.js";
+import { extractUserText } from "../../core/utils/messages.js";
 import type { ChatMessageModel } from "../ui/chat_message_model.js";
 
 export function buildHistoryMessageModel(message: Message): ChatMessageModel | undefined {
@@ -24,17 +24,7 @@ export function buildHistoryMessageModel(message: Message): ChatMessageModel | u
 }
 
 export function extractHistoryUserText(message: Message): string {
-  if (typeof message.content === "string") {
-    return stripTauUserDisplayText(message.content);
-  }
-
-  const parts: string[] = [];
-  for (const block of message.content) {
-    if (block.type === "text") {
-      parts.push(block.text);
-    }
-  }
-  return stripTauUserDisplayText(parts.join("\n"));
+  return extractUserText(message);
 }
 
 function formatToolResultNotice(toolResult: ToolResultMessage): string {

--- a/src/tui/listen_capture.ts
+++ b/src/tui/listen_capture.ts
@@ -8,6 +8,7 @@ import {
 import type { CoreDeps } from "../core/runtime/deps.js";
 import type { SpawnCaptureResult } from "../core/utils/spawn_capture.js";
 import { transcribeAudio } from "../core/utils/speech_to_text.js";
+import type { SpeechToTextContext } from "../core/utils/speech_to_text_context.js";
 
 export const LISTEN_TEMP_FILE_TEMPLATE = "/tmp/tau-listen.XXXXXX";
 export const LISTEN_RECORDING_MIN_BYTES = 1024;
@@ -105,6 +106,7 @@ export async function transcribeListenAudio(args: {
   config: Config;
   deps: CoreDeps;
   audio: Buffer;
+  context?: SpeechToTextContext;
 }): Promise<string> {
   const provider = getSpeechToTextProvider(args.config);
   const apiKey = getSpeechToTextApiKey(args.config, args.deps);
@@ -119,5 +121,6 @@ export async function transcribeListenAudio(args: {
     mimeType: "audio/wav",
     fileName: "speech.wav",
     language: "en",
+    context: args.context,
   });
 }

--- a/src/tui/session_chat_controller.ts
+++ b/src/tui/session_chat_controller.ts
@@ -29,6 +29,7 @@ import type { ToolUiEvent } from "../core/tools/registry.js";
 import { REASONING_LEVELS, type ReasoningEffort, type RiskLevel } from "../core/types.js";
 import { formatAdaptiveNumber, formatTokenWindow } from "../core/utils/format.js";
 import { extractAssistantText } from "../core/utils/messages.js";
+import { collectSpeechToTextContext } from "../core/utils/speech_to_text_context.js";
 import {
   getAutoCompactionMetadataFromMessage,
   hasAutoCompactionContinuationMetadata,
@@ -933,6 +934,7 @@ export class SessionChatController {
         config: this.config,
         deps: this.deps,
         audio,
+        context: collectSpeechToTextContext(this.snapshot),
       });
       const text = transcript.trim();
       if (!text) {

--- a/test/gemini_transcription.test.js
+++ b/test/gemini_transcription.test.js
@@ -68,8 +68,14 @@ describe("gemini transcription", () => {
     expect(request.contents[0].parts[0].text).toContain(
       "Do not transcribe the context itself, and do not add words from the context that were not spoken.",
     );
-    expect(request.contents[0].parts[0].text).toContain("1. User: Can we support OAuth");
-    expect(request.contents[0].parts[0].text).toContain("2. Assistant: Yes, the Acme SSO flow");
+    expect(request.contents[0].parts[0].text).toContain("<speech-to-text-context>");
+    expect(request.contents[0].parts[0].text).toContain(
+      '<message index="1" role="user">\nCan we support OAuth',
+    );
+    expect(request.contents[0].parts[0].text).toContain(
+      '<message index="2" role="assistant">\nYes, the Acme SSO flow',
+    );
+    expect(request.contents[0].parts[0].text).toContain("</speech-to-text-context>");
     expect(request.contents[0].parts[1].inlineData.mimeType).toBe("audio/ogg");
     expect(request.contents[0].parts[1].inlineData.data).toBe(
       Buffer.from("audio payload").toString("base64"),

--- a/test/gemini_transcription.test.js
+++ b/test/gemini_transcription.test.js
@@ -30,6 +30,12 @@ describe("gemini transcription", () => {
       audio: Buffer.from("audio payload"),
       mimeType: "audio/ogg",
       fetchImpl: fetchMock,
+      context: {
+        messages: [
+          { role: "user", text: "Can we support OAuth for Acme SSO?" },
+          { role: "assistant", text: "Yes, the Acme SSO flow can reuse the callback handler." },
+        ],
+      },
     });
 
     expect(transcript).toBe("ship the fix");
@@ -56,6 +62,14 @@ describe("gemini transcription", () => {
     expect(request.contents[0].parts[0].text).toContain(
       "Transcribe the attached audio into the transcription field.",
     );
+    expect(request.contents[0].parts[0].text).toContain(
+      "Use the recent conversation context below only to resolve likely words, names, acronyms, terminology, and references in the audio.",
+    );
+    expect(request.contents[0].parts[0].text).toContain(
+      "Do not transcribe the context itself, and do not add words from the context that were not spoken.",
+    );
+    expect(request.contents[0].parts[0].text).toContain("1. User: Can we support OAuth");
+    expect(request.contents[0].parts[0].text).toContain("2. Assistant: Yes, the Acme SSO flow");
     expect(request.contents[0].parts[1].inlineData.mimeType).toBe("audio/ogg");
     expect(request.contents[0].parts[1].inlineData.data).toBe(
       Buffer.from("audio payload").toString("base64"),

--- a/test/speech_to_text_context.test.js
+++ b/test/speech_to_text_context.test.js
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { collectSpeechToTextContext } from "../dist/core/utils/speech_to_text_context.js";
+
+function userMessage(id, text) {
+  return {
+    id,
+    state: "committed",
+    modelVisible: true,
+    message: { role: "user", content: text, timestamp: 1 },
+  };
+}
+
+function assistantMessage(id, text, content = [{ type: "text", text }]) {
+  return {
+    id,
+    state: "committed",
+    modelVisible: true,
+    message: { role: "assistant", content, timestamp: 1 },
+  };
+}
+
+function snapshot(messages) {
+  return { messages };
+}
+
+describe("speech-to-text context", () => {
+  it("collects user messages and assistant final responses from the last two turns", () => {
+    const context = collectSpeechToTextContext(
+      snapshot([
+        userMessage("user-1", "first user"),
+        assistantMessage("assistant-1", "first assistant"),
+        userMessage("user-2", "second user"),
+        assistantMessage("assistant-tool", "checking", [
+          { type: "text", text: "checking" },
+          { type: "toolCall", id: "tool-1", name: "bash", arguments: {} },
+        ]),
+        assistantMessage("assistant-2", "second assistant"),
+        userMessage("user-3", "third user"),
+        assistantMessage("assistant-3", "third assistant"),
+      ]),
+    );
+
+    expect(context.messages).toEqual([
+      { role: "user", text: "second user" },
+      { role: "assistant", text: "second assistant" },
+      { role: "user", text: "third user" },
+      { role: "assistant", text: "third assistant" },
+    ]);
+  });
+
+  it("middle-truncates each context message to 4096 tokens", () => {
+    const longText = `${"a".repeat(13_000)} middle ${"z".repeat(13_000)}`;
+
+    const context = collectSpeechToTextContext(
+      snapshot([userMessage("user-1", longText), assistantMessage("assistant-1", longText)]),
+    );
+
+    expect(context.messages).toHaveLength(2);
+    for (const message of context.messages) {
+      expect(message.text).toContain("a".repeat(100));
+      expect(message.text).toContain("tokens truncated");
+      expect(message.text).toContain("z".repeat(100));
+      expect(message.text).not.toContain(" middle ");
+    }
+  });
+});

--- a/test/speech_to_text_context.test.js
+++ b/test/speech_to_text_context.test.js
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { collectSpeechToTextContext } from "../dist/core/utils/speech_to_text_context.js";
+import {
+  collectSpeechToTextContext,
+  formatSpeechToTextContext,
+} from "../dist/core/utils/speech_to_text_context.js";
 
 function userMessage(id, text) {
   return {
@@ -62,5 +65,27 @@ describe("speech-to-text context", () => {
       expect(message.text).toContain("z".repeat(100));
       expect(message.text).not.toContain(" middle ");
     }
+  });
+
+  it("formats context with xml-like message boundaries", () => {
+    const formatted = formatSpeechToTextContext({
+      messages: [
+        { role: "user", text: "Can we support <Acme> & partners?" },
+        { role: "assistant", text: "Yes, use OAuth." },
+      ],
+    });
+
+    expect(formatted).toBe(
+      [
+        "<speech-to-text-context>",
+        '  <message index="1" role="user">',
+        "Can we support &lt;Acme&gt; &amp; partners?",
+        "  </message>",
+        '  <message index="2" role="assistant">',
+        "Yes, use OAuth.",
+        "  </message>",
+        "</speech-to-text-context>",
+      ].join("\n"),
+    );
   });
 });


### PR DESCRIPTION
## why

Speech-to-text currently transcribes voice input without any awareness of the recent conversation. That makes ambiguous words, project terminology, acronyms, and references harder to resolve correctly.

## what

This adds a small shared speech-to-text context collector that includes recent committed user and assistant text only, excluding tools, system messages, drafts, and other non-final content. TUI `/listen` and Telegram audio transcription pass that context into the shared transcription path.

Gemini transcription now includes the context in its prompt with explicit instructions to use it only for disambiguating likely words, names, acronyms, terminology, and references, while still transcribing only the spoken audio. Mistral behavior remains unchanged because the current endpoint wrapper does not accept contextual prompt input.

fixes #260
