### PR TITLE
add exit slash command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -304,7 +304,7 @@ The `--debug` flag respects `--persona` and `--no-agent-context-files`, so you c
 
 ## Commands
 
-- `/help`, `/new`, `/rewind`, `/diff [git diff args...]` (opens the TUI-local diff review tool), `/copy:text`, `/copy:code`, `/reload`, `/listen` (macOS only; can record while assistant works; warns on Linux), `/speak` (macOS only; speaks the last assistant message)
+- `/help`, `/new`, `/exit`, `/rewind`, `/diff [git diff args...]` (opens the TUI-local diff review tool), `/copy:text`, `/copy:code`, `/reload`, `/listen` (macOS only; can record while assistant works; warns on Linux), `/speak` (macOS only; speaks the last assistant message)
 - `/compact:summary-only`, `/compact:summary-and-last` - Manually compact history into a single synthetic user summary message with compaction-model-selected original user messages copied verbatim inside the summary (optionally includes last assistant message verbatim when available); automatic compaction is separate and keeps a retained recent tail
 - `/prune:earliest`, `/prune:largest`, `/prune:smart` - Prune tool results and compact edit call payloads/results
 - `/risk:read-only`, `/risk:read-write`, `/persona:<id>`, `/prompt:<id>`, `/theme:<id>`

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ For stdio attach, use `--session <id>` before `--`:
 tau attach --session 0195d6e4-4cf9-7f44-a2d8-f8f7f49ee9d3 -- ssh vps 'cd /path/to/repo && tau rpc --risk read-only'
 ```
 
-Session attach renders the authoritative session snapshot, streams live `session.delta` updates, submits normal user input, supports steering/interruption, runs `!`/`!!` shell commands in the session execution environment, records `/listen` from the local microphone, speaks `/speak` locally, reloads session content with `/reload`, changes the session risk level with `/risk:<level>` or `Ctrl+R`, switches session personas with `/persona:<id>` or `Ctrl+P`, inserts session prompt templates with `/prompt:<id>`, compacts or prunes the session with `/compact:*` and `/prune:*`, and creates a new session with `/new`.
+Session attach renders the authoritative session snapshot, streams live `session.delta` updates, submits normal user input, supports steering/interruption, runs `!`/`!!` shell commands in the session execution environment, records `/listen` from the local microphone, speaks `/speak` locally, reloads session content with `/reload`, changes the session risk level with `/risk:<level>` or `Ctrl+R`, switches session personas with `/persona:<id>` or `Ctrl+P`, inserts session prompt templates with `/prompt:<id>`, compacts or prunes the session with `/compact:*` and `/prune:*`, creates a new session with `/new`, and exits with `/exit` or `Ctrl+C` twice.
 
 ## Telegram runner
 
@@ -450,6 +450,7 @@ tau supports slash commands for common actions:
 | --- | --- |
 | `/help` | show available commands |
 | `/new` | clear the session and start fresh |
+| `/exit` | exit the TUI |
 | `/rewind` | open a picker to rewind context from a selected user message |
 | `/copy:text` | copy the last assistant message |
 | `/copy:code` | copy just the code blocks |

--- a/src/core/commands/registry.ts
+++ b/src/core/commands/registry.ts
@@ -6,6 +6,7 @@ export type Command = (
   | { type: "help" }
   | { type: "copyText" }
   | { type: "copyCode" }
+  | { type: "exit" }
   | { type: "new" }
   | { type: "rewind" }
   | { type: "diff"; argsText: string }
@@ -48,6 +49,7 @@ export interface CommandDispatchContext {
   help: () => void;
   copyText: () => Promise<void>;
   copyCode: () => Promise<void>;
+  exit: () => void;
   newSession: () => Promise<void>;
   rewind: () => void;
   diff: (argsText: string) => Promise<void> | void;
@@ -241,6 +243,22 @@ export function createCommandRegistry(): CommandRegistry<CommandDispatchContext>
       return { type: "help", extra };
     },
     run: (ctx) => ctx.help(),
+  });
+
+  registry.register({
+    id: "exit",
+    usage: "/exit",
+    description: "exit tau",
+    autocompleteDescription: "exit tau",
+    argument: "none",
+    section: "base",
+    allowDuringStreaming: true,
+    parse: (raw) => {
+      const { command, extra } = splitCommandInput(raw);
+      if (command !== "/exit") return null;
+      return { type: "exit", extra };
+    },
+    run: (ctx) => ctx.exit(),
   });
 
   registry.register({

--- a/src/tui/session_chat_app.ts
+++ b/src/tui/session_chat_app.ts
@@ -140,6 +140,7 @@ export class SessionChatApp implements ModeAdapter {
         themeId: options.themeId,
         themes: options.themes ?? [],
       });
+      let app: SessionChatApp;
       const controller = new SessionChatController({
         view,
         session,
@@ -152,6 +153,7 @@ export class SessionChatApp implements ModeAdapter {
         queuedUserMessages,
         caffeinated: options.caffeinated,
         themeIds: (options.themes ?? []).map((theme) => theme.id),
+        onExit: () => app.exit(),
       });
       const sources = controller.getAutocompleteSources();
       view.setAutocompleteProvider(
@@ -170,7 +172,7 @@ export class SessionChatApp implements ModeAdapter {
         ),
       );
       const handlers = controller.getInputHandlers();
-      const app = new SessionChatApp({
+      app = new SessionChatApp({
         view,
         controller,
         client: options.client,
@@ -221,7 +223,7 @@ export class SessionChatApp implements ModeAdapter {
     const now = Date.now();
     if (this.lastCtrlCAt !== undefined && now - this.lastCtrlCAt <= EXIT_DOUBLE_PRESS_WINDOW_MS) {
       this.lastCtrlCAt = undefined;
-      void this.stop().finally(() => process.exit(0));
+      this.exit();
       return;
     }
 
@@ -229,6 +231,10 @@ export class SessionChatApp implements ModeAdapter {
     this.view.addSystemMessage("press ctrl+c again to quit", "warn", {
       toastDurationMs: EXIT_TOAST_DURATION_MS,
     });
+  }
+
+  private exit(): void {
+    void this.stop().finally(() => process.exit(0));
   }
 }
 

--- a/src/tui/session_chat_controller.ts
+++ b/src/tui/session_chat_controller.ts
@@ -106,6 +106,7 @@ export type SessionChatControllerOptions = {
   queuedUserMessages?: string[];
   caffeinated?: boolean;
   themeIds?: string[];
+  onExit?: () => void;
 };
 
 export class SessionChatController {
@@ -176,6 +177,7 @@ export class SessionChatController {
       help: () => this.showHelp(),
       copyText: () => this.copyLastAssistantText(),
       copyCode: () => this.copyLastAssistantCode(),
+      exit: () => options.onExit?.(),
       newSession: () => this.createNewSession(),
       rewind: () => this.startRewindFlow(),
       diff: (argsText) => this.startDiffReview(argsText),


### PR DESCRIPTION
## why

The TUI could only be exited with `Ctrl+C` twice, which is less discoverable and can be awkward in environments where key handling is inconsistent.

## what

This adds `/exit` as a local TUI slash command. It routes through the command registry and controller to the existing application shutdown path, so `Ctrl+C` twice remains unchanged while `/exit` gives users a text-command equivalent.

fixes #272
