### PR TITLE
copy deployed Nook sites

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,7 +294,7 @@ The `--debug` flag respects `--persona` and `--no-agent-context-files`, so you c
 - `tau install [--global] [--force] [--prompt <id> | --skill <name>]` - Install starter prompts and skills (or one selected item)
 - `tau tool pdf-unpack <file.pdf>` - OCR a PDF with Mistral, render local page patches with `pdftoppm`, and print the artifact paths.
 - `tau nook setup --domain <domain> --zone-name <zone> --access-team-domain <url> --access-aud <aud>` / `tau nook destroy --domain <domain> --access-client-id <id> --access-client-secret <secret> --yes` - Deploy or remove the bundled Nook Cloudflare Worker stack with Wrangler. Destroy first calls the authenticated Worker cleanup endpoint, then deletes the Worker and R2 bucket.
-- `tau nook deploy <dir> --site <slug> [--public]`, `tau nook list`, `tau nook delete <site>`, `tau nook skill`, `tau nook template ...`, and `tau nook kv ...` - Operate a configured Nook target
+- `tau nook deploy <dir> --site <slug> [--public]`, `tau nook copy <site> <dir>`, `tau nook list`, `tau nook delete <site>`, `tau nook skill`, `tau nook template ...`, and `tau nook kv ...` - Operate a configured Nook target
 - `tau telegram --config-file <path>` - Run the Telegram bot adapter over local in-process Tau SDK sessions
 - `tau diff-tool [--help]` - Built-in browser diff review demo tool and reference implementation for the diff-review protocol
 - `TAU_CODEX_ACCOUNT` (env var) - Force a specific Codex account by email or account id (same matching as logout); disables failover

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ tau nook setup \
   --access-aud <access-application-audience>
 tau nook deploy ./dist --site demo
 tau nook deploy ./dist --site demo --public
+mkdir restored-demo && tau nook copy demo ./restored-demo
 tau nook template save starter ./app
 tau nook template copy starter ./next-app
 tau nook kv put demo settings '{"theme":"dark"}'

--- a/src/core/nook/cli.ts
+++ b/src/core/nook/cli.ts
@@ -50,6 +50,7 @@ export function printNookHelp(log: (line: string) => void = console.log): void {
       "  tau nook destroy --domain <domain> --access-client-id <id> --access-client-secret <secret> --yes",
       "  tau nook skill",
       "  tau nook deploy <dir> --site <slug> [--public]",
+      "  tau nook copy <site> <dir>",
       "  tau nook list",
       "  tau nook delete <site>",
       "  tau nook template list",
@@ -135,6 +136,19 @@ export async function runNookCommand(
       if (!site || args.length !== 1) throw new Error("usage: tau nook delete <site>");
       await client.deleteSite(site);
       stdout(`deleted ${site}`);
+      return;
+    }
+
+    if (subcommand === "copy") {
+      const [site, directory] = args;
+      if (!site || !directory || args.length !== 2) {
+        throw new Error("usage: tau nook copy <site> <dir>");
+      }
+      const result = await client.copySiteToDirectory(
+        site,
+        resolve(options.cwd ?? process.cwd(), directory),
+      );
+      stdout(`copied site ${result.site} to ${directory}`);
       return;
     }
 

--- a/src/core/nook/client.ts
+++ b/src/core/nook/client.ts
@@ -44,6 +44,19 @@ export type NookDeployResult = {
   byteCount: number;
 };
 
+export type NookSiteManifestResult = {
+  site: string;
+  deploymentId: string;
+  visibility: NookVisibility;
+  fileCount: number;
+  byteCount: number;
+  files: NookManifestFile[];
+};
+
+export type NookSiteCopyResult = Omit<NookSiteManifestResult, "files"> & {
+  directory: string;
+};
+
 export type NookKvListResult = {
   site: string;
   keys: Array<{ key: string; sizeBytes: number; updatedAt: string }>;
@@ -75,7 +88,7 @@ type NookClientOptions = {
 
 type NookClientDeployFile = NookDeployFile | NookBackendDeployFile;
 
-type NookDownloadedTemplateFile = NookManifestFile & {
+type NookDownloadedFile = NookManifestFile & {
   content: Buffer;
 };
 
@@ -83,6 +96,25 @@ function bufferToArrayBuffer(buffer: Buffer): ArrayBuffer {
   const copy = new ArrayBuffer(buffer.byteLength);
   new Uint8Array(copy).set(buffer);
   return copy;
+}
+
+function validateCopyDestination(directory: string, artifact: string): void {
+  if (!existsSync(directory))
+    throw new Error(`${artifact} copy destination does not exist: ${directory}`);
+  if (!lstatSync(directory).isDirectory()) {
+    throw new Error(`${artifact} copy destination is not a directory: ${directory}`);
+  }
+  if (readdirSync(directory).length > 0) {
+    throw new Error(`${artifact} copy destination is not empty: ${directory}`);
+  }
+}
+
+function writeDownloadedFiles(directory: string, files: NookDownloadedFile[]): void {
+  for (const file of files) {
+    const destination = join(directory, file.path.replace(/^\/+/, ""));
+    mkdirSync(dirname(destination), { recursive: true });
+    writeFileSync(destination, file.content);
+  }
 }
 
 async function readDeployFileContent(file: NookClientDeployFile): Promise<Blob> {
@@ -178,6 +210,54 @@ export class NookClient {
       { method: "DELETE" },
     );
     return result;
+  }
+
+  async getSiteManifest(site: string): Promise<NookSiteManifestResult> {
+    return await this.requestJson<NookSiteManifestResult>(
+      `${this.baseUrl()}/__nook/api/sites/${encodeURIComponent(site)}`,
+    );
+  }
+
+  async downloadSiteFile(site: string, deploymentId: string, path: string): Promise<Buffer> {
+    const url = new URL(`${this.baseUrl()}/__nook/api/sites/${encodeURIComponent(site)}/file`);
+    url.searchParams.set("deployment", deploymentId);
+    url.searchParams.set("path", path);
+    const response = await this.fetchImpl(url, { headers: this.authHeaders() });
+    if (!response.ok) throw new Error(await formatNookHttpError(response));
+    return Buffer.from(await response.arrayBuffer());
+  }
+
+  async downloadSiteFiles(
+    site: string,
+    manifest: NookSiteManifestResult,
+  ): Promise<NookDownloadedFile[]> {
+    validateNookTemplateManifest(manifest.files);
+    const byteCount = manifest.files.reduce((total, file) => total + file.sizeBytes, 0);
+    if (manifest.fileCount !== manifest.files.length || manifest.byteCount !== byteCount) {
+      throw new Error("site manifest summary does not match its files");
+    }
+    const downloaded: NookDownloadedFile[] = [];
+    for (const file of manifest.files) {
+      const content = await this.downloadSiteFile(site, manifest.deploymentId, file.path);
+      if (content.byteLength !== file.sizeBytes) {
+        throw new Error(`site file '${file.path}' size does not match manifest`);
+      }
+      const sha256 = createHash("sha256").update(content).digest("hex");
+      if (sha256 !== file.sha256) {
+        throw new Error(`site file '${file.path}' hash does not match manifest`);
+      }
+      downloaded.push({ ...file, content });
+    }
+    return downloaded;
+  }
+
+  async copySiteToDirectory(site: string, directory: string): Promise<NookSiteCopyResult> {
+    validateCopyDestination(directory, "site");
+    const manifest = await this.getSiteManifest(site);
+    const files = await this.downloadSiteFiles(site, manifest);
+    writeDownloadedFiles(directory, files);
+    const { files: _files, ...result } = manifest;
+    return { ...result, directory };
   }
 
   async deploySite(args: {
@@ -312,7 +392,7 @@ export class NookClient {
   async downloadTemplateFiles(
     name: string,
     manifest: NookTemplateManifestResult,
-  ): Promise<NookDownloadedTemplateFile[]> {
+  ): Promise<NookDownloadedFile[]> {
     validateNookTemplateManifest(manifest.files);
     const byteCount = manifest.files.reduce((total, file) => total + file.sizeBytes, 0);
     if (
@@ -321,7 +401,7 @@ export class NookClient {
     ) {
       throw new Error("template manifest summary does not match its files");
     }
-    const downloaded: NookDownloadedTemplateFile[] = [];
+    const downloaded: NookDownloadedFile[] = [];
     for (const file of manifest.files) {
       const content = await this.downloadTemplateFile(
         name,
@@ -341,25 +421,10 @@ export class NookClient {
   }
 
   async copyTemplateToDirectory(name: string, directory: string): Promise<NookTemplateCopyResult> {
-    if (!existsSync(directory)) {
-      throw new Error(`template copy destination does not exist: ${directory}`);
-    }
-    const stats = lstatSync(directory);
-    if (!stats.isDirectory()) {
-      throw new Error(`template copy destination is not a directory: ${directory}`);
-    }
-    if (readdirSync(directory).length > 0) {
-      throw new Error(`template copy destination is not empty: ${directory}`);
-    }
-
+    validateCopyDestination(directory, "template");
     const manifest = await this.getTemplateManifest(name);
     const files = await this.downloadTemplateFiles(name, manifest);
-    for (const file of files) {
-      const relativePath = file.path.replace(/^\/+/, "");
-      const destination = join(directory, relativePath);
-      mkdirSync(dirname(destination), { recursive: true });
-      writeFileSync(destination, file.content);
-    }
+    writeDownloadedFiles(directory, files);
     return {
       ...manifest.template,
       directory,

--- a/src/core/nook/index.ts
+++ b/src/core/nook/index.ts
@@ -2,6 +2,8 @@ export { NookCliError, printNookHelp, runNookCommand } from "./cli.js";
 export type {
   NookDeployResult,
   NookKvListResult,
+  NookSiteCopyResult,
+  NookSiteManifestResult,
   NookSiteSummary,
   NookTemplateCopyResult,
   NookTemplateManifestResult,

--- a/src/core/tools/nook.ts
+++ b/src/core/tools/nook.ts
@@ -26,9 +26,9 @@ const NOOK_DESCRIPTION = [
   "Do not use this tool autonomously; use it only when the user asks to manage Nook, deploy/publish/host an app or artifact, inspect Nook state, or manage Nook KV.",
   "If the user asks to deploy a static artifact or mini-app, this is usually the right deployment target.",
   "When preparing site files for deployment, write the complete site directory under a fresh mktemp directory and deploy that directory; do not scatter generated site files into the project tree.",
-  "Templates are Nook-hosted editable directory snapshots. Copy requires an existing empty destination directory; edit/build it normally, then deploy a built static directory separately.",
+  "Sites and templates can be copied to an existing empty destination directory. Edit/build copied files normally, then deploy a built static directory separately.",
   "All operations require read-write risk.",
-  "Input keys by operation: read_skill, list_sites, and list_templates need only operation; deploy_site needs site and directory, with public optional; delete_site needs site; template copy/save/delete operations need template, and copy/save also need directory; get_kv and delete_kv need site and key; put_kv needs site, key, and value; list_kv needs site, with prefix optional.",
+  "Input keys by operation: read_skill, list_sites, and list_templates need only operation; deploy_site and copy_site need site and directory, with public optional only for deploy_site; delete_site needs site; template copy/save/delete operations need template, and copy/save also need directory; get_kv and delete_kv need site and key; put_kv needs site, key, and value; list_kv needs site, with prefix optional.",
 ].join(" ");
 
 export const NOOK_TOOL: Tool = {
@@ -38,10 +38,11 @@ export const NOOK_TOOL: Tool = {
     {
       operation: Type.String({
         description:
-          "Operation to run. Required keys: read_skill/list_sites/list_templates only operation; deploy_site site+directory; delete_site site; copy_template/save_template template+directory; delete_template template; get_kv/delete_kv site+key; put_kv site+key+value; list_kv site.",
+          "Operation to run. Required keys: read_skill/list_sites/list_templates only operation; deploy_site/copy_site site+directory; delete_site site; copy_template/save_template template+directory; delete_template template; get_kv/delete_kv site+key; put_kv site+key+value; list_kv site.",
         enum: [
           "read_skill",
           "deploy_site",
+          "copy_site",
           "list_sites",
           "delete_site",
           "list_templates",
@@ -57,13 +58,13 @@ export const NOOK_TOOL: Tool = {
       site: Type.Optional(
         Type.String({
           description:
-            "Nook site slug. Required for deploy_site, delete_site, get_kv, put_kv, delete_kv, and list_kv.",
+            "Nook site slug. Required for deploy_site, copy_site, delete_site, get_kv, put_kv, delete_kv, and list_kv.",
         }),
       ),
       directory: Type.Optional(
         Type.String({
           description:
-            "Directory in the session workspace. Required for deploy_site, copy_template, and save_template. copy_template requires the directory to exist and be empty.",
+            "Directory in the session workspace. Required for deploy_site, copy_site, copy_template, and save_template. Copy operations require the directory to exist and be empty.",
         }),
       ),
       public: Type.Optional(
@@ -96,6 +97,7 @@ const nookArgsSchema = z
     operation: z.enum([
       "read_skill",
       "deploy_site",
+      "copy_site",
       "list_sites",
       "delete_site",
       "list_templates",
@@ -217,6 +219,27 @@ export function createNookToolDefinition(backend: ToolExecutionBackend): ToolDef
           case "delete_site":
             result = await client.deleteSite(requireArg(args, "site"));
             break;
+          case "copy_site": {
+            const site = requireArg(args, "site");
+            const directory = requireArg(args, "directory");
+            const destination = await backend.listDir(directory);
+            if (destination.entries.length > 0) {
+              throw new Error(`site copy destination is not empty: ${directory}`);
+            }
+            const manifest = await client.getSiteManifest(site);
+            const files = await client.downloadSiteFiles(site, manifest);
+            for (const file of files) {
+              await backend.writeFileBinary(joinBackendPath(directory, file.path), file.content);
+            }
+            result = {
+              site,
+              directory,
+              deploymentId: manifest.deploymentId,
+              fileCount: files.length,
+              byteCount: files.reduce((total, file) => total + file.sizeBytes, 0),
+            };
+            break;
+          }
           case "list_templates":
             result = { templates: await client.listTemplates() };
             break;

--- a/src/nook/README.md
+++ b/src/nook/README.md
@@ -56,6 +56,8 @@ Destroy first calls `https://<domain>/__nook/api/destroy` through Cloudflare Acc
 ```sh
 tau nook deploy ./dist --site demo
 tau nook deploy ./dist --site demo --public
+mkdir restored-demo
+tau nook copy demo ./restored-demo
 ```
 
 Deploy requirements:
@@ -70,6 +72,7 @@ Deploy requirements:
 - Uploads are checked against the manifest byte size and SHA-256 digest.
 - Each site can have at most three non-expired pending deploy sessions.
 - Deployed asset URLs remain stable across deploys, so responses require cache revalidation.
+- `copy` downloads the active deployment into an existing empty directory and verifies every file against its manifest. Site KV is not copied.
 
 ## templates
 

--- a/src/nook/worker/index.ts
+++ b/src/nook/worker/index.ts
@@ -693,7 +693,7 @@ async function handleBaseApi(
   }
 
   const match = url.pathname.match(
-    /^\/__nook\/api\/sites(?:\/([^/]+))?(?:\/deploy\/([^/]+)\/(file|finish)|\/deploy\/start)?$/,
+    /^\/__nook\/api\/sites(?:\/([^/]+))?(?:\/deploy\/([^/]+)\/(file|finish)|\/deploy\/start|\/file)?$/,
   );
   if (!match) return error("not_found", "Unknown Nook API route", 404);
 
@@ -714,6 +714,52 @@ async function handleBaseApi(
     await siteFetch(env, site, "/delete", { method: "POST" });
     await registryFetch(env, `/sites/${encodeURIComponent(site)}`, { method: "DELETE" });
     return json({ site, deleted: true });
+  }
+
+  if (request.method === "GET" && url.pathname === `/__nook/api/sites/${site}`) {
+    const active = await siteFetch(env, site, "/active");
+    if (!active.ok) return active;
+    const deployment = (await active.json()) as {
+      deploymentId: string;
+      public: boolean;
+      files: ManifestFile[];
+    };
+    return json({
+      site,
+      deploymentId: deployment.deploymentId,
+      visibility: deployment.public ? "public" : "private",
+      fileCount: deployment.files.length,
+      byteCount: deployment.files.reduce((total, file) => total + file.sizeBytes, 0),
+      files: deployment.files,
+    });
+  }
+
+  if (request.method === "GET" && url.pathname === `/__nook/api/sites/${site}/file`) {
+    const deploymentId = url.searchParams.get("deployment");
+    if (!deploymentId || !/^dep_[a-f0-9]{24}$/.test(deploymentId)) {
+      return error("invalid_deployment", "Invalid deployment", 400);
+    }
+    const path = url.searchParams.get("path");
+    const normalized = path ? normalizeAssetPath(path) : undefined;
+    if (!normalized || normalized !== path)
+      return error("invalid_path", "Invalid site file path", 400);
+    const active = await siteFetch(env, site, "/active");
+    if (!active.ok) return active;
+    const deployment = (await active.json()) as {
+      deploymentId: string;
+      files: ManifestFile[];
+    };
+    if (deployment.deploymentId !== deploymentId) {
+      return error("deployment_changed", "Active deployment changed during copy", 409);
+    }
+    if (!deployment.files.some((file) => file.path === normalized)) {
+      return error("invalid_path", "Path is not in the active deployment manifest", 400);
+    }
+    const object = await env.ASSETS.get(assetKey(site, deploymentId, normalized));
+    if (!object) return error("not_found", "Site file not found", 404);
+    return new Response(object.body, {
+      headers: { "content-type": object.httpMetadata?.contentType ?? "application/octet-stream" },
+    });
   }
 
   if (request.method === "POST" && url.pathname.endsWith("/deploy/start")) {

--- a/test/nook.test.js
+++ b/test/nook.test.js
@@ -162,6 +162,56 @@ describe("nook config", () => {
   });
 });
 
+describe("nook site copy", () => {
+  it("copies verified active deployment files into an existing empty directory", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "tau-nook-site-copy-test-"));
+    const content = Buffer.from("<html>restored</html>");
+    const sha256 = createHash("sha256").update(content).digest("hex");
+    const fetchImpl = vi.fn(async (input) => {
+      const url = new URL(String(input));
+      if (url.pathname === "/__nook/api/sites/demo") {
+        return Response.json({
+          site: "demo",
+          deploymentId: "dep_aaaaaaaaaaaaaaaaaaaaaaaa",
+          visibility: "private",
+          fileCount: 1,
+          byteCount: content.byteLength,
+          files: [
+            {
+              path: "/index.html",
+              sizeBytes: content.byteLength,
+              contentType: "text/html; charset=utf-8",
+              sha256,
+            },
+          ],
+        });
+      }
+      if (url.pathname === "/__nook/api/sites/demo/file") {
+        expect(url.searchParams.get("deployment")).toBe("dep_aaaaaaaaaaaaaaaaaaaaaaaa");
+        expect(url.searchParams.get("path")).toBe("/index.html");
+        return new Response(content);
+      }
+      throw new Error(`unexpected request ${url}`);
+    });
+    const client = new NookClient({ config: { domain: "nook.example.com" }, fetchImpl });
+
+    const result = await client.copySiteToDirectory("demo", directory);
+
+    expect(result.deploymentId).toBe("dep_aaaaaaaaaaaaaaaaaaaaaaaa");
+    expect(readFileSync(join(directory, "index.html"))).toEqual(content);
+  });
+
+  it("rejects a non-empty destination before downloading", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "tau-nook-site-copy-test-"));
+    writeFileSync(join(directory, "existing.txt"), "keep");
+    const fetchImpl = vi.fn();
+    const client = new NookClient({ config: { domain: "nook.example.com" }, fetchImpl });
+
+    await expect(client.copySiteToDirectory("demo", directory)).rejects.toThrow(/not empty/);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
 describe("nook templates", () => {
   it("copies verified binary files into an existing empty directory", async () => {
     const directory = await mkdtemp(join(tmpdir(), "tau-nook-copy-test-"));


### PR DESCRIPTION
## why

A deployed Nook site's original local source may no longer be available, which makes small follow-up edits unnecessarily difficult even though the active deployment still contains the complete static artifact.

## what

Add `tau nook copy <site> <dir>` and the corresponding `copy_site` model-tool operation. The Worker exposes the active deployment manifest and authenticated file downloads, while clients verify file sizes and SHA-256 hashes before restoring the deployment into an existing empty directory.

The download remains pinned to the active deployment ID so a concurrent redeploy fails the copy instead of mixing deployment contents. Site KV remains separate and is not copied.

fixes #285
