### PR TITLE
remove risk controls

### DIFF
--- a/.tau/skills/guided-review/SKILL.md
+++ b/.tau/skills/guided-review/SKILL.md
@@ -106,7 +106,7 @@ Use the `diff_review` tool for each chunk when it is available.
 
 Prefer `source: "git_diff"` when a chunk can be represented cleanly with `git diff` arguments, especially path-limited scopes such as `["main...HEAD", "--", "src/foo.ts", "test/foo.test.ts"]` or `["--", "src/foo.ts"]`.
 
-Use `source: "patch_files"` only when path-limited `git diff` is not precise enough, such as selected hunks, hand-curated subsets, or multiple custom patches. Patch files must contain git unified diff sections with `diff --git` headers. If writing patch files would require read-write access that is not available, explain the limitation and either use a broader `git_diff` chunk or ask the user to switch risk level.
+Use `source: "patch_files"` only when path-limited `git diff` is not precise enough, such as selected hunks, hand-curated subsets, or multiple custom patches. Patch files must contain git unified diff sections with `diff --git` headers. If the available tools cannot write patch files, explain the limitation and use a broader `git_diff` chunk.
 
 ## Required preamble before each review
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,5 @@
 # Tau
 
-Terminal-based AI chat client with tool execution, streaming responses, and risk-level controls. Supports Anthropic, OpenAI, and Google models.
-
 ## Platform support
 
 - **Supported**: macOS and Linux.
@@ -146,26 +144,7 @@ Tau is pre-v1 and the priority is to reach a clean, stable v1 design. Prefer exp
 
 ## Tool system
 
-| Tool | Purpose | Risk requirement |
-| --- | --- | --- |
-| `bash` | Shell execution | `read-only` for reads, `read-write` for writes |
-| `write` | Create/overwrite files | `read-write` |
-| `edit` | Replace exact text in files | `read-write` |
-| `view_image` | View an image file | `read-only` |
-| `spawn_agent` | Start a background subagent | `read-only` or `read-write` |
-| `send_input_to_agent` | Send input to an idle subagent | `read-only` or `read-write` |
-| `wait_for_agents` | Await completed subagent outputs, returning when at least one requested agent finishes | `read-only` or `read-write` |
-| `terminate_agent` | Stop a running subagent | `read-only` or `read-write` |
-| `emit_output` | Subagent-only output to main (currently disabled in subagent registries) | `read-only` or `read-write` |
-| `nook` | Operate the configured Nook static mini-app platform | `read-write` |
-
-Note: read/list/grep tool definitions exist in `src/core/tools`, but ToolCatalog does not register them in the default tool set. The TUI advertises `diff_review` as a client-provided tool; it is not a host tool registry entry. The `nook` host tool is automatically exposed only when effective Tau config contains `nook`, and all operations require read-write risk.
-
-Risk levels (`read-only`, `read-write`) gate model tool calls. Subagents inherit the session risk level unless overridden in persona config. The model declares intent via `safetyLevel` on bash calls.
-
-Main session system prompts are immutable after session start to preserve model caching. The environment tag is not updated mid-session. `/risk` changes are injected as system messages on the next user turn instead. Subagent prompts are rebuilt on risk changes so inherited risk applies to subagents.
-
-Prompt/context tag style: use dash-case for XML-like tag names in prompt text (for example `<risk-level>`, `<available-skills>`, `<tool-call>`, `<tool-result>`, `<last-assistant-message-verbatim>`). Do not introduce new snake_case tag names.
+Enabled tools execute directly. Persona and subagent tool lists determine tool availability; there is no secondary read/write authorization gate.
 
 **Bash limits**: 1MB raw capture (tail of output, stdout/stderr merged in arrival order), 60s timeout. No TTY/stdin (interactive prompts and editors will hang or fail). Environment sanitized by dropping vars that match sensitive key patterns, git is forced non-interactive (no prompt/editor/pager, batch-mode ssh).
 
@@ -185,8 +164,6 @@ Prompt/context tag style: use dash-case for XML-like tag names in prompt text (f
 - Current preview shapes: bash uses head/tail output plus a status line; write shows up to 16 preview lines with a status line; edit uses a truncated diff preview with counts.
 - Pruned tool results patch existing tool cards by `toolCallId`, preserve headers, replace the body with model-visible pruned content, and prefix status as `✂ pruned · <existing status>` (or `✂ pruned` when no status exists).
 
-**Subagent-only tools**: subagents run with a dedicated tool registry that includes the tools enabled for that subagent (inherited from the main persona or explicitly overridden). The `emit_output` tool definition remains in the codebase but is currently disabled for subagent registries. Risk level is inherited by default but can be overridden per subagent, including `read-write` even when the main session is `read-only`. The built-in `default` subagent prompt wraps and inherits the main persona system prompt, while enforcing default-subagent rules that take precedence on conflicts. `spawn_agent` can optionally set launch model/reasoning via `<provider>/<model>:<effort>` (allowlisted by `launchModels`) and can optionally set `workingDirectory`. When `workingDirectory` is set, the subagent runs from that directory and its prompt context (cwd, AGENTS.md scope, skills block) is rebuilt as if tau was started there. See `src/core/subagents/subagent_engine.ts` and `src/core/tools/spawn_agent.ts`.
-
 **Subagent limit**: at most 8 subagents may run concurrently.
 
 ## Personas and subagents
@@ -201,33 +178,29 @@ Personas can be defined at user level (`~/.config/tau/personas/*.md`) and projec
 - `serviceTier`: `priority` or `flex` for providers that support service tiers (currently `openai` and `openai-codex`)
 - `allowedReasoningLevels`: list of reasoning levels (`none`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`) shown in the UI
 - `skills`: list of enabled skill names (matched by `name` in skill frontmatter), or `"*"` to enable all discovered skills. if omitted on custom personas, defaults to `"*"`; set `skills: []` to disable skills completely.
-- `subagents`: optional map of subagent definitions. The built-in `default` subagent is implicitly enabled unless `default: false` is provided. Custom subagents must be defined as `{ systemPrompt, description?, provider+model?, reasoning?, serviceTier?, tools?, riskLevel?, launchModels? }` with lowercase-dash names (max 64 chars). `launchModels` values are allowlisted launch overrides in `<provider>/<model>:<effort>` format. Persona/subagent model ids may be unbundled as long as provider is known (Tau derives provider defaults when needed, and `models.json` can override fields). The `default` subagent cannot be overridden.
-- `tools`: list of tool names to enable for this persona. allowed: `bash`, `write`, `edit`, `view_image`, `spawn_agent`, `send_input_to_agent`, `wait_for_agents`, `terminate_agent`. if omitted, defaults to `bash`, `write`, `edit`, `view_image` (and subagent tools when subagents are enabled). risk levels still apply.
 
 On conflicts, the most specific level wins (built-ins are the base layer).
 
 ## Configuration
 
-- **Global**: `~/.config/tau/config.json` (API keys, `defaultPersona`, `defaultRisk`, `disableBuiltinPersonas`, `disableBuiltinThemes`, `defaultTheme`, `diffTool`, `builtInDiffTool`, `agentContextFiles`, `subagents`, `autoCompact`, `modelSystemNotices`, `speechToText`, `cloudflareSandbox`, `flySprites`). This level is only included when cwd is inside home.
-  - `apiKeys` (optional): Map of provider id to API key (`apiKeys.<provider>`). Keys merge by provider id across config levels.
-  - `apiKeys.parallel` (optional): Parallel API key for `web_search`/`web_fetch` usage in subagents.
-  - `apiKeys.mistral` (optional): Mistral API key for `/listen`, Telegram audio transcription, and PDF OCR.
-  - `apiKeys.google` (optional): Google API key for Gemini chat models, `/speak`, and speech-to-text when `speechToText.provider` is `gemini`.
-  - `defaultPersona` (optional): String persona reference used by default when starting the app. Accepts `<id>` or `<id>:<reasoning>` and matches are exact/case-sensitive. Overridden by `--persona` flag.
-  - `defaultRisk` (optional): Default risk level (`read-only`, `read-write`). Overridden by `--risk` flag. Defaults to `read-only`.
-  - `disableBuiltinPersonas` (optional): If true, tau will not load built-in personas, only entries from disk.
-  - `disableBuiltinThemes` (optional): If true, tau will not load built-in themes, only entries from disk.
-  - `defaultTheme` (optional): Theme id to load from built-in themes, `.tau/themes/<id>.json`, or `~/.config/tau/themes/<id>.json`. Must be non-empty and matches are exact/case-sensitive. Defaults to `gold`.
-  - `diffTool` (optional): Diff-review tool launcher config (`command`, optional `args`, optional `env`). Relative `command` paths resolve from the config level root. `/diff` launches this tool from the TUI side while host-owned review work runs through the session protocol.
-  - `builtInDiffTool` (optional): Built-in diff tool settings used only by the fallback launcher. `codeTheme` sets the initial code theme, defaults to `github-dark-dimmed`, and accepts the dark themes listed in README.md; users can still switch themes in the diff tool UI.
-  - `subagents.defaultLaunchModels` (optional): Allowlisted `spawn_agent` launch overrides for the built-in `default` subagent (`<provider>/<model>:<effort>` entries).
-  - `autoCompact` (optional): Automatic compaction settings, merged field-by-field. Defaults are `{ "enabled": true, "reserveTokens": 16384, "keepRecentTokens": 20000 }`. Threshold detection uses only provider-reported assistant usage against `model.contextWindow - reserveTokens`; Tau's token heuristic is only used after threshold crossing to choose the retained-tail cut point, with retention capped at that threshold. Auto-compaction summarizes older context, asks the compaction model to select original user messages to append verbatim inside the summary by history id, keeps a recent tail, inserts a hidden continuation user message, and emits `compaction_start`/`compaction_end` core events. Context-overflow compact-and-retry is not implemented.
-  - `modelSystemNotices` (optional): Map of `<provider>/<model>` to notice text. Provider ids must be known and model ids are exact/case-sensitive against the merged configured model catalog (built-in + layered `models.json`). Tau prepends the notice as a `<system>` block before each user message sent to that model (main session and subagents).
-  - `speechToText` (optional): Speech-to-text config for `/listen` and Telegram audio transcription. `provider` is required when present and accepts `mistral` (default, Voxtral) or `gemini` (Gemini 3.5 Flash with minimal thinking).
-  - `cloudflareSandbox.bridges` (optional): Host-owned Cloudflare Sandbox bridge targets for hosted execution environments. Each bridge has `url`, optional `apiKey`, optional `apiKeyEnv`, and optional `home`. `session.create` references bridges by id plus an already-provisioned `sandboxId` and real sandbox `cwd`; Tau does not create or provision Cloudflare sandboxes during session creation. Tau resolves config/content from the sandbox `cwd`, while bridge credentials are resolved by the host and are not persisted in session snapshots.
-  - `flySprites.apis` (optional): Host-owned Fly Sprites API targets for hosted execution environments. Each API has optional `baseURL`, optional `token`, optional `tokenEnv`, and optional `home`. `session.create` references APIs by id plus an already-provisioned `spriteName` and real Sprite `cwd`; Tau does not create or provision Sprites during session creation. Tau resolves config/content from the Sprite `cwd`, while API tokens are resolved by the host and are not persisted in session snapshots.
-  - `nook` (optional): Single effective Nook target for an already deployed Cloudflare Nook instance. Fields: required `domain`, optional `accessClientId`, optional `accessClientSecret`, optional `accessClientSecretEnv`. When `accessClientSecretEnv` resolves to a value, it wins over `accessClientSecret`. The Nook Worker validates Cloudflare Access JWTs against the configured Access issuer and audience; raw service-token headers are only used to pass Cloudflare Access and are not trusted by the Worker. `tau nook setup` takes infrastructure route and Access validation inputs through `--zone-name`/`--access-team-domain`/`--access-aud` or `NOOK_ZONE_NAME`/`NOOK_ACCESS_TEAM_DOMAIN`/`NOOK_ACCESS_AUD`. `tau nook destroy` takes cleanup service-token inputs through flags or `NOOK_ACCESS_CLIENT_ID`/`NOOK_ACCESS_CLIENT_SECRET`.
-  - Telegram runner settings are loaded from a separate JSON file passed via `tau telegram --config-file <path>` (`bots` map keyed by bot id, optional `maxSessions`, `projects`, `workspaceRoot`, `systemMessage`, and project fields like `workingDirectory`, `description`, `bootstrapCommands`, and `backgroundBootstrapCommands`). Telegram sessions are chat-scoped within each bot, allowed groups share one group session namespace, and group turns trigger only on explicit bot mentions. Telegram repositories use automatic persistent bare caches at `<workspaceRoot>-repo-cache/<projectId>.git`, refreshed with pruned fetches and reinitialized if the configured repo changes. Session records are persisted at `<workspaceRoot>-sessions.json`; normal shutdown preserves session workspaces, startup removes workspace-root entries not referenced by recoverable persisted sessions, and running sessions recover as waiting for input, while missing workspaces are reconstructed from the repository cache before Tau snapshot reconnection. Bootstrap command lists run only when a workspace is created or reconstructed, not when a preserved workspace is reconnected. The Telegram adapter reconstructs chat routing from persisted session ownership and prunes stale `tau-telegram-attachments-*` directories under the system temp directory. Assume zero or one Telegram runner process per host; concurrent runners are unsupported.
+- `apiKeys` (optional): Map of provider id to API key (`apiKeys.<provider>`). Keys merge by provider id across config levels.
+- `apiKeys.parallel` (optional): Parallel API key for `web_search`/`web_fetch` usage in subagents.
+- `apiKeys.mistral` (optional): Mistral API key for `/listen`, Telegram audio transcription, and PDF OCR.
+- `apiKeys.google` (optional): Google API key for Gemini chat models, `/speak`, and speech-to-text when `speechToText.provider` is `gemini`.
+- `defaultPersona` (optional): String persona reference used by default when starting the app. Accepts `<id>` or `<id>:<reasoning>` and matches are exact/case-sensitive. Overridden by `--persona` flag.
+- `disableBuiltinPersonas` (optional): If true, tau will not load built-in personas, only entries from disk.
+- `disableBuiltinThemes` (optional): If true, tau will not load built-in themes, only entries from disk.
+- `defaultTheme` (optional): Theme id to load from built-in themes, `.tau/themes/<id>.json`, or `~/.config/tau/themes/<id>.json`. Must be non-empty and matches are exact/case-sensitive. Defaults to `gold`.
+- `diffTool` (optional): Diff-review tool launcher config (`command`, optional `args`, optional `env`). Relative `command` paths resolve from the config level root. `/diff` launches this tool from the TUI side while host-owned review work runs through the session protocol.
+- `builtInDiffTool` (optional): Built-in diff tool settings used only by the fallback launcher. `codeTheme` sets the initial code theme, defaults to `github-dark-dimmed`, and accepts the dark themes listed in README.md; users can still switch themes in the diff tool UI.
+- `subagents.defaultLaunchModels` (optional): Allowlisted `spawn_agent` launch overrides for the built-in `default` subagent (`<provider>/<model>:<effort>` entries).
+- `autoCompact` (optional): Automatic compaction settings, merged field-by-field. Defaults are `{ "enabled": true, "reserveTokens": 16384, "keepRecentTokens": 20000 }`. Threshold detection uses only provider-reported assistant usage against `model.contextWindow - reserveTokens`; Tau's token heuristic is only used after threshold crossing to choose the retained-tail cut point, with retention capped at that threshold. Auto-compaction summarizes older context, asks the compaction model to select original user messages to append verbatim inside the summary by history id, keeps a recent tail, inserts a hidden continuation user message, and emits `compaction_start`/`compaction_end` core events. Context-overflow compact-and-retry is not implemented.
+- `modelSystemNotices` (optional): Map of `<provider>/<model>` to notice text. Provider ids must be known and model ids are exact/case-sensitive against the merged configured model catalog (built-in + layered `models.json`). Tau prepends the notice as a `<system>` block before each user message sent to that model (main session and subagents).
+- `speechToText` (optional): Speech-to-text config for `/listen` and Telegram audio transcription. `provider` is required when present and accepts `mistral` (default, Voxtral) or `gemini` (Gemini 3.5 Flash with minimal thinking).
+- `cloudflareSandbox.bridges` (optional): Host-owned Cloudflare Sandbox bridge targets for hosted execution environments. Each bridge has `url`, optional `apiKey`, optional `apiKeyEnv`, and optional `home`. `session.create` references bridges by id plus an already-provisioned `sandboxId` and real sandbox `cwd`; Tau does not create or provision Cloudflare sandboxes during session creation. Tau resolves config/content from the sandbox `cwd`, while bridge credentials are resolved by the host and are not persisted in session snapshots.
+- `flySprites.apis` (optional): Host-owned Fly Sprites API targets for hosted execution environments. Each API has optional `baseURL`, optional `token`, optional `tokenEnv`, and optional `home`. `session.create` references APIs by id plus an already-provisioned `spriteName` and real Sprite `cwd`; Tau does not create or provision Sprites during session creation. Tau resolves config/content from the Sprite `cwd`, while API tokens are resolved by the host and are not persisted in session snapshots.
+- `nook` (optional): Single effective Nook target for an already deployed Cloudflare Nook instance. Fields: required `domain`, optional `accessClientId`, optional `accessClientSecret`, optional `accessClientSecretEnv`. When `accessClientSecretEnv` resolves to a value, it wins over `accessClientSecret`. The Nook Worker validates Cloudflare Access JWTs against the configured Access issuer and audience; raw service-token headers are only used to pass Cloudflare Access and are not trusted by the Worker. `tau nook setup` takes infrastructure route and Access validation inputs through `--zone-name`/`--access-team-domain`/`--access-aud` or `NOOK_ZONE_NAME`/`NOOK_ACCESS_TEAM_DOMAIN`/`NOOK_ACCESS_AUD`. `tau nook destroy` takes cleanup service-token inputs through flags or `NOOK_ACCESS_CLIENT_ID`/`NOOK_ACCESS_CLIENT_SECRET`.
+- Telegram runner settings are loaded from a separate JSON file passed via `tau telegram --config-file <path>` (`bots` map keyed by bot id, optional `maxSessions`, `projects`, `workspaceRoot`, `systemMessage`, and project fields like `workingDirectory`, `description`, `bootstrapCommands`, and `backgroundBootstrapCommands`). Telegram sessions are chat-scoped within each bot, allowed groups share one group session namespace, and group turns trigger only on explicit bot mentions. Telegram repositories use automatic persistent bare caches at `<workspaceRoot>-repo-cache/<projectId>.git`, refreshed with pruned fetches and reinitialized if the configured repo changes. Session records are persisted at `<workspaceRoot>-sessions.json`; normal shutdown preserves session workspaces, startup removes workspace-root entries not referenced by recoverable persisted sessions, and running sessions recover as waiting for input, while missing workspaces are reconstructed from the repository cache before Tau snapshot reconnection. Bootstrap command lists run only when a workspace is created or reconstructed, not when a preserved workspace is reconnected. The Telegram adapter reconstructs chat routing from persisted session ownership and prunes stale `tau-telegram-attachments-*` directories under the system temp directory. Assume zero or one Telegram runner process per host; concurrent runners are unsupported.
 
 - **Config levels**: `.tau/config.json` files are discovered from cwd up to home (or filesystem root if cwd is outside home). The global level is included only when cwd is under home. Scalars use most-specific wins; `apiKeys`, `autoCompact`, `modelSystemNotices`, `cloudflareSandbox.bridges`, and `flySprites.apis` merge per field; `diffTool` is selected from the most specific level, and its relative `command` is resolved from that level root; `builtInDiffTool` is selected from the most specific level and applies to the built-in `tau diff-tool` demo; `agentContextFiles` are additive.
 - **Model overrides**: `~/.config/tau/models.json` (global, only when cwd is under home) and `.tau/models.json` (project) are discovered using the same level resolution as `config.json`. Entries overlay bundled model definitions by `provider + model id` (most specific wins), including request-wide `cost.tiers` selected by the highest matching `inputTokensAbove` threshold. Known providers only.
@@ -273,7 +246,6 @@ Trigger sensitivity is a concept that guides how proactively the model should ac
 - `--debug` - Print debug info (loaded personas, prompts, skills, full system prompt, tool schemas) and exit
 - `--load`, `-l <file>` - Load a checkpoint file in TUI mode
 - `--persona <id>[:<level>]`, `-p` - Start with a specific persona and optional reasoning level
-- `--risk <level>`, `-r` - Set initial risk level (`read-only`, `read-write`)
 - `--caffeinated` - Keep macOS awake during active assistant turns in TUI mode (currently a no-op on Linux)
 - `--no-agent-context-files` - Disable AGENTS.md injection into the system prompt
 
@@ -286,7 +258,6 @@ The `--debug` flag respects `--persona` and `--no-agent-context-files`, so you c
 - `tau rpc` - Run headless stdio RPC mode (NDJSON request/response + core event streaming)
 - `tau serve [--host <host>] [--port <port>] [--auth-token <token>]` - Host session protocol over WebSocket (`TAU_WS_AUTH_TOKEN` can provide the token)
 - `tau attach [--session <id> | --new --cwd <path>] [--auth-token <token>] ws://host:port` - Run the terminal UI against a WebSocket session host
-- `tau attach [--session <id> | --new --cwd <path>] -- <command...>` - Run the terminal UI against a session-protocol command, for example `ssh vps 'tau rpc --risk read-only'`; without `--session` or `--new`, attach lists hosted sessions and prompts for a selection, and new sessions require a host-local execution cwd
 - `tau auth login codex` - OAuth login for ChatGPT Plus/Pro; stores `~/.config/tau/auth.json`
 - `tau auth list` - List authenticated accounts and usage windows
 - `tau auth logout codex --account <email>` - Remove stored OAuth credentials
@@ -307,16 +278,11 @@ The `--debug` flag respects `--persona` and `--no-agent-context-files`, so you c
 - `/help`, `/new`, `/exit`, `/rewind`, `/diff [git diff args...]` (opens the TUI-local diff review tool), `/copy:text`, `/copy:code`, `/reload`, `/listen` (macOS only; can record while assistant works; warns on Linux), `/speak` (macOS only; speaks the last assistant message)
 - `/compact:summary-only`, `/compact:summary-and-last` - Manually compact history into a single synthetic user summary message with compaction-model-selected original user messages copied verbatim inside the summary (optionally includes last assistant message verbatim when available); automatic compaction is separate and keeps a retained recent tail
 - `/prune:earliest`, `/prune:largest`, `/prune:smart` - Prune tool results and compact edit call payloads/results
-- `/risk:read-only`, `/risk:read-write`, `/persona:<id>`, `/prompt:<id>`, `/theme:<id>`
 - `!<cmd>` - Direct bash execution (bypasses model)
 - `!!<cmd>` - Direct bash execution without adding output to the model context
 - `#<request>` - Memory mode for updating AGENTS.md (single-line only)
 
 Slash commands only trigger on single-line inputs. `/diff` launches the local diff tool and records returned review feedback without auto-running the assistant. Unknown slash-prefixed text is sent as a normal prompt.
-
-RPC mode command surface is protocol-based (`initialize`, `session.create`, `session.list`, `session.observe`, `session.unobserve`, `session.record`, `session.submit`, `session.queue`, `session.steer`, `session.cancelPendingMessages`, `session.retry`, `session.exec`, `session.interrupt`, `session.snapshot`, `session.setRisk`, `session.setReasoning`, `session.setPersona`, `session.resolvePrompt`, `session.autocompletePaths`, `session.reload`, `session.compact`, `session.prune`, `session.rewind`, `session.terminateSubagent`, `session.ephemeral.create`, `session.ephemeral.submit`, `session.ephemeral.close`, `session.clientTool.ack`, `session.clientTool.result`) over NDJSON stdin/stdout.
-
-**Keybindings**: `Shift+Tab` (cycle reasoning), `Ctrl+R` (cycle risk level), `Ctrl+P` (cycle personality), `Ctrl+T` (toggle thinking), `Ctrl+O` (compact UI), `Ctrl+S` (stash input to clipboard), `Ctrl+Y` (toggle voice recording for `/listen`), `Ctrl+G` (terminate selected subagent), `Ctrl+Enter` (steer running assistant with editor input), `Enter x2` (retry last response on empty input), `Escape x2` (clear current prompt), `Alt+Up` (cancel pending queue and steering messages into the editor), `Alt+Down` (cycle active subagents), `Escape` (interrupt active work), `Ctrl+C` (press twice to exit)
 
 Reasoning changes are allowed while a turn is running. The active user-message turn keeps the reasoning captured when that turn started, including all tool-call subturns; the new reasoning applies to the next submitted, queued, or steering user-message turn when it actually starts.
 
@@ -382,7 +348,6 @@ EOF
 
 ## Security
 
-- Risk levels gate model tools only; `!` commands bypass checks
 - Bash sanitizes environment, blocks `*_KEY`, `*_SECRET`, `*_TOKEN`, `*_PASSWORD` patterns
 - Process groups terminated on abort to prevent orphaned processes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # Tau
 
+Terminal-based AI chat client with tool execution and streaming responses. Supports Anthropic, OpenAI, and Google models.
+
 ## Platform support
 
 - **Supported**: macOS and Linux.
@@ -144,7 +146,24 @@ Tau is pre-v1 and the priority is to reach a clean, stable v1 design. Prefer exp
 
 ## Tool system
 
-Enabled tools execute directly. Persona and subagent tool lists determine tool availability; there is no secondary read/write authorization gate.
+| Tool | Purpose |
+| --- | --- |
+| `bash` | Shell execution |
+| `write` | Create/overwrite files |
+| `edit` | Replace exact text in files |
+| `view_image` | View an image file |
+| `spawn_agent` | Start a background subagent |
+| `send_input_to_agent` | Send input to an idle subagent |
+| `wait_for_agents` | Await completed subagent outputs, returning when at least one requested agent finishes |
+| `terminate_agent` | Stop a running subagent |
+| `emit_output` | Subagent-only output to main (currently disabled in subagent registries) |
+| `nook` | Operate the configured Nook static mini-app platform |
+
+Note: read/list/grep tool definitions exist in `src/core/tools`, but ToolCatalog does not register them in the default tool set. The TUI advertises `diff_review` as a client-provided tool; it is not a host tool registry entry. The `nook` host tool is automatically exposed only when effective Tau config contains `nook`.
+
+Enabled tools execute directly. Persona and subagent tool lists determine tool availability. Immediate tool-call argument schemas remain strict.
+
+Prompt/context tag style: use dash-case for XML-like tag names in prompt text (for example `<available-skills>`, `<tool-call>`, `<tool-result>`, `<last-assistant-message-verbatim>`). Do not introduce new snake_case tag names.
 
 **Bash limits**: 1MB raw capture (tail of output, stdout/stderr merged in arrival order), 60s timeout. No TTY/stdin (interactive prompts and editors will hang or fail). Environment sanitized by dropping vars that match sensitive key patterns, git is forced non-interactive (no prompt/editor/pager, batch-mode ssh).
 
@@ -164,6 +183,8 @@ Enabled tools execute directly. Persona and subagent tool lists determine tool a
 - Current preview shapes: bash uses head/tail output plus a status line; write shows up to 16 preview lines with a status line; edit uses a truncated diff preview with counts.
 - Pruned tool results patch existing tool cards by `toolCallId`, preserve headers, replace the body with model-visible pruned content, and prefix status as `✂ pruned · <existing status>` (or `✂ pruned` when no status exists).
 
+**Subagent-only tools**: subagents run with a dedicated tool registry that includes the tools enabled for that subagent (inherited from the main persona or explicitly overridden). The `emit_output` tool definition remains in the codebase but is currently disabled for subagent registries. The built-in `default` subagent prompt wraps and inherits the main persona system prompt, while enforcing default-subagent rules that take precedence on conflicts. `spawn_agent` can optionally set launch model/reasoning via `<provider>/<model>:<effort>` (allowlisted by `launchModels`) and can optionally set `workingDirectory`. When `workingDirectory` is set, the subagent runs from that directory and its prompt context (cwd, AGENTS.md scope, skills block) is rebuilt as if tau was started there. See `src/core/subagents/subagent_engine.ts` and `src/core/tools/spawn_agent.ts`.
+
 **Subagent limit**: at most 8 subagents may run concurrently.
 
 ## Personas and subagents
@@ -178,29 +199,34 @@ Personas can be defined at user level (`~/.config/tau/personas/*.md`) and projec
 - `serviceTier`: `priority` or `flex` for providers that support service tiers (currently `openai` and `openai-codex`)
 - `allowedReasoningLevels`: list of reasoning levels (`none`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`) shown in the UI
 - `skills`: list of enabled skill names (matched by `name` in skill frontmatter), or `"*"` to enable all discovered skills. if omitted on custom personas, defaults to `"*"`; set `skills: []` to disable skills completely.
+- `subagents`: optional map of subagent definitions. The built-in `default` subagent is implicitly enabled unless `default: false` is provided. Custom subagents must be defined as `{ systemPrompt, description?, provider+model?, reasoning?, serviceTier?, tools?, launchModels? }` with lowercase-dash names (max 64 chars). `launchModels` values are allowlisted launch overrides in `<provider>/<model>:<effort>` format. Persona/subagent model ids may be unbundled as long as provider is known (Tau derives provider defaults when needed, and `models.json` can override fields). The `default` subagent cannot be overridden.
+- `tools`: list of tool names to enable for this persona. allowed: `bash`, `write`, `edit`, `view_image`, `spawn_agent`, `send_input_to_agent`, `wait_for_agents`, `terminate_agent`. if omitted, defaults to `bash`, `write`, `edit`, `view_image` (and subagent tools when subagents are enabled).
 
 On conflicts, the most specific level wins (built-ins are the base layer).
 
 ## Configuration
 
-- `apiKeys` (optional): Map of provider id to API key (`apiKeys.<provider>`). Keys merge by provider id across config levels.
-- `apiKeys.parallel` (optional): Parallel API key for `web_search`/`web_fetch` usage in subagents.
-- `apiKeys.mistral` (optional): Mistral API key for `/listen`, Telegram audio transcription, and PDF OCR.
-- `apiKeys.google` (optional): Google API key for Gemini chat models, `/speak`, and speech-to-text when `speechToText.provider` is `gemini`.
-- `defaultPersona` (optional): String persona reference used by default when starting the app. Accepts `<id>` or `<id>:<reasoning>` and matches are exact/case-sensitive. Overridden by `--persona` flag.
-- `disableBuiltinPersonas` (optional): If true, tau will not load built-in personas, only entries from disk.
-- `disableBuiltinThemes` (optional): If true, tau will not load built-in themes, only entries from disk.
-- `defaultTheme` (optional): Theme id to load from built-in themes, `.tau/themes/<id>.json`, or `~/.config/tau/themes/<id>.json`. Must be non-empty and matches are exact/case-sensitive. Defaults to `gold`.
-- `diffTool` (optional): Diff-review tool launcher config (`command`, optional `args`, optional `env`). Relative `command` paths resolve from the config level root. `/diff` launches this tool from the TUI side while host-owned review work runs through the session protocol.
-- `builtInDiffTool` (optional): Built-in diff tool settings used only by the fallback launcher. `codeTheme` sets the initial code theme, defaults to `github-dark-dimmed`, and accepts the dark themes listed in README.md; users can still switch themes in the diff tool UI.
-- `subagents.defaultLaunchModels` (optional): Allowlisted `spawn_agent` launch overrides for the built-in `default` subagent (`<provider>/<model>:<effort>` entries).
-- `autoCompact` (optional): Automatic compaction settings, merged field-by-field. Defaults are `{ "enabled": true, "reserveTokens": 16384, "keepRecentTokens": 20000 }`. Threshold detection uses only provider-reported assistant usage against `model.contextWindow - reserveTokens`; Tau's token heuristic is only used after threshold crossing to choose the retained-tail cut point, with retention capped at that threshold. Auto-compaction summarizes older context, asks the compaction model to select original user messages to append verbatim inside the summary by history id, keeps a recent tail, inserts a hidden continuation user message, and emits `compaction_start`/`compaction_end` core events. Context-overflow compact-and-retry is not implemented.
-- `modelSystemNotices` (optional): Map of `<provider>/<model>` to notice text. Provider ids must be known and model ids are exact/case-sensitive against the merged configured model catalog (built-in + layered `models.json`). Tau prepends the notice as a `<system>` block before each user message sent to that model (main session and subagents).
-- `speechToText` (optional): Speech-to-text config for `/listen` and Telegram audio transcription. `provider` is required when present and accepts `mistral` (default, Voxtral) or `gemini` (Gemini 3.5 Flash with minimal thinking).
-- `cloudflareSandbox.bridges` (optional): Host-owned Cloudflare Sandbox bridge targets for hosted execution environments. Each bridge has `url`, optional `apiKey`, optional `apiKeyEnv`, and optional `home`. `session.create` references bridges by id plus an already-provisioned `sandboxId` and real sandbox `cwd`; Tau does not create or provision Cloudflare sandboxes during session creation. Tau resolves config/content from the sandbox `cwd`, while bridge credentials are resolved by the host and are not persisted in session snapshots.
-- `flySprites.apis` (optional): Host-owned Fly Sprites API targets for hosted execution environments. Each API has optional `baseURL`, optional `token`, optional `tokenEnv`, and optional `home`. `session.create` references APIs by id plus an already-provisioned `spriteName` and real Sprite `cwd`; Tau does not create or provision Sprites during session creation. Tau resolves config/content from the Sprite `cwd`, while API tokens are resolved by the host and are not persisted in session snapshots.
-- `nook` (optional): Single effective Nook target for an already deployed Cloudflare Nook instance. Fields: required `domain`, optional `accessClientId`, optional `accessClientSecret`, optional `accessClientSecretEnv`. When `accessClientSecretEnv` resolves to a value, it wins over `accessClientSecret`. The Nook Worker validates Cloudflare Access JWTs against the configured Access issuer and audience; raw service-token headers are only used to pass Cloudflare Access and are not trusted by the Worker. `tau nook setup` takes infrastructure route and Access validation inputs through `--zone-name`/`--access-team-domain`/`--access-aud` or `NOOK_ZONE_NAME`/`NOOK_ACCESS_TEAM_DOMAIN`/`NOOK_ACCESS_AUD`. `tau nook destroy` takes cleanup service-token inputs through flags or `NOOK_ACCESS_CLIENT_ID`/`NOOK_ACCESS_CLIENT_SECRET`.
-- Telegram runner settings are loaded from a separate JSON file passed via `tau telegram --config-file <path>` (`bots` map keyed by bot id, optional `maxSessions`, `projects`, `workspaceRoot`, `systemMessage`, and project fields like `workingDirectory`, `description`, `bootstrapCommands`, and `backgroundBootstrapCommands`). Telegram sessions are chat-scoped within each bot, allowed groups share one group session namespace, and group turns trigger only on explicit bot mentions. Telegram repositories use automatic persistent bare caches at `<workspaceRoot>-repo-cache/<projectId>.git`, refreshed with pruned fetches and reinitialized if the configured repo changes. Session records are persisted at `<workspaceRoot>-sessions.json`; normal shutdown preserves session workspaces, startup removes workspace-root entries not referenced by recoverable persisted sessions, and running sessions recover as waiting for input, while missing workspaces are reconstructed from the repository cache before Tau snapshot reconnection. Bootstrap command lists run only when a workspace is created or reconstructed, not when a preserved workspace is reconnected. The Telegram adapter reconstructs chat routing from persisted session ownership and prunes stale `tau-telegram-attachments-*` directories under the system temp directory. Assume zero or one Telegram runner process per host; concurrent runners are unsupported.
+- **Global**: `~/.config/tau/config.json` (API keys, `defaultPersona`, `disableBuiltinPersonas`, `disableBuiltinThemes`, `defaultTheme`, `diffTool`, `builtInDiffTool`, `agentContextFiles`, `subagents`, `autoCompact`, `modelSystemNotices`, `speechToText`, `cloudflareSandbox`, `flySprites`). This level is only included when cwd is inside home.
+  - `apiKeys` (optional): Map of provider id to API key (`apiKeys.<provider>`). Keys merge by provider id across config levels.
+  - `apiKeys.parallel` (optional): Parallel API key for `web_search`/`web_fetch` usage in subagents.
+  - `apiKeys.mistral` (optional): Mistral API key for `/listen`, Telegram audio transcription, and PDF OCR.
+  - `apiKeys.google` (optional): Google API key for Gemini chat models, `/speak`, and speech-to-text when `speechToText.provider` is `gemini`.
+  - `defaultPersona` (optional): String persona reference used by default when starting the app. Accepts `<id>` or `<id>:<reasoning>` and matches are exact/case-sensitive. Overridden by `--persona` flag.
+  - `disableBuiltinPersonas` (optional): If true, tau will not load built-in personas, only entries from disk.
+  - `disableBuiltinThemes` (optional): If true, tau will not load built-in themes, only entries from disk.
+  - `defaultTheme` (optional): Theme id to load from built-in themes, `.tau/themes/<id>.json`, or `~/.config/tau/themes/<id>.json`. Must be non-empty and matches are exact/case-sensitive. Defaults to `gold`.
+  - `diffTool` (optional): Diff-review tool launcher config (`command`, optional `args`, optional `env`). Relative `command` paths resolve from the config level root. `/diff` launches this tool from the TUI side while host-owned review work runs through the session protocol.
+  - `builtInDiffTool` (optional): Built-in diff tool settings used only by the fallback launcher. `codeTheme` sets the initial code theme, defaults to `github-dark-dimmed`, and accepts the dark themes listed in README.md; users can still switch themes in the diff tool UI.
+  - `subagents.defaultLaunchModels` (optional): Allowlisted `spawn_agent` launch overrides for the built-in `default` subagent (`<provider>/<model>:<effort>` entries).
+  - `autoCompact` (optional): Automatic compaction settings, merged field-by-field. Defaults are `{ "enabled": true, "reserveTokens": 16384, "keepRecentTokens": 20000 }`. Threshold detection uses only provider-reported assistant usage against `model.contextWindow - reserveTokens`; Tau's token heuristic is only used after threshold crossing to choose the retained-tail cut point, with retention capped at that threshold. Auto-compaction summarizes older context, asks the compaction model to select original user messages to append verbatim inside the summary by history id, keeps a recent tail, inserts a hidden continuation user message, and emits `compaction_start`/`compaction_end` core events. Context-overflow compact-and-retry is not implemented.
+  - `modelSystemNotices` (optional): Map of `<provider>/<model>` to notice text. Provider ids must be known and model ids are exact/case-sensitive against the merged configured model catalog (built-in + layered `models.json`). Tau prepends the notice as a `<system>` block before each user message sent to that model (main session and subagents).
+  - `speechToText` (optional): Speech-to-text config for `/listen` and Telegram audio transcription. `provider` is required when present and accepts `mistral` (default, Voxtral) or `gemini` (Gemini 3.5 Flash with minimal thinking).
+  - `cloudflareSandbox.bridges` (optional): Host-owned Cloudflare Sandbox bridge targets for hosted execution environments. Each bridge has `url`, optional `apiKey`, optional `apiKeyEnv`, and optional `home`. `session.create` references bridges by id plus an already-provisioned `sandboxId` and real sandbox `cwd`; Tau does not create or provision Cloudflare sandboxes during session creation. Tau resolves config/content from the sandbox `cwd`, while bridge credentials are resolved by the host and are not persisted in session snapshots.
+  - `flySprites.apis` (optional): Host-owned Fly Sprites API targets for hosted execution environments. Each API has optional `baseURL`, optional `token`, optional `tokenEnv`, and optional `home`. `session.create` references APIs by id plus an already-provisioned `spriteName` and real Sprite `cwd`; Tau does not create or provision Sprites during session creation. Tau resolves config/content from the Sprite `cwd`, while API tokens are resolved by the host and are not persisted in session snapshots.
+  - `nook` (optional): Single effective Nook target for an already deployed Cloudflare Nook instance. Fields: required `domain`, optional `accessClientId`, optional `accessClientSecret`, optional `accessClientSecretEnv`. When `accessClientSecretEnv` resolves to a value, it wins over `accessClientSecret`. The Nook Worker validates Cloudflare Access JWTs against the configured Access issuer and audience; raw service-token headers are only used to pass Cloudflare Access and are not trusted by the Worker. `tau nook setup` takes infrastructure route and Access validation inputs through `--zone-name`/`--access-team-domain`/`--access-aud` or `NOOK_ZONE_NAME`/`NOOK_ACCESS_TEAM_DOMAIN`/`NOOK_ACCESS_AUD`. `tau nook destroy` takes cleanup service-token inputs through flags or `NOOK_ACCESS_CLIENT_ID`/`NOOK_ACCESS_CLIENT_SECRET`.
+  - Telegram runner settings are loaded from a separate JSON file passed via `tau telegram --config-file <path>` (`bots` map keyed by bot id, optional `maxSessions`, `projects`, `workspaceRoot`, `systemMessage`, and project fields like `workingDirectory`, `description`, `bootstrapCommands`, and `backgroundBootstrapCommands`). Telegram sessions are chat-scoped within each bot, allowed groups share one group session namespace, and group turns trigger only on explicit bot mentions. Telegram repositories use automatic persistent bare caches at `<workspaceRoot>-repo-cache/<projectId>.git`, refreshed with pruned fetches and reinitialized if the configured repo changes. Session records are persisted at `<workspaceRoot>-sessions.json`; normal shutdown preserves session workspaces, startup removes workspace-root entries not referenced by recoverable persisted sessions, and running sessions recover as waiting for input, while missing workspaces are reconstructed from the repository cache before Tau snapshot reconnection. Bootstrap command lists run only when a workspace is created or reconstructed, not when a preserved workspace is reconnected. The Telegram adapter reconstructs chat routing from persisted session ownership and prunes stale `tau-telegram-attachments-*` directories under the system temp directory. Assume zero or one Telegram runner process per host; concurrent runners are unsupported.
+
+Unknown object fields in user-authored configuration are accepted and stripped after known fields are validated.
 
 - **Config levels**: `.tau/config.json` files are discovered from cwd up to home (or filesystem root if cwd is outside home). The global level is included only when cwd is under home. Scalars use most-specific wins; `apiKeys`, `autoCompact`, `modelSystemNotices`, `cloudflareSandbox.bridges`, and `flySprites.apis` merge per field; `diffTool` is selected from the most specific level, and its relative `command` is resolved from that level root; `builtInDiffTool` is selected from the most specific level and applies to the built-in `tau diff-tool` demo; `agentContextFiles` are additive.
 - **Model overrides**: `~/.config/tau/models.json` (global, only when cwd is under home) and `.tau/models.json` (project) are discovered using the same level resolution as `config.json`. Entries overlay bundled model definitions by `provider + model id` (most specific wins), including request-wide `cost.tiers` selected by the highest matching `inputTokensAbove` threshold. Known providers only.
@@ -258,6 +284,7 @@ The `--debug` flag respects `--persona` and `--no-agent-context-files`, so you c
 - `tau rpc` - Run headless stdio RPC mode (NDJSON request/response + core event streaming)
 - `tau serve [--host <host>] [--port <port>] [--auth-token <token>]` - Host session protocol over WebSocket (`TAU_WS_AUTH_TOKEN` can provide the token)
 - `tau attach [--session <id> | --new --cwd <path>] [--auth-token <token>] ws://host:port` - Run the terminal UI against a WebSocket session host
+- `tau attach [--session <id> | --new --cwd <path>] -- <command...>` - Run the terminal UI against a session-protocol command, for example `ssh vps 'tau rpc'`; without `--session` or `--new`, attach lists hosted sessions and prompts for a selection, and new sessions require a host-local execution cwd
 - `tau auth login codex` - OAuth login for ChatGPT Plus/Pro; stores `~/.config/tau/auth.json`
 - `tau auth list` - List authenticated accounts and usage windows
 - `tau auth logout codex --account <email>` - Remove stored OAuth credentials
@@ -278,11 +305,16 @@ The `--debug` flag respects `--persona` and `--no-agent-context-files`, so you c
 - `/help`, `/new`, `/exit`, `/rewind`, `/diff [git diff args...]` (opens the TUI-local diff review tool), `/copy:text`, `/copy:code`, `/reload`, `/listen` (macOS only; can record while assistant works; warns on Linux), `/speak` (macOS only; speaks the last assistant message)
 - `/compact:summary-only`, `/compact:summary-and-last` - Manually compact history into a single synthetic user summary message with compaction-model-selected original user messages copied verbatim inside the summary (optionally includes last assistant message verbatim when available); automatic compaction is separate and keeps a retained recent tail
 - `/prune:earliest`, `/prune:largest`, `/prune:smart` - Prune tool results and compact edit call payloads/results
+- `/persona:<id>`, `/prompt:<id>`, `/theme:<id>`
 - `!<cmd>` - Direct bash execution (bypasses model)
 - `!!<cmd>` - Direct bash execution without adding output to the model context
 - `#<request>` - Memory mode for updating AGENTS.md (single-line only)
 
 Slash commands only trigger on single-line inputs. `/diff` launches the local diff tool and records returned review feedback without auto-running the assistant. Unknown slash-prefixed text is sent as a normal prompt.
+
+RPC mode command surface is protocol-based (`initialize`, `session.create`, `session.list`, `session.observe`, `session.unobserve`, `session.record`, `session.submit`, `session.queue`, `session.steer`, `session.cancelPendingMessages`, `session.retry`, `session.exec`, `session.interrupt`, `session.snapshot`, `session.setReasoning`, `session.setPersona`, `session.resolvePrompt`, `session.autocompletePaths`, `session.reload`, `session.compact`, `session.prune`, `session.rewind`, `session.terminateSubagent`, `session.ephemeral.create`, `session.ephemeral.submit`, `session.ephemeral.close`, `session.clientTool.ack`, `session.clientTool.result`) over NDJSON stdin/stdout.
+
+**Keybindings**: `Shift+Tab` (cycle reasoning), `Ctrl+P` (cycle personality), `Ctrl+T` (toggle thinking), `Ctrl+O` (compact UI), `Ctrl+S` (stash input to clipboard), `Ctrl+Y` (toggle voice recording for `/listen`), `Ctrl+G` (terminate selected subagent), `Ctrl+Enter` (steer running assistant with editor input), `Enter x2` (retry last response on empty input), `Escape x2` (clear current prompt), `Alt+Up` (cancel pending queue and steering messages into the editor), `Alt+Down` (cycle active subagents), `Escape` (interrupt active work), `Ctrl+C` (press twice to exit)
 
 Reasoning changes are allowed while a turn is running. The active user-message turn keeps the reasoning captured when that turn started, including all tool-call subturns; the new reasoning applies to the next submitted, queued, or steering user-message turn when it actually starts.
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ filters: `--since`, `--persona`, `--provider`, `--model`.
 tau can run without the TUI via NDJSON RPC over stdin/stdout:
 
 ```sh
-tau rpc --persona gpt-5.5-coder --risk read-only
+
 ```
 
 RPC mode reuses the same startup config, persona loading, and risk handling as interactive mode. stdin/stdout are reserved for protocol traffic in this mode (piped stdin is **not** treated as an initial user message). `--caffeinated` is a macOS-only TUI flag and is rejected outside TUI mode.
@@ -94,7 +94,7 @@ for protocol details and examples, see [docs/rpc.md](docs/rpc.md).
 tau can host sessions over WebSocket:
 
 ```sh
-tau serve --host 0.0.0.0 --port 8787 --auth-token "$TAU_WS_AUTH_TOKEN" --risk read-only
+
 ```
 
 WebSocket auth tokens authorize full session access. Prefer `wss://` behind a trusted TLS proxy on untrusted networks, avoid putting tokens in URLs or shell history, and treat any proxy/access logs that capture headers, query strings, or WebSocket handshake details as sensitive.
@@ -127,16 +127,14 @@ tau attach --new --execution-kind fly-sprite --fly-api default --fly-sprite spri
 tau can also run the terminal UI against any command that speaks the same session protocol on stdin/stdout:
 
 ```sh
-tau attach -- ssh vps 'cd /path/to/repo && tau rpc --risk read-only'
+
 ```
 
 For stdio attach, use `--session <id>` before `--`:
 
 ```sh
-tau attach --session 0195d6e4-4cf9-7f44-a2d8-f8f7f49ee9d3 -- ssh vps 'cd /path/to/repo && tau rpc --risk read-only'
-```
 
-Session attach renders the authoritative session snapshot, streams recoverable `session.delta` updates and independently revisioned, non-persisted `session.pendingUserMessages` replacements, submits normal user input through `session.submit`, `session.queue`, and `session.steer`, supports steering/interruption, runs `!`/`!!` shell commands in the session execution environment, records `/listen` from the local microphone, speaks `/speak` locally, reloads session content with `/reload`, changes the session risk level with `/risk:<level>` or `Ctrl+R`, switches session personas with `/persona:<id>` or `Ctrl+P`, inserts session prompt templates with `/prompt:<id>`, compacts or prunes the session with `/compact:*` and `/prune:*`, creates a new session with `/new`, and exits with `/exit` or `Ctrl+C` twice.
+```
 
 ## Telegram runner
 
@@ -199,7 +197,7 @@ Add a single configured target to Tau config after deploying the Worker and crea
 }
 ```
 
-Template copies require a destination directory that already exists and is empty. The Worker validates Cloudflare Access JWTs against the Access JWKS with the configured issuer and audience. Tau sends service-token headers to Cloudflare Access for CLI/API calls, but the Worker does not treat those raw headers as authentication. When `nook` is configured, Tau automatically exposes a read-write model tool named `nook`. Detailed setup, deploy, template, Worker, browser SDK, and V0 scope notes live in [src/nook/README.md](src/nook/README.md).
+Template copies require a destination directory that already exists and is empty. The Worker validates Cloudflare Access JWTs against the Access JWKS with the configured issuer and audience. Tau sends service-token headers to Cloudflare Access for CLI/API calls, but the Worker does not treat those raw headers as authentication. When `nook` is configured, Tau automatically exposes a model tool named `nook`. Detailed setup, deploy, template, Worker, browser SDK, and V0 scope notes live in [src/nook/README.md](src/nook/README.md).
 
 ## SDK usage (Node)
 
@@ -258,13 +256,9 @@ this writes prompts and skills into `.tau/` under your current working directory
 
 ## security notice
 
-**the risk level system is a UX guardrail, not a hard security boundary.** it helps prevent accidental writes and guides model behavior, but it has significant limitations:
-
-- **model trust**: the bash tool relies on the model honestly declaring whether a command is a read or write. there's no runtime validation that the command actually matches the declared intent. a model could declare `safetyLevel="read"` while running `rm -rf /`.
 - **no command analysis**: the system doesn't inspect command content. it trusts the declared safety level without verifying what the command actually does.
 - **full system access**: the model can access any file on your system that your user account can read or write, not just the current working directory. if you need stronger isolation, run Tau inside a VM or container.
 - **no tty / non-interactive tools**: tool commands run with stdin ignored and no TTY. anything that prompts for input or opens an editor can hang or fail (for example `sudo`, `ssh` password prompts, `git` credential prompts). tau also forces git into non-interactive mode (no prompt/editor/pager, batch-mode ssh).
-- **user bypasses**: the `!` prefix executes shell commands directly and completely bypasses risk level checks. this is intentional for direct use, but means risk levels only constrain the model, not the user.
 
 note that there is no confirmation step before tool execution. the model runs commands immediately, and you can only observe the results after the fact.
 
@@ -305,7 +299,6 @@ available palette tokens (theme keys):
 - diff: `diffAdd`, `diffRemove`
 - toasts: `toastSuccess`, `toastWarn`, `toastError`
 - user: `userSurface`, `userMemorySurface`, `userMemoryText`
-- risk: `riskReadOnlyText`, `riskReadWriteText`
 
 example theme file (`.tau/themes/solarized.json`):
 
@@ -323,24 +316,7 @@ and in config (`.tau/config.json` or `~/.config/tau/config.json`):
 { "defaultTheme": "solarized" }
 ```
 
-## risk levels
-
-tau uses risk levels to control what the model can do. this lets you stay in control while working alongside AI.
-
-- **read-only** (default): model can run read-only tools (no file modifications)
-- **read-write**: model can create, edit, and delete files
-
-sub-agents inherit the session risk level unless overridden in persona config. a sub-agent configured with `riskLevel: read-write` can write even when the main session is `read-only`.
-
-start with a specific risk level (exact values: `read-only` or `read-write`):
-
-```sh
-tau --risk read-write
-```
-
-or change it during a session with `/risk:read-only` or `/risk:read-write`.
-
-the default is read-only because it lets the model investigate your code and answer questions without risk of unintended changes. bump it to read-write when you're ready to let the model make edits.
+Enabled tools execute directly; persona and sub-agent tool lists determine which tools are available.
 
 ## power management (macOS)
 
@@ -378,8 +354,6 @@ tau --persona opus-4.8-coder
 ## sub-agents
 
 some personas can run isolated sub-agents via the `spawn_agent`, `send_input_to_agent`, `wait_for_agents`, and `terminate_agent` tools. sub-agents report progress in the subagent panel, and `wait_for_agents` returns completed outputs as soon as at least one requested agent finishes.
-
-the built-in `default` sub-agent is available unless disabled. it inherits the main persona's model, settings, tool access (minus sub-agent management tools), risk level, and system prompt. the inherited main prompt is wrapped with default sub-agent-specific rules, and those wrapper rules take precedence on conflicts. custom sub-agents can override model, reasoning, tools, and risk level. a sub-agent configured with `riskLevel: read-write` can perform writes even when the main session is `read-only`.
 
 `spawn_agent` supports an optional launch override string (`model: "<provider>/<model>:<effort>"`) and an optional `workingDirectory`. when `workingDirectory` is set, the sub-agent runs from that directory and its prompt context (cwd, AGENTS.md scope, and skills block) is rebuilt as if tau was started there. launch overrides are allowlisted per subagent. custom subagents can define `launchModels` in persona frontmatter, and the built-in `default` sub-agent uses `subagents.defaultLaunchModels` from config.
 
@@ -469,8 +443,6 @@ tau supports slash commands for common actions:
 | `/persona:<id>` | switch to a different persona |
 | `/prompt:<id>` | insert a saved prompt template |
 | `/theme:<id>` | switch to a loaded theme |
-| `/risk:read-only` | allow read-only tool calls |
-| `/risk:read-write` | allow all tools |
 | `!<cmd>` | run a shell command directly (bypasses risk checks) |
 | `!!<cmd>` | run a shell command without adding output to the model context |
 
@@ -493,7 +465,6 @@ the prune commands drop bash tool results from the active context without summar
 | key          | action                                    |
 | ------------ | ----------------------------------------- |
 | `shift+tab`  | cycle reasoning effort                    |
-| `ctrl+r`     | cycle risk level                          |
 | `ctrl+p`     | cycle personality                         |
 | `ctrl+t`     | toggle thinking visibility                |
 | `ctrl+o`     | toggle compact tool display               |
@@ -526,7 +497,6 @@ model definitions can be extended and overridden through `~/.config/tau/models.j
     "mistral": "..."
   },
   "defaultPersona": "gpt-5.5-chat",
-  "defaultRisk": "read-write",
   "disableBuiltinPersonas": false,
   "disableBuiltinThemes": false,
   "defaultTheme": "solarized",
@@ -579,8 +549,6 @@ model definitions can be extended and overridden through `~/.config/tau/models.j
 for built-in providers and features, the `apiKeys` field uses these keys: `anthropic`, `openai`, `google`, `parallel`, and `mistral`. keys are merged across config levels by key name.
 
 the `defaultPersona` field specifies which persona to use when starting the app. it accepts `<id>` or `<id>:<reasoning>`, and matching is exact/case-sensitive. the `--persona` flag overrides this setting.
-
-the `defaultRisk` field sets the initial risk level (`read-only` or `read-write`). the `--risk` flag overrides this setting. if not specified, defaults to `read-only`.
 
 the `defaultTheme` field sets the theme id to load at startup. it must be non-empty, and matching is exact/case-sensitive. if not specified, it defaults to `gold`.
 
@@ -675,8 +643,6 @@ optional frontmatter fields:
 - `serviceTier`: `priority` or `flex` for providers that support service tiers (currently `openai` and `openai-codex`)
 - `allowedReasoningLevels`: list of reasoning levels shown in the ui
 - `skills`: list of enabled skill names (matched by `name` in skill frontmatter), or `"*"` to enable all discovered skills. if omitted, custom personas default to `"*"`. set `skills: []` to disable skills completely.
-- `tools`: optional list of persona-selected host tools. Nook is not selected here; when effective config contains `nook`, Tau exposes the `nook` tool automatically and gates every operation on read-write risk.
-- `subagents`: optional map of subagent definitions. the built-in `default` sub-agent is implicit unless `default: false` is provided. custom subagents must include `systemPrompt` and may include `description`, `provider`+`model`, `reasoning`, `serviceTier`, `tools`, `riskLevel`, and `launchModels` (when specifying a model, `provider` and `model` must be provided together). names must be lowercase with dashes (max 64 chars). `launchModels` entries must use `<provider>/<model>:<effort>` and are used to allowlist launch-time `spawn_agent` overrides. example:
   ```yaml
   subagents:
     default: false
@@ -688,12 +654,10 @@ optional frontmatter fields:
       model: claude-haiku-4-5
       reasoning: medium
       tools: [web_search, web_fetch, bash]
-      riskLevel: read-only
       launchModels:
         - openai/gpt-5.5:high
         - anthropic/claude-haiku-4-5:medium
   ```
-- `tools`: list of tool names to enable for this persona. allowed: `bash`, `write`, `edit`, `view_image`, `spawn_agent`, `send_input_to_agent`, `wait_for_agents`, `terminate_agent`. if omitted, defaults to `bash`, `write`, `edit`, `view_image` (and subagent tools when subagents are enabled). risk levels still apply.
 
 the markdown body becomes the system prompt.
 
@@ -744,8 +708,6 @@ enable skills per persona with the `skills` frontmatter field. you can list spec
 use `/reload` to pick up changes to personas, model overrides, prompts, skills, and AGENTS.md without restarting.
 
 ## how it works
-
-tau connects your terminal to large language models, giving them tools to interact with your filesystem. when you ask the model to explore code or make changes, it decides which tools to use and executes them subject to the active risk level.
 
 the model sees your messages, any file contents you've shared, and the results of tool calls. it doesn't have ambient access to your filesystem; it only sees what you show it or what it explicitly requests through tools.
 

--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ filters: `--since`, `--persona`, `--provider`, `--model`.
 tau can run without the TUI via NDJSON RPC over stdin/stdout:
 
 ```sh
-
+tau rpc --persona gpt-5.5-coder
 ```
 
-RPC mode reuses the same startup config, persona loading, and risk handling as interactive mode. stdin/stdout are reserved for protocol traffic in this mode (piped stdin is **not** treated as an initial user message). `--caffeinated` is a macOS-only TUI flag and is rejected outside TUI mode.
+RPC mode reuses the same startup config and persona loading as interactive mode. stdin/stdout are reserved for protocol traffic in this mode (piped stdin is **not** treated as an initial user message). `--caffeinated` is a macOS-only TUI flag and is rejected outside TUI mode.
 
 for protocol details and examples, see [docs/rpc.md](docs/rpc.md).
 
@@ -94,7 +94,7 @@ for protocol details and examples, see [docs/rpc.md](docs/rpc.md).
 tau can host sessions over WebSocket:
 
 ```sh
-
+tau serve --host 0.0.0.0 --port 8787 --auth-token "$TAU_WS_AUTH_TOKEN"
 ```
 
 WebSocket auth tokens authorize full session access. Prefer `wss://` behind a trusted TLS proxy on untrusted networks, avoid putting tokens in URLs or shell history, and treat any proxy/access logs that capture headers, query strings, or WebSocket handshake details as sensitive.
@@ -127,14 +127,16 @@ tau attach --new --execution-kind fly-sprite --fly-api default --fly-sprite spri
 tau can also run the terminal UI against any command that speaks the same session protocol on stdin/stdout:
 
 ```sh
-
+tau attach -- ssh vps 'cd /path/to/repo && tau rpc'
 ```
 
 For stdio attach, use `--session <id>` before `--`:
 
 ```sh
-
+tau attach --session 0195d6e4-4cf9-7f44-a2d8-f8f7f49ee9d3 -- ssh vps 'cd /path/to/repo && tau rpc'
 ```
+
+Session attach renders the authoritative session snapshot, streams recoverable `session.delta` updates and independently revisioned, non-persisted `session.pendingUserMessages` replacements, submits normal user input through `session.submit`, `session.queue`, and `session.steer`, supports steering/interruption, runs `!`/`!!` shell commands in the session execution environment, records `/listen` from the local microphone, speaks `/speak` locally, reloads session content with `/reload`, switches session personas with `/persona:<id>` or `Ctrl+P`, inserts session prompt templates with `/prompt:<id>`, compacts or prunes the session with `/compact:*` and `/prune:*`, creates a new session with `/new`, and exits with `/exit` or `Ctrl+C` twice.
 
 ## Telegram runner
 
@@ -256,7 +258,6 @@ this writes prompts and skills into `.tau/` under your current working directory
 
 ## security notice
 
-- **no command analysis**: the system doesn't inspect command content. it trusts the declared safety level without verifying what the command actually does.
 - **full system access**: the model can access any file on your system that your user account can read or write, not just the current working directory. if you need stronger isolation, run Tau inside a VM or container.
 - **no tty / non-interactive tools**: tool commands run with stdin ignored and no TTY. anything that prompts for input or opens an editor can hang or fail (for example `sudo`, `ssh` password prompts, `git` credential prompts). tau also forces git into non-interactive mode (no prompt/editor/pager, batch-mode ssh).
 
@@ -316,7 +317,9 @@ and in config (`.tau/config.json` or `~/.config/tau/config.json`):
 { "defaultTheme": "solarized" }
 ```
 
-Enabled tools execute directly; persona and sub-agent tool lists determine which tools are available.
+## tool access
+
+enabled tools execute directly. persona and sub-agent tool lists determine which tools are available.
 
 ## power management (macOS)
 
@@ -354,6 +357,8 @@ tau --persona opus-4.8-coder
 ## sub-agents
 
 some personas can run isolated sub-agents via the `spawn_agent`, `send_input_to_agent`, `wait_for_agents`, and `terminate_agent` tools. sub-agents report progress in the subagent panel, and `wait_for_agents` returns completed outputs as soon as at least one requested agent finishes.
+
+the built-in `default` sub-agent is available unless disabled. it inherits the main persona's model, settings, tool access (minus sub-agent management tools), and system prompt. the inherited main prompt is wrapped with default sub-agent-specific rules, and those wrapper rules take precedence on conflicts. custom sub-agents can override model, reasoning, and tools.
 
 `spawn_agent` supports an optional launch override string (`model: "<provider>/<model>:<effort>"`) and an optional `workingDirectory`. when `workingDirectory` is set, the sub-agent runs from that directory and its prompt context (cwd, AGENTS.md scope, and skills block) is rebuilt as if tau was started there. launch overrides are allowlisted per subagent. custom subagents can define `launchModels` in persona frontmatter, and the built-in `default` sub-agent uses `subagents.defaultLaunchModels` from config.
 
@@ -443,7 +448,7 @@ tau supports slash commands for common actions:
 | `/persona:<id>` | switch to a different persona |
 | `/prompt:<id>` | insert a saved prompt template |
 | `/theme:<id>` | switch to a loaded theme |
-| `!<cmd>` | run a shell command directly (bypasses risk checks) |
+| `!<cmd>` | run a shell command directly |
 | `!!<cmd>` | run a shell command without adding output to the model context |
 
 tau automatically compacts long sessions when provider-reported usage approaches the model context limit. automatic compaction summarizes older context, asks the compaction model to select original user messages to append verbatim inside the summary by history id, retains a recent tail verbatim, and inserts a hidden continuation note so the assistant continues without asking you to repeat context.
@@ -643,6 +648,8 @@ optional frontmatter fields:
 - `serviceTier`: `priority` or `flex` for providers that support service tiers (currently `openai` and `openai-codex`)
 - `allowedReasoningLevels`: list of reasoning levels shown in the ui
 - `skills`: list of enabled skill names (matched by `name` in skill frontmatter), or `"*"` to enable all discovered skills. if omitted, custom personas default to `"*"`. set `skills: []` to disable skills completely.
+- `tools`: optional list of persona-selected host tools. Nook is not selected here; when effective config contains `nook`, Tau exposes the `nook` tool automatically.
+- `subagents`: optional map of subagent definitions. the built-in `default` sub-agent is implicit unless `default: false` is provided. custom subagents must include `systemPrompt` and may include `description`, `provider`+`model`, `reasoning`, `serviceTier`, `tools`, and `launchModels` (when specifying a model, `provider` and `model` must be provided together). names must be lowercase with dashes (max 64 chars). `launchModels` entries must use `<provider>/<model>:<effort>` and are used to allowlist launch-time `spawn_agent` overrides. example:
   ```yaml
   subagents:
     default: false
@@ -658,6 +665,7 @@ optional frontmatter fields:
         - openai/gpt-5.5:high
         - anthropic/claude-haiku-4-5:medium
   ```
+- `tools`: list of tool names to enable for this persona. allowed: `bash`, `write`, `edit`, `view_image`, `spawn_agent`, `send_input_to_agent`, `wait_for_agents`, `terminate_agent`. if omitted, defaults to `bash`, `write`, `edit`, `view_image` (and subagent tools when subagents are enabled).
 
 the markdown body becomes the system prompt.
 
@@ -708,6 +716,8 @@ enable skills per persona with the `skills` frontmatter field. you can list spec
 use `/reload` to pick up changes to personas, model overrides, prompts, skills, and AGENTS.md without restarting.
 
 ## how it works
+
+tau connects your terminal to large language models, giving them tools to interact with your filesystem. when you ask the model to explore code or make changes, it decides which tools to use and executes them directly.
 
 the model sees your messages, any file contents you've shared, and the results of tool calls. it doesn't have ambient access to your filesystem; it only sees what you show it or what it explicitly requests through tools.
 

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -5,7 +5,7 @@ rpc mode runs tau without the interactive TUI. instead of rendering a terminal U
 the same session protocol can also be hosted over WebSocket:
 
 ```sh
-tau serve --host 0.0.0.0 --port 8787 --auth-token "$TAU_WS_AUTH_TOKEN" --risk read-only
+
 ```
 
 and observed from a local TUI:
@@ -17,13 +17,13 @@ tau attach --auth-token "$TAU_WS_AUTH_TOKEN" ws://vps:8787
 start it like this:
 
 ```sh
-tau rpc --persona gpt-5.5-coder --risk read-only
+
 ```
 
 The terminal UI can attach to any command that exposes this protocol over stdio:
 
 ```sh
-tau attach -- ssh vps 'cd /repo && tau rpc --risk read-only'
+
 ```
 
 Use `tau attach --session <id> -- <command...>` to attach the TUI to an existing stored session id.
@@ -31,8 +31,6 @@ Use `tau attach --session <id> -- <command...>` to attach the TUI to an existing
 Use `tau attach --session <id> ws://host:port` to attach the TUI to an existing stored session on a WebSocket server.
 
 Use `tau attach --new --cwd /path/to/repo ws://host:port` or `tau attach --new --cwd /path/to/repo -- <command...>` to create and attach a fresh hosted session in an already-provisioned host-local directory. Add `--execution-kind cloudflare-sandbox --cloudflare-bridge <id> --cloudflare-sandbox <sandboxId>` or `--execution-kind fly-sprite --fly-api <id> --fly-sprite <name>` to create sessions in those already-provisioned execution environments. Without `--session` or `--new`, attach asks the server for `session.list` and prompts for which session to open; choosing to create a session prompts for the execution environment.
-
-you can still use the usual startup flags (`--persona`, `--risk`, `--no-agent-context-files`, etc). `--persona` accepts `<id>` or `<id>:<reasoning>`. rpc and serve mode start without creating a session or selecting a project cwd; clients must call `session.list`, `session.observe`, or `session.create` with an execution environment. `session.create` resolves session-owned Tau config, model overlays, personas, prompt metadata, skills, project files, and AGENTS.md context from the selected execution environment cwd, then persists the resolved session bootstrap in the session snapshot. Prompt bodies and other large execution-environment content are loaded lazily when used. Component-owned config stays with the component that runs it: the attaching TUI uses local TUI config such as themes and speech settings, the host uses host config such as sandbox bridge credentials, and the execution environment owns session content/defaults. `--caffeinated` is TUI-only and rejected outside TUI mode.
 
 ## transport
 
@@ -102,7 +100,6 @@ when the rpc server starts, it immediately emits a `ready` line:
     "session.exec",
     "session.interrupt",
     "session.snapshot",
-    "session.setRisk",
     "session.setReasoning",
     "session.setPersona",
     "session.resolvePrompt",
@@ -200,7 +197,6 @@ params (required):
       "session.exec",
       "session.interrupt",
       "session.snapshot",
-      "session.setRisk",
       "session.setReasoning",
       "session.setPersona",
       "session.resolvePrompt",
@@ -307,7 +303,6 @@ Establishes observation for that session on this connection and returns the auth
     "costTotal": 0,
     "settings": {
       "personaId": "gpt-5.5-coder",
-      "riskLevel": "read-only",
       "reasoning": "medium"
     },
     "bootstrap": { "...": "model and prompt bootstrap metadata" },
@@ -569,7 +564,6 @@ returns current session state:
 - `sessionId`
 - `revision` (monotonic snapshot revision for this session id)
 - `lifecycle` (`"idle"` or `"running"`)
-- `settings` (current persona id, risk level, reasoning, and service tier)
 - `bootstrap` (selected model/provider metadata and prompt-composition metadata)
 - `catalog` (lightweight personas, prompt metadata, and skills available to observed clients)
 - `executionEnvironment` (where tools/files/commands execute)
@@ -583,18 +577,13 @@ derive transcript length from `messages.length`; the protocol does not duplicate
 
 User message text in `messages` is the raw recoverable Tau session text. It may start with Tau's internal metadata prefix, which is persisted for recovery but is never sent to the model or shown to users. After that metadata is removed, user text may start with one or more strict hidden model instruction blocks in the form `<system>...</system>\n`; these blocks are sent to the model as part of the user turn but should be hidden from user-facing renderers. Clients that render user messages should derive display text by removing Tau metadata and then removing only leading exact `<system>...</system>\n` blocks from user messages. Do not apply this display projection to assistant, tool, or protocol system messages.
 
-#### session.setRisk
-
 params (required):
 
 ```json
 {
-  "sessionId": "0195d6e4-4cf9-7f44-a2d8-f8f7f49ee9d3",
-  "riskLevel": "read-write"
+  "sessionId": "0195d6e4-4cf9-7f44-a2d8-f8f7f49ee9d3"
 }
 ```
-
-sets the session risk level to `"read-only"` or `"read-write"` and returns the authoritative updated session snapshot. The host applies the change through the session mutation queue so it does not race another mutating request or an active turn.
 
 #### session.setReasoning
 
@@ -748,12 +737,9 @@ params (required):
 {
   "sessionId": "0195d6e4-4cf9-7f44-a2d8-f8f7f49ee9d3",
   "instructions": "You are helping with a focused code review...",
-  "tools": ["bash", "view_image"],
-  "riskLevel": "read-only"
+  "tools": ["bash", "view_image"]
 }
 ```
-
-creates a host-owned ephemeral agent context outside the persisted session timeline. The context inherits the hosted session persona and execution environment, appends the provided instructions, uses the requested tool set and risk level, and returns `{ "contextId" }`. These contexts are not persisted in `session.snapshot` and are not recoverable after disconnect or host restart.
 
 #### session.ephemeral.submit
 
@@ -928,7 +914,6 @@ for lines that cannot produce a valid request id (for example malformed json), `
 `runRpcServer` handles incoming lines concurrently with explicit serialization for mutating transitions. this means:
 
 - multiple requests can be accepted before earlier ones complete
-- `session.record`, `session.setRisk`, `session.setReasoning`, `session.setPersona`, `session.reload`, `session.compact`, `session.prune`, `session.rewind`, `session.terminateSubagent`, `session.ephemeral.create`, and `session.ephemeral.close` run through a session-owned mutation queue (arrival order across clients observed to the same live session)
 - `session.setReasoning` updates settings immediately without interrupting an active turn; active turns keep their captured reasoning and the new setting applies to the next user-message turn
 - only one idle-only `session.submit`, `session.retry`, or `session.exec` can run at once (`busy` otherwise)
 - `session.queue` can be accepted during active work and runs after the active turn settles

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -5,7 +5,7 @@ rpc mode runs tau without the interactive TUI. instead of rendering a terminal U
 the same session protocol can also be hosted over WebSocket:
 
 ```sh
-
+tau serve --host 0.0.0.0 --port 8787 --auth-token "$TAU_WS_AUTH_TOKEN"
 ```
 
 and observed from a local TUI:
@@ -17,13 +17,13 @@ tau attach --auth-token "$TAU_WS_AUTH_TOKEN" ws://vps:8787
 start it like this:
 
 ```sh
-
+tau rpc --persona gpt-5.5-coder
 ```
 
 The terminal UI can attach to any command that exposes this protocol over stdio:
 
 ```sh
-
+tau attach -- ssh vps 'cd /repo && tau rpc'
 ```
 
 Use `tau attach --session <id> -- <command...>` to attach the TUI to an existing stored session id.
@@ -32,9 +32,11 @@ Use `tau attach --session <id> ws://host:port` to attach the TUI to an existing 
 
 Use `tau attach --new --cwd /path/to/repo ws://host:port` or `tau attach --new --cwd /path/to/repo -- <command...>` to create and attach a fresh hosted session in an already-provisioned host-local directory. Add `--execution-kind cloudflare-sandbox --cloudflare-bridge <id> --cloudflare-sandbox <sandboxId>` or `--execution-kind fly-sprite --fly-api <id> --fly-sprite <name>` to create sessions in those already-provisioned execution environments. Without `--session` or `--new`, attach asks the server for `session.list` and prompts for which session to open; choosing to create a session prompts for the execution environment.
 
+you can still use the usual startup flags (`--persona`, `--no-agent-context-files`, etc). `--persona` accepts `<id>` or `<id>:<reasoning>`. rpc and serve mode start without creating a session or selecting a project cwd; clients must call `session.list`, `session.observe`, or `session.create` with an execution environment. `session.create` resolves session-owned Tau config, model overlays, personas, prompt metadata, skills, project files, and AGENTS.md context from the selected execution environment cwd, then persists the resolved session bootstrap in the session snapshot. Prompt bodies and other large execution-environment content are loaded lazily when used. Component-owned config stays with the component that runs it: the attaching TUI uses local TUI config such as themes and speech settings, the host uses host config such as sandbox bridge credentials, and the execution environment owns session content/defaults. `--caffeinated` is TUI-only and rejected outside TUI mode.
+
 ## transport
 
-The session protocol has one semantic request/response/delta contract and multiple transports.
+The session protocol has one semantic request/response/delta contract and multiple transports. Object payloads accept and strip unknown fields while still validating known fields, required fields, discriminators, and method names.
 
 ### stdio
 
@@ -564,6 +566,7 @@ returns current session state:
 - `sessionId`
 - `revision` (monotonic snapshot revision for this session id)
 - `lifecycle` (`"idle"` or `"running"`)
+- `settings` (current persona id, reasoning, and service tier)
 - `bootstrap` (selected model/provider metadata and prompt-composition metadata)
 - `catalog` (lightweight personas, prompt metadata, and skills available to observed clients)
 - `executionEnvironment` (where tools/files/commands execute)
@@ -576,14 +579,6 @@ returns current session state:
 derive transcript length from `messages.length`; the protocol does not duplicate it. The first committed message is the effective system instruction message. Running state is derived from `lifecycle`, draft/interrupted messages, tools, agents, and operations; there is no `activeTurn` side object. If an assistant turn is interrupted mid-stream, the streamed content is retained as an `interrupted` assistant message and remains model-visible unless the host intentionally marks that record `modelVisible: false`.
 
 User message text in `messages` is the raw recoverable Tau session text. It may start with Tau's internal metadata prefix, which is persisted for recovery but is never sent to the model or shown to users. After that metadata is removed, user text may start with one or more strict hidden model instruction blocks in the form `<system>...</system>\n`; these blocks are sent to the model as part of the user turn but should be hidden from user-facing renderers. Clients that render user messages should derive display text by removing Tau metadata and then removing only leading exact `<system>...</system>\n` blocks from user messages. Do not apply this display projection to assistant, tool, or protocol system messages.
-
-params (required):
-
-```json
-{
-  "sessionId": "0195d6e4-4cf9-7f44-a2d8-f8f7f49ee9d3"
-}
-```
 
 #### session.setReasoning
 
@@ -740,6 +735,8 @@ params (required):
   "tools": ["bash", "view_image"]
 }
 ```
+
+creates a host-owned ephemeral agent context outside the persisted session timeline. The context inherits the hosted session persona and execution environment, appends the provided instructions, uses the requested tool set, and returns `{ "contextId" }`. These contexts are not persisted in `session.snapshot` and are not recoverable after disconnect or host restart.
 
 #### session.ephemeral.submit
 
@@ -914,6 +911,7 @@ for lines that cannot produce a valid request id (for example malformed json), `
 `runRpcServer` handles incoming lines concurrently with explicit serialization for mutating transitions. this means:
 
 - multiple requests can be accepted before earlier ones complete
+- `session.record`, `session.setReasoning`, `session.setPersona`, `session.reload`, `session.compact`, `session.prune`, `session.rewind`, `session.terminateSubagent`, `session.ephemeral.create`, and `session.ephemeral.close` run through a session-owned mutation queue (arrival order across clients observed to the same live session)
 - `session.setReasoning` updates settings immediately without interrupting an active turn; active turns keep their captured reasoning and the new setting applies to the next user-message turn
 - only one idle-only `session.submit`, `session.retry`, or `session.exec` can run at once (`busy` otherwise)
 - `session.queue` can be accepted during active work and runs after the active turn settles

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -4,7 +4,6 @@ tau ships a Node SDK at `@markusylisiurunen/tau/sdk`. by default it creates an i
 
 ```sh
 tau attach ws://vps:8787
-tau attach -- ssh vps 'cd /repo && tau rpc --risk read-only'
 ```
 
 ## install and import
@@ -28,7 +27,6 @@ import {
 
 const client = await createTauSdkClient({
   persona: "gpt-5.5-coder",
-  riskLevel: "read-only",
 });
 
 const session = await client.sessions.create({
@@ -95,8 +93,6 @@ sdk lifecycle notes:
   - default persona id and optional reasoning level for locally created in-process sessions
 - `reasoning?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max"`
   - explicit reasoning effort for locally created in-process sessions
-- `riskLevel?: "read-only" | "read-write"`
-  - default risk level for locally created in-process sessions
 - `noAgentContextFiles?: boolean`
   - disables AGENTS.md context discovery for locally created in-process sessions
 - `connectTimeoutMs?: number`
@@ -296,8 +292,6 @@ options:
 - `snapshot()`
   - sends `session.snapshot` with this session id
   - returns raw recoverable session user text; renderers should use `getTauUserDisplayText()` or `projectTauUserText()` to hide Tau metadata and leading exact `<system>...</system>\n` blocks from user messages before showing them to users
-- `setRiskLevel("read-only" | "read-write")`
-  - sends `session.setRisk` with this session id and resolves with the updated session snapshot
 - `setReasoning("none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max")`
   - sends `session.setReasoning` with this session id and resolves with `{ revision, settings }`
 - `setPersona(personaId)`
@@ -323,7 +317,6 @@ options:
 - `terminateSubagent(subagentId)`
   - sends `session.terminateSubagent` with this session id
   - resolves with `{ found: boolean }`
-- `createEphemeralContext({ instructions, tools, riskLevel })`
   - sends `session.ephemeral.create` with this session id
   - creates non-persisted host-owned agent context and returns `{ contextId }`
 - `submitEphemeralThread({ contextId, threadId, forkFromThreadId?, message })`

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -4,6 +4,7 @@ tau ships a Node SDK at `@markusylisiurunen/tau/sdk`. by default it creates an i
 
 ```sh
 tau attach ws://vps:8787
+tau attach -- ssh vps 'cd /repo && tau rpc'
 ```
 
 ## install and import
@@ -317,6 +318,7 @@ options:
 - `terminateSubagent(subagentId)`
   - sends `session.terminateSubagent` with this session id
   - resolves with `{ found: boolean }`
+- `createEphemeralContext({ instructions, tools })`
   - sends `session.ephemeral.create` with this session id
   - creates non-persisted host-owned agent context and returns `{ contextId }`
 - `submitEphemeralThread({ contextId, threadId, forkFromThreadId?, message })`

--- a/docs/session-event-protocol-redesign.md
+++ b/docs/session-event-protocol-redesign.md
@@ -137,13 +137,10 @@ type SessionSnapshot = {
 ```ts
 type SessionSettingsSnapshot = {
   personaId: string;
-  riskLevel: "read-only" | "read-write";
   reasoning?: ReasoningEffort;
   serviceTier?: "priority" | "flex";
 };
 ```
-
-The snapshot should store the current risk level, not both default and current risk. Defaults are only used when creating a session.
 
 `bootstrap` describes resolved runtime facts that clients need to understand the session: selected model/provider metadata and prompt-composition identifiers. Execution environment identity lives in the top-level `executionEnvironment` snapshot field. Bootstrap should not duplicate large prompt bodies or mutable per-turn settings that already live in `settings`.
 
@@ -382,7 +379,6 @@ type SessionChange =
 For broad rewrites, do not overfit patch changes:
 
 - `session.reload`: `snapshot.reset`
-- `session.setRisk`: `snapshot.reset`
 - `session.setReasoning`: `settings.set`
 - `session.setPersona`: `snapshot.reset`
 - `session.compact`: `snapshot.reset`
@@ -696,10 +692,9 @@ Known tool renderers can use typed facets. Unknown tools can still render name, 
 4. Tool UI payloads are stored as `SessionToolRun` updates and typed facets before they cross the protocol boundary.
 5. Notices are timeline notice records.
 6. Subagent UI events are stored as `agents` updates.
-7. `snapshot.reset` is used for reload, persona/risk changes, rewind, compact, and prune; reasoning changes use `settings.set`.
-8. Transports and SDK listeners expose `session.delta`; ephemeral agent progress uses `session.ephemeral`.
-9. TUI rendering is driven from snapshots and local delta application.
-10. Themes stay in TUI-local config/content loading rather than the session protocol.
-11. Wire-level `eventVersion`, `event`, `tool_ui`, and `session_update` semantics are removed from the session protocol.
+7. Transports and SDK listeners expose `session.delta`; ephemeral agent progress uses `session.ephemeral`.
+8. TUI rendering is driven from snapshots and local delta application.
+9. Themes stay in TUI-local config/content loading rather than the session protocol.
+10. Wire-level `eventVersion`, `event`, `tool_ui`, and `session_update` semantics are removed from the session protocol.
 
 This is a breaking protocol change, which is appropriate before v1. Avoid aliases or compatibility shims.

--- a/docs/session-event-protocol-redesign.md
+++ b/docs/session-event-protocol-redesign.md
@@ -692,9 +692,10 @@ Known tool renderers can use typed facets. Unknown tools can still render name, 
 4. Tool UI payloads are stored as `SessionToolRun` updates and typed facets before they cross the protocol boundary.
 5. Notices are timeline notice records.
 6. Subagent UI events are stored as `agents` updates.
-7. Transports and SDK listeners expose `session.delta`; ephemeral agent progress uses `session.ephemeral`.
-8. TUI rendering is driven from snapshots and local delta application.
-9. Themes stay in TUI-local config/content loading rather than the session protocol.
-10. Wire-level `eventVersion`, `event`, `tool_ui`, and `session_update` semantics are removed from the session protocol.
+7. `snapshot.reset` is used for reload, persona changes, rewind, compact, and prune; reasoning changes use `settings.set`.
+8. Transports and SDK listeners expose `session.delta`; ephemeral agent progress uses `session.ephemeral`.
+9. TUI rendering is driven from snapshots and local delta application.
+10. Themes stay in TUI-local config/content loading rather than the session protocol.
+11. Wire-level `eventVersion`, `event`, `tool_ui`, and `session_update` semantics are removed from the session protocol.
 
 This is a breaking protocol change, which is appropriate before v1. Avoid aliases or compatibility shims.

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -42,7 +42,6 @@ Telegram runner settings are loaded from the JSON file passed to `--config-file`
       "bootstrapCommands": ["npm ci"],
       "backgroundBootstrapCommands": ["npm run build"],
       "persona": "gpt-5.5-coder",
-      "riskLevel": "read-only",
       "noAgentContextFiles": false
     }
   }

--- a/scripts/generate-themes.js
+++ b/scripts/generate-themes.js
@@ -170,9 +170,6 @@ const generatePalette = (brandHue, appearance) => {
     userReviewText: toHex(userReviewText),
     userReviewTextMuted: toHex(userReviewTextMuted),
     userReviewTextDim: toHex(userReviewTextDim),
-
-    riskReadOnlyText: toHex(textMuted),
-    riskReadWriteText: toHex(textMuted),
   };
 };
 

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -1,18 +1,11 @@
 import { parsePersonaReference } from "./persona_reference.js";
-import {
-  type Persona,
-  REASONING_LEVELS,
-  type ReasoningEffort,
-  type RiskLevel,
-  RiskLevelSchema,
-} from "./types.js";
+import { type Persona, REASONING_LEVELS, type ReasoningEffort } from "./types.js";
 
 export type CliOptions = {
   help: boolean;
   debug: boolean;
   personaId?: string;
   reasoningOverride?: ReasoningEffort;
-  riskLevel?: RiskLevel;
   caffeinated: boolean;
   noAgentContextFiles: boolean;
 };
@@ -81,21 +74,6 @@ function parsePersonaOption(
   };
 }
 
-function parseRiskOption(raw: string): RiskLevel {
-  const normalized = raw.trim();
-  if (!normalized) {
-    throw new CliError("missing value for --risk");
-  }
-
-  const parsed = RiskLevelSchema.safeParse(normalized);
-  if (!parsed.success) {
-    const allowed = RiskLevelSchema.options.join(", ");
-    throw new CliError(`invalid risk level '${raw}'. allowed levels: ${allowed}`);
-  }
-
-  return parsed.data;
-}
-
 function parseValue(
   arg: string,
   argv: string[],
@@ -122,7 +100,6 @@ export function parseCliArgs(argv: string[], personas: Persona[]): CliOptions {
   let debug = false;
   let personaId: string | undefined;
   let reasoningOverride: ReasoningEffort | undefined;
-  let riskLevel: RiskLevel | undefined;
   let caffeinated = false;
   let noAgentContextFiles = false;
 
@@ -163,13 +140,6 @@ export function parseCliArgs(argv: string[], personas: Persona[]): CliOptions {
       continue;
     }
 
-    if (arg === "--risk" || arg === "-r" || arg.startsWith("--risk=") || arg.startsWith("-r=")) {
-      const parsed = parseValue(arg, argv, i);
-      riskLevel = parseRiskOption(parsed.value);
-      i = parsed.nextIndex;
-      continue;
-    }
-
     if (arg.startsWith("-")) {
       throw new CliError(`unknown option: ${arg}`);
     }
@@ -182,7 +152,6 @@ export function parseCliArgs(argv: string[], personas: Persona[]): CliOptions {
     debug,
     personaId,
     reasoningOverride,
-    riskLevel,
     caffeinated,
     noAgentContextFiles,
   };
@@ -191,7 +160,6 @@ export function parseCliArgs(argv: string[], personas: Persona[]): CliOptions {
 export function printHelp(personas: Persona[]): void {
   const personaList = personas.map((p) => p.id).join(", ");
   const reasoningList = REASONING_LEVELS.join(", ");
-  const riskList = RiskLevelSchema.options.join(", ");
 
   console.log(
     [
@@ -217,8 +185,6 @@ export function printHelp(personas: Persona[]): void {
       `  --persona, -p <id>[:<level>]  start with a persona. available: ${personaList}.`,
       `                                optionally specify reasoning level. levels: ${reasoningList}.`,
       `                                if not specified, uses resolved config defaultPersona.`,
-      `  --risk, -r <level>            set initial model risk level. levels: ${riskList}.`,
-      `                                if not specified, uses resolved config defaultRisk (default: read-only).`,
       "  --caffeinated                 keep macOS awake during active assistant turns in TUI mode (no-op on Linux).",
       "  --no-agent-context-files      disable AGENTS.md injection into the system prompt.",
       "",
@@ -237,12 +203,8 @@ export function printHelp(personas: Persona[]): void {
       "examples:",
       "  tau --persona gpt-5.4-chat:high",
       "  tau -p opus-4.8-coder",
-      "  tau --persona gpt-5.4-chat:medium --risk read-write",
-      "  tau -p gpt-5.4-coder:high -r read-write",
-      "  tau serve --host 0.0.0.0 --port 8787 --risk read-only",
       "  tau attach --new --cwd /repo ws://127.0.0.1:8787",
       "  tau attach ws://127.0.0.1:8787",
-      "  tau attach --new --cwd /repo -- ssh vps 'tau rpc --risk read-only'",
       "",
       "notes:",
       "  use `tau auth login codex` to authenticate ChatGPT subscription credentials.",
@@ -254,7 +216,6 @@ export function printHelp(personas: Persona[]): void {
       "  /diff opens the local diff review tool and delegates review work to the session host.",
       "  you can switch persona during a session with /persona:<id>.",
       "  insert prompt templates with /prompt:<id>.",
-      "  you can change model risk level during a session with /risk:read-only or /risk:read-write.",
       "  if stdin is piped, its contents are sent as the first message automatically in TUI mode.",
       "  in RPC mode, stdin/stdout are reserved for protocol traffic.",
       "  reasoning only affects providers that support it.",

--- a/src/core/commands/index.ts
+++ b/src/core/commands/index.ts
@@ -9,6 +9,4 @@ export type {
 export {
   CommandRegistry,
   createCommandRegistry,
-  getRiskLevelAutocompleteOptions,
-  getRiskLevelDescription,
 } from "./registry.js";

--- a/src/core/commands/registry.ts
+++ b/src/core/commands/registry.ts
@@ -1,5 +1,5 @@
 import { dirname } from "node:path";
-import { type RiskLevel, RiskLevelSchema, type Skill } from "../types.js";
+import type { Skill } from "../types.js";
 import { formatPathForDisplay } from "../utils/format.js";
 
 export type Command = (
@@ -18,7 +18,6 @@ export type Command = (
   | { type: "reload" }
   | { type: "listen" }
   | { type: "speak" }
-  | { type: "risk"; level: RiskLevel }
   | { type: "persona"; id: string }
   | { type: "prompt"; id: string }
   | { type: "theme"; id: string }
@@ -26,8 +25,8 @@ export type Command = (
 ) & { extra?: string };
 
 export type CommandId = Command["type"];
-export type CommandArgument = "none" | "risk" | "persona" | "prompt" | "theme";
-export type CommandSection = "base" | "risk" | "trailing";
+export type CommandArgument = "none" | "persona" | "prompt" | "theme";
+export type CommandSection = "base" | "trailing";
 
 export interface CommandInfo {
   id: CommandId;
@@ -61,7 +60,6 @@ export interface CommandDispatchContext {
   reload: () => Promise<void>;
   listen: () => Promise<void> | void;
   speak: () => Promise<void> | void;
-  risk: (level: RiskLevel) => void;
   persona: (id: string) => void;
   prompt: (id: string) => void;
   theme: (id: string) => void;
@@ -71,33 +69,8 @@ export interface CommandDispatchContext {
 export interface HelpTextOptions {
   agentsFiles?: string[];
   skills?: Skill[];
-  riskLevels?: RiskLevel[];
   themes?: string[];
   formatPath?: (path: string) => string;
-}
-
-const DEFAULT_RISK_LEVELS: RiskLevel[] = ["read-only", "read-write"];
-const RISK_LEVEL_HELP_DESCRIPTIONS: Record<RiskLevel, string> = {
-  "read-only": "allow read-only tool calls",
-  "read-write": "allow all tools",
-};
-
-export function getRiskLevelDescription(level: RiskLevel): string {
-  switch (level) {
-    case "read-only":
-      return "read-only tools";
-    case "read-write":
-      return "all tools";
-  }
-}
-
-export function getRiskLevelAutocompleteOptions(
-  allowed: RiskLevel[],
-): Array<{ id: RiskLevel; description: string }> {
-  return allowed.map((level) => ({
-    id: level,
-    description: RISK_LEVEL_HELP_DESCRIPTIONS[level],
-  }));
 }
 
 function formatSkillPath(fullPath: string, formatPath: (path: string) => string): string {
@@ -151,7 +124,7 @@ export class CommandRegistry<Ctx = unknown> {
 
   buildHelpText(options: HelpTextOptions = {}): string {
     const lines: string[] = [];
-    const { agentsFiles, skills, riskLevels, themes } = options;
+    const { agentsFiles, skills, themes } = options;
     const formatPath = options.formatPath ?? formatPathForDisplay;
 
     if (agentsFiles && agentsFiles.length > 0) {
@@ -177,20 +150,11 @@ export class CommandRegistry<Ctx = unknown> {
     const commands = this.list().filter((command) => command.argument !== "theme" || hasThemes);
     const baseCommands = commands.filter((command) => command.section === "base");
     const trailingCommands = commands.filter((command) => command.section === "trailing");
-    const riskCommand = commands.find((command) => command.section === "risk");
 
     const commandEntries: Array<[string, string]> = [];
     baseCommands.forEach((command) => {
       commandEntries.push([command.usage, command.description]);
     });
-
-    if (riskCommand) {
-      const allowed = riskLevels ?? DEFAULT_RISK_LEVELS;
-      allowed.forEach((level) => {
-        const description = RISK_LEVEL_HELP_DESCRIPTIONS[level];
-        commandEntries.push([`/risk:${level}`, description]);
-      });
-    }
 
     trailingCommands.forEach((command) => {
       commandEntries.push([command.usage, command.description]);
@@ -198,7 +162,6 @@ export class CommandRegistry<Ctx = unknown> {
 
     const keyEntries: Array<[string, string]> = [
       ["shift+tab", "cycle reasoning effort"],
-      ["ctrl+r", "cycle risk level"],
       ["ctrl+p", "cycle personality"],
       ["ctrl+t", "toggle thoughts visibility"],
       ["ctrl+o", "toggle compact tool UI"],
@@ -455,23 +418,6 @@ export function createCommandRegistry(): CommandRegistry<CommandDispatchContext>
       return { type: "copyCode", extra };
     },
     run: (ctx) => ctx.copyCode(),
-  });
-
-  registry.register({
-    id: "risk",
-    usage: "/risk:<level>",
-    description: "set risk level",
-    argument: "risk",
-    section: "risk",
-    parse: (raw) => {
-      const { command, extra } = splitCommandInput(raw);
-      const match = command.match(/^\/risk:(read-only|read-write)$/i);
-      if (!match) return null;
-      const parsed = RiskLevelSchema.safeParse(match[1]?.toLowerCase());
-      if (!parsed.success) return null;
-      return { type: "risk", level: parsed.data, extra };
-    },
-    run: (ctx, command) => ctx.risk(command.level),
   });
 
   registry.register({

--- a/src/core/commands/registry.ts
+++ b/src/core/commands/registry.ts
@@ -26,7 +26,6 @@ export type Command = (
 
 export type CommandId = Command["type"];
 export type CommandArgument = "none" | "persona" | "prompt" | "theme";
-export type CommandSection = "base" | "trailing";
 
 export interface CommandInfo {
   id: CommandId;
@@ -34,7 +33,6 @@ export interface CommandInfo {
   description: string;
   autocompleteDescription?: string;
   argument: CommandArgument;
-  section: CommandSection;
 }
 
 interface CommandDefinition<Ctx, T extends Command = Command> extends CommandInfo {
@@ -148,17 +146,10 @@ export class CommandRegistry<Ctx = unknown> {
 
     const hasThemes = (themes?.length ?? 0) > 0;
     const commands = this.list().filter((command) => command.argument !== "theme" || hasThemes);
-    const baseCommands = commands.filter((command) => command.section === "base");
-    const trailingCommands = commands.filter((command) => command.section === "trailing");
-
-    const commandEntries: Array<[string, string]> = [];
-    baseCommands.forEach((command) => {
-      commandEntries.push([command.usage, command.description]);
-    });
-
-    trailingCommands.forEach((command) => {
-      commandEntries.push([command.usage, command.description]);
-    });
+    const commandEntries = commands.map((command): [string, string] => [
+      command.usage,
+      command.description,
+    ]);
 
     const keyEntries: Array<[string, string]> = [
       ["shift+tab", "cycle reasoning effort"],
@@ -199,7 +190,6 @@ export function createCommandRegistry(): CommandRegistry<CommandDispatchContext>
     description: "show this help",
     autocompleteDescription: "show help",
     argument: "none",
-    section: "base",
     parse: (raw) => {
       const { command, extra } = splitCommandInput(raw);
       if (command !== "/help") return null;
@@ -214,7 +204,6 @@ export function createCommandRegistry(): CommandRegistry<CommandDispatchContext>
     description: "exit tau",
     autocompleteDescription: "exit tau",
     argument: "none",
-    section: "base",
     allowDuringStreaming: true,
     parse: (raw) => {
       const { command, extra } = splitCommandInput(raw);
@@ -230,7 +219,6 @@ export function createCommandRegistry(): CommandRegistry<CommandDispatchContext>
     description: "new session",
     autocompleteDescription: "new session",
     argument: "none",
-    section: "base",
     parse: (raw) => {
       const { command, extra } = splitCommandInput(raw);
       if (command !== "/new") return null;
@@ -245,7 +233,6 @@ export function createCommandRegistry(): CommandRegistry<CommandDispatchContext>
     description: "rewind context to an earlier user message",
     autocompleteDescription: "rewind context to a selected user message",
     argument: "none",
-    section: "base",
     parse: (raw) => {
       const { command, extra } = splitCommandInput(raw);
       if (command !== "/rewind") return null;
@@ -260,7 +247,6 @@ export function createCommandRegistry(): CommandRegistry<CommandDispatchContext>
     description: "open the local diff review tool for the session diff",
     autocompleteDescription: "open diff review for git diff args",
     argument: "none",
-    section: "base",
     parse: (raw) => {
       const { command, extra } = splitCommandInput(raw);
       if (command !== "/diff") return null;
@@ -275,7 +261,6 @@ export function createCommandRegistry(): CommandRegistry<CommandDispatchContext>
     description: "summarize and start new session",
     autocompleteDescription: "compact history to a summary",
     argument: "none",
-    section: "base",
     parse: (raw) => {
       const { command, extra } = splitCommandInput(raw);
       if (command !== "/compact:summary-only") return null;
@@ -290,7 +275,6 @@ export function createCommandRegistry(): CommandRegistry<CommandDispatchContext>
     description: "summarize and include previous last assistant message",
     autocompleteDescription: "compact history, keep last assistant message",
     argument: "none",
-    section: "base",
     parse: (raw) => {
       const { command, extra } = splitCommandInput(raw);
       if (command !== "/compact:summary-and-last") return null;
@@ -305,7 +289,6 @@ export function createCommandRegistry(): CommandRegistry<CommandDispatchContext>
     description: "prune earliest tool results from context",
     autocompleteDescription: "prune earliest tool results",
     argument: "none",
-    section: "base",
     parse: (raw) => {
       const { command, extra } = splitCommandInput(raw);
       if (command !== "/prune:earliest") return null;
@@ -320,7 +303,6 @@ export function createCommandRegistry(): CommandRegistry<CommandDispatchContext>
     description: "prune largest tool results from context",
     autocompleteDescription: "prune largest tool results",
     argument: "none",
-    section: "base",
     parse: (raw) => {
       const { command, extra } = splitCommandInput(raw);
       if (command !== "/prune:largest") return null;
@@ -335,7 +317,6 @@ export function createCommandRegistry(): CommandRegistry<CommandDispatchContext>
     description: "prune tool results using model selection",
     autocompleteDescription: "prune tool results with model selection",
     argument: "none",
-    section: "base",
     parse: (raw) => {
       const { command, extra } = splitCommandInput(raw);
       if (command !== "/prune:smart") return null;
@@ -350,7 +331,6 @@ export function createCommandRegistry(): CommandRegistry<CommandDispatchContext>
     description: "reload prompts, skills, themes, and AGENTS.md",
     autocompleteDescription: "reload prompts, skills, themes, and AGENTS.md",
     argument: "none",
-    section: "base",
     parse: (raw) => {
       const { command, extra } = splitCommandInput(raw);
       if (command !== "/reload") return null;
@@ -365,7 +345,6 @@ export function createCommandRegistry(): CommandRegistry<CommandDispatchContext>
     description: "start voice recording and transcription",
     autocompleteDescription: "start voice recording",
     argument: "none",
-    section: "base",
     allowDuringStreaming: true,
     parse: (raw) => {
       const { command, extra } = splitCommandInput(raw);
@@ -381,7 +360,6 @@ export function createCommandRegistry(): CommandRegistry<CommandDispatchContext>
     description: "speak the last assistant message aloud",
     autocompleteDescription: "speak the last assistant message",
     argument: "none",
-    section: "base",
     parse: (raw) => {
       const { command, extra } = splitCommandInput(raw);
       if (command !== "/speak") return null;
@@ -396,7 +374,6 @@ export function createCommandRegistry(): CommandRegistry<CommandDispatchContext>
     description: "copy last assistant message",
     autocompleteDescription: "copy last assistant message",
     argument: "none",
-    section: "base",
     parse: (raw) => {
       const { command, extra } = splitCommandInput(raw);
       if (command !== "/copy:text") return null;
@@ -411,7 +388,6 @@ export function createCommandRegistry(): CommandRegistry<CommandDispatchContext>
     description: "copy code blocks from last assistant message",
     autocompleteDescription: "copy code blocks from last assistant message",
     argument: "none",
-    section: "base",
     parse: (raw) => {
       const { command, extra } = splitCommandInput(raw);
       if (command !== "/copy:code") return null;
@@ -425,7 +401,6 @@ export function createCommandRegistry(): CommandRegistry<CommandDispatchContext>
     usage: "/persona:<id>",
     description: "switch persona",
     argument: "persona",
-    section: "trailing",
     parse: (raw) => {
       const { command, extra } = splitCommandInput(raw);
       const match = command.match(/^\/persona:(.+)$/i);
@@ -441,7 +416,6 @@ export function createCommandRegistry(): CommandRegistry<CommandDispatchContext>
     usage: "/prompt:<id>",
     description: "insert prompt template",
     argument: "prompt",
-    section: "trailing",
     allowDuringStreaming: true,
     parse: (raw) => {
       const { command, extra } = splitCommandInput(raw);
@@ -458,7 +432,6 @@ export function createCommandRegistry(): CommandRegistry<CommandDispatchContext>
     usage: "/theme:<id>",
     description: "switch theme",
     argument: "theme",
-    section: "trailing",
     parse: (raw) => {
       const { command, extra } = splitCommandInput(raw);
       const match = command.match(/^\/theme:(.+)$/i);
@@ -474,7 +447,6 @@ export function createCommandRegistry(): CommandRegistry<CommandDispatchContext>
     usage: "",
     description: "",
     argument: "none",
-    section: "base",
     hidden: true,
     parse: () => null,
     run: (ctx, command) => ctx.unknown(command.raw),

--- a/src/core/config/builtin_themes.ts
+++ b/src/core/config/builtin_themes.ts
@@ -37,8 +37,6 @@ export const PALETTE_TOKEN_NAMES = [
   "userReviewText",
   "userReviewTextMuted",
   "userReviewTextDim",
-  "riskReadOnlyText",
-  "riskReadWriteText",
 ] as const;
 
 export const builtinThemes: ThemeDefinition[] = [
@@ -81,8 +79,6 @@ export const builtinThemes: ThemeDefinition[] = [
       userReviewText: "#bad0aa",
       userReviewTextMuted: "#9da498",
       userReviewTextDim: "#7b7e79",
-      riskReadOnlyText: "#928a8c",
-      riskReadWriteText: "#928a8c",
     },
     variants: {
       light: {
@@ -122,8 +118,6 @@ export const builtinThemes: ThemeDefinition[] = [
         userReviewText: "#183400",
         userReviewTextMuted: "#424f38",
         userReviewTextDim: "#686e64",
-        riskReadOnlyText: "#7f7074",
-        riskReadWriteText: "#7f7074",
       },
     },
     sourcePath: "builtin:themes/crimson.json",
@@ -168,8 +162,6 @@ export const builtinThemes: ThemeDefinition[] = [
       userReviewText: "#bad0aa",
       userReviewTextMuted: "#9da498",
       userReviewTextDim: "#7b7e79",
-      riskReadOnlyText: "#928a89",
-      riskReadWriteText: "#928a89",
     },
     variants: {
       light: {
@@ -209,8 +201,6 @@ export const builtinThemes: ThemeDefinition[] = [
         userReviewText: "#183400",
         userReviewTextMuted: "#424f38",
         userReviewTextDim: "#686e64",
-        riskReadOnlyText: "#80706f",
-        riskReadWriteText: "#80706f",
       },
     },
     sourcePath: "builtin:themes/ember.json",
@@ -255,8 +245,6 @@ export const builtinThemes: ThemeDefinition[] = [
       userReviewText: "#bad0aa",
       userReviewTextMuted: "#9da498",
       userReviewTextDim: "#7b7e79",
-      riskReadOnlyText: "#928a87",
-      riskReadWriteText: "#928a87",
     },
     variants: {
       light: {
@@ -296,8 +284,6 @@ export const builtinThemes: ThemeDefinition[] = [
         userReviewText: "#183400",
         userReviewTextMuted: "#424f38",
         userReviewTextDim: "#686e64",
-        riskReadOnlyText: "#7f716a",
-        riskReadWriteText: "#7f716a",
       },
     },
     sourcePath: "builtin:themes/gold.json",
@@ -342,8 +328,6 @@ export const builtinThemes: ThemeDefinition[] = [
       userReviewText: "#bad0aa",
       userReviewTextMuted: "#9da498",
       userReviewTextDim: "#7b7e79",
-      riskReadOnlyText: "#908b86",
-      riskReadWriteText: "#908b86",
     },
     variants: {
       light: {
@@ -383,8 +367,6 @@ export const builtinThemes: ThemeDefinition[] = [
         userReviewText: "#183400",
         userReviewTextMuted: "#424f38",
         userReviewTextDim: "#686e64",
-        riskReadOnlyText: "#7c7368",
-        riskReadWriteText: "#7c7368",
       },
     },
     sourcePath: "builtin:themes/lime.json",
@@ -429,8 +411,6 @@ export const builtinThemes: ThemeDefinition[] = [
       userReviewText: "#bad0aa",
       userReviewTextMuted: "#9da498",
       userReviewTextDim: "#7b7e79",
-      riskReadOnlyText: "#8e8c85",
-      riskReadWriteText: "#8e8c85",
     },
     variants: {
       light: {
@@ -470,8 +450,6 @@ export const builtinThemes: ThemeDefinition[] = [
         userReviewText: "#183400",
         userReviewTextMuted: "#424f38",
         userReviewTextDim: "#686e64",
-        riskReadOnlyText: "#787568",
-        riskReadWriteText: "#787568",
       },
     },
     sourcePath: "builtin:themes/grass.json",
@@ -516,8 +494,6 @@ export const builtinThemes: ThemeDefinition[] = [
       userReviewText: "#bad0aa",
       userReviewTextMuted: "#9da498",
       userReviewTextDim: "#7b7e79",
-      riskReadOnlyText: "#8b8d86",
-      riskReadWriteText: "#8b8d86",
     },
     variants: {
       light: {
@@ -557,8 +533,6 @@ export const builtinThemes: ThemeDefinition[] = [
         userReviewText: "#183400",
         userReviewTextMuted: "#424f38",
         userReviewTextDim: "#686e64",
-        riskReadOnlyText: "#737669",
-        riskReadWriteText: "#737669",
       },
     },
     sourcePath: "builtin:themes/emerald.json",
@@ -603,8 +577,6 @@ export const builtinThemes: ThemeDefinition[] = [
       userReviewText: "#bad0aa",
       userReviewTextMuted: "#9da498",
       userReviewTextDim: "#7b7e79",
-      riskReadOnlyText: "#898e88",
-      riskReadWriteText: "#898e88",
     },
     variants: {
       light: {
@@ -644,8 +616,6 @@ export const builtinThemes: ThemeDefinition[] = [
         userReviewText: "#183400",
         userReviewTextMuted: "#424f38",
         userReviewTextDim: "#686e64",
-        riskReadOnlyText: "#6e786d",
-        riskReadWriteText: "#6e786d",
       },
     },
     sourcePath: "builtin:themes/jade.json",
@@ -690,8 +660,6 @@ export const builtinThemes: ThemeDefinition[] = [
       userReviewText: "#bad0aa",
       userReviewTextMuted: "#9da498",
       userReviewTextDim: "#7b7e79",
-      riskReadOnlyText: "#878e8b",
-      riskReadWriteText: "#878e8b",
     },
     variants: {
       light: {
@@ -731,8 +699,6 @@ export const builtinThemes: ThemeDefinition[] = [
         userReviewText: "#183400",
         userReviewTextMuted: "#424f38",
         userReviewTextDim: "#686e64",
-        riskReadOnlyText: "#6a7872",
-        riskReadWriteText: "#6a7872",
       },
     },
     sourcePath: "builtin:themes/teal.json",
@@ -777,8 +743,6 @@ export const builtinThemes: ThemeDefinition[] = [
       userReviewText: "#bad0aa",
       userReviewTextMuted: "#9da498",
       userReviewTextDim: "#7b7e79",
-      riskReadOnlyText: "#868e8e",
-      riskReadWriteText: "#868e8e",
     },
     variants: {
       light: {
@@ -818,8 +782,6 @@ export const builtinThemes: ThemeDefinition[] = [
         userReviewText: "#183400",
         userReviewTextMuted: "#424f38",
         userReviewTextDim: "#686e64",
-        riskReadOnlyText: "#687877",
-        riskReadWriteText: "#687877",
       },
     },
     sourcePath: "builtin:themes/cyan.json",
@@ -864,8 +826,6 @@ export const builtinThemes: ThemeDefinition[] = [
       userReviewText: "#bad0aa",
       userReviewTextMuted: "#9da498",
       userReviewTextDim: "#7b7e79",
-      riskReadOnlyText: "#868e90",
-      riskReadWriteText: "#868e90",
     },
     variants: {
       light: {
@@ -905,8 +865,6 @@ export const builtinThemes: ThemeDefinition[] = [
         userReviewText: "#183400",
         userReviewTextMuted: "#424f38",
         userReviewTextDim: "#686e64",
-        riskReadOnlyText: "#68787c",
-        riskReadWriteText: "#68787c",
       },
     },
     sourcePath: "builtin:themes/azure.json",
@@ -951,8 +909,6 @@ export const builtinThemes: ThemeDefinition[] = [
       userReviewText: "#bad0aa",
       userReviewTextMuted: "#9da498",
       userReviewTextDim: "#7b7e79",
-      riskReadOnlyText: "#878d92",
-      riskReadWriteText: "#878d92",
     },
     variants: {
       light: {
@@ -992,8 +948,6 @@ export const builtinThemes: ThemeDefinition[] = [
         userReviewText: "#183400",
         userReviewTextMuted: "#424f38",
         userReviewTextDim: "#686e64",
-        riskReadOnlyText: "#6a767f",
-        riskReadWriteText: "#6a767f",
       },
     },
     sourcePath: "builtin:themes/cobalt.json",
@@ -1038,8 +992,6 @@ export const builtinThemes: ThemeDefinition[] = [
       userReviewText: "#bad0aa",
       userReviewTextMuted: "#9da498",
       userReviewTextDim: "#7b7e79",
-      riskReadOnlyText: "#898c92",
-      riskReadWriteText: "#898c92",
     },
     variants: {
       light: {
@@ -1079,8 +1031,6 @@ export const builtinThemes: ThemeDefinition[] = [
         userReviewText: "#183400",
         userReviewTextMuted: "#424f38",
         userReviewTextDim: "#686e64",
-        riskReadOnlyText: "#6e7581",
-        riskReadWriteText: "#6e7581",
       },
     },
     sourcePath: "builtin:themes/violet.json",
@@ -1125,8 +1075,6 @@ export const builtinThemes: ThemeDefinition[] = [
       userReviewText: "#bad0aa",
       userReviewTextMuted: "#9da498",
       userReviewTextDim: "#7b7e79",
-      riskReadOnlyText: "#8c8b92",
-      riskReadWriteText: "#8c8b92",
     },
     variants: {
       light: {
@@ -1166,8 +1114,6 @@ export const builtinThemes: ThemeDefinition[] = [
         userReviewText: "#183400",
         userReviewTextMuted: "#424f38",
         userReviewTextDim: "#686e64",
-        riskReadOnlyText: "#737380",
-        riskReadWriteText: "#737380",
       },
     },
     sourcePath: "builtin:themes/purple.json",
@@ -1212,8 +1158,6 @@ export const builtinThemes: ThemeDefinition[] = [
       userReviewText: "#bad0aa",
       userReviewTextMuted: "#9da498",
       userReviewTextDim: "#7b7e79",
-      riskReadOnlyText: "#8e8a91",
-      riskReadWriteText: "#8e8a91",
     },
     variants: {
       light: {
@@ -1253,8 +1197,6 @@ export const builtinThemes: ThemeDefinition[] = [
         userReviewText: "#183400",
         userReviewTextMuted: "#424f38",
         userReviewTextDim: "#686e64",
-        riskReadOnlyText: "#78717d",
-        riskReadWriteText: "#78717d",
       },
     },
     sourcePath: "builtin:themes/magenta.json",
@@ -1299,8 +1241,6 @@ export const builtinThemes: ThemeDefinition[] = [
       userReviewText: "#bad0aa",
       userReviewTextMuted: "#9da498",
       userReviewTextDim: "#7b7e79",
-      riskReadOnlyText: "#908a8e",
-      riskReadWriteText: "#908a8e",
     },
     variants: {
       light: {
@@ -1340,8 +1280,6 @@ export const builtinThemes: ThemeDefinition[] = [
         userReviewText: "#183400",
         userReviewTextMuted: "#424f38",
         userReviewTextDim: "#686e64",
-        riskReadOnlyText: "#7c7079",
-        riskReadWriteText: "#7c7079",
       },
     },
     sourcePath: "builtin:themes/rose.json",

--- a/src/core/config/content_loader.ts
+++ b/src/core/config/content_loader.ts
@@ -21,7 +21,7 @@ import {
   type ToolName,
 } from "../tools/tool_names.js";
 import type { Persona, Skill } from "../types.js";
-import { ReasoningEffortSchema, RiskLevelSchema, ServiceTierSchema } from "../types.js";
+import { ReasoningEffortSchema, ServiceTierSchema } from "../types.js";
 import { formatZodError } from "../utils/zod.js";
 import type { ConfigDeps } from "./deps.js";
 import { parseMarkdownFrontMatter } from "./markdown_frontmatter.js";
@@ -77,12 +77,11 @@ const SubagentSpecSchema = z
     reasoning: ReasoningEffortSchema.optional(),
     serviceTier: ServiceTierSchema.optional(),
     tools: z.array(z.string()).optional(),
-    riskLevel: RiskLevelSchema.optional(),
     launchModels: z.array(z.string()).optional(),
     systemPrompt: z.string().trim().min(1).optional(),
     description: z.string().trim().min(1).optional(),
   })
-  .passthrough()
+  .strip()
   .superRefine((spec, ctx) => {
     const hasProvider = spec.provider !== undefined;
     const hasModel = spec.model !== undefined;
@@ -233,7 +232,6 @@ function parseSubagentConfig(
     }
     const tools = toolsResult.tools;
     const launchModels = launchModelsResult.launchModels;
-    const riskLevel = specRaw.riskLevel;
     const settings =
       specRaw.reasoning !== undefined || specRaw.serviceTier !== undefined
         ? {
@@ -258,7 +256,6 @@ function parseSubagentConfig(
       ...(modelObj ? { model: modelObj } : {}),
       ...(settings ? { settings } : {}),
       ...(tools !== undefined ? { tools } : {}),
-      ...(riskLevel ? { riskLevel } : {}),
       ...(launchModels !== undefined ? { launchModels } : {}),
     };
 
@@ -495,7 +492,7 @@ const personaFrontMatterSchema = z
     subagents: z.unknown().optional(),
     tools: z.unknown().optional(),
   })
-  .passthrough();
+  .strip();
 
 const skillsSchema = z.union([z.literal("*"), z.array(z.string())]);
 
@@ -505,7 +502,7 @@ const promptFrontMatterSchema = z
     label: z.string().trim().optional(),
     description: z.string().trim().optional(),
   })
-  .passthrough();
+  .strip();
 
 const PERSONA_TOOL_NAMES = [
   TOOL_NAME_BASH,

--- a/src/core/config/diff_tool.ts
+++ b/src/core/config/diff_tool.ts
@@ -14,7 +14,7 @@ const DiffToolSchema = z
     args: z.array(z.string()).optional(),
     env: z.record(z.string(), z.string()).optional(),
   })
-  .passthrough();
+  .strip();
 
 export function parseDiffToolConfig(
   raw: unknown,

--- a/src/core/config/schema.ts
+++ b/src/core/config/schema.ts
@@ -9,7 +9,7 @@ import {
 import { normalizeNookDomain } from "../nook/validation.js";
 import { formatPersonaReference, parsePersonaReference } from "../persona_reference.js";
 import { parseSubagentLaunchModelList } from "../subagents/launch_model.js";
-import { REASONING_LEVELS, type RiskLevel, RiskLevelSchema } from "../types.js";
+import { REASONING_LEVELS } from "../types.js";
 import { normalizeModelNoticeKey, parseModelNoticeKey } from "../utils/model_notices.js";
 import type { ConfigDeps } from "./deps.js";
 import type { DiffToolConfig } from "./diff_tool.js";
@@ -21,7 +21,6 @@ import { getVirtualConfigDefaults } from "./virtual_defaults.js";
 export interface Config {
   apiKeys?: Record<string, string>;
   defaultPersona?: string;
-  defaultRisk?: RiskLevel;
   disableBuiltinPersonas?: boolean;
   disableBuiltinThemes?: boolean;
   defaultTheme?: string;
@@ -120,7 +119,6 @@ export type TelegramProjectConfig = {
   bootstrapCommands?: string[];
   backgroundBootstrapCommands?: string[];
   persona?: string;
-  riskLevel?: RiskLevel;
   noAgentContextFiles?: boolean;
 };
 
@@ -181,26 +179,7 @@ const BuiltInDiffToolSchema = z
   .object({
     codeTheme: z.string().trim().min(1).optional(),
   })
-  .passthrough();
-
-const KNOWN_TOP_LEVEL_CONFIG_KEYS = new Set([
-  "apiKeys",
-  "defaultPersona",
-  "defaultRisk",
-  "disableBuiltinPersonas",
-  "disableBuiltinThemes",
-  "defaultTheme",
-  "diffTool",
-  "builtInDiffTool",
-  "agentContextFiles",
-  "subagents",
-  "autoCompact",
-  "modelSystemNotices",
-  "speechToText",
-  "cloudflareSandbox",
-  "flySprites",
-  "nook",
-]);
+  .strip();
 
 const NonEmptyStringSchema = z.string().trim().min(1);
 const BooleanSchema = z.boolean();
@@ -211,7 +190,7 @@ const SpeechToTextConfigSchema = z
   .object({
     provider: z.enum(["mistral", "gemini"]),
   })
-  .passthrough();
+  .strip();
 const CloudflareSandboxBridgeSchema = z
   .object({
     url: NonEmptyStringSchema,
@@ -219,12 +198,12 @@ const CloudflareSandboxBridgeSchema = z
     apiKeyEnv: NonEmptyStringSchema.optional(),
     home: NonEmptyStringSchema.optional(),
   })
-  .strict();
+  .strip();
 const CloudflareSandboxConfigSchema = z
   .object({
     bridges: z.record(NonEmptyStringSchema, CloudflareSandboxBridgeSchema).optional(),
   })
-  .strict();
+  .strip();
 const FlySpritesApiSchema = z
   .object({
     baseURL: NonEmptyStringSchema.optional(),
@@ -232,12 +211,12 @@ const FlySpritesApiSchema = z
     tokenEnv: NonEmptyStringSchema.optional(),
     home: NonEmptyStringSchema.optional(),
   })
-  .strict();
+  .strip();
 const FlySpritesConfigSchema = z
   .object({
     apis: z.record(NonEmptyStringSchema, FlySpritesApiSchema).optional(),
   })
-  .strict();
+  .strip();
 const NookConfigSchema = z
   .object({
     domain: NonEmptyStringSchema,
@@ -245,12 +224,12 @@ const NookConfigSchema = z
     accessClientSecret: NonEmptyStringSchema.optional(),
     accessClientSecretEnv: NonEmptyStringSchema.optional(),
   })
-  .strict();
+  .strip();
 const SubagentsConfigSchema = z
   .object({
     defaultLaunchModels: z.array(z.string()).optional(),
   })
-  .passthrough();
+  .strip();
 const StringRecordSchema = z.object({}).catchall(z.unknown());
 const PositiveIntegerSchema = z.number().int().finite().gt(0);
 const AutoCompactConfigSchema = z
@@ -259,7 +238,7 @@ const AutoCompactConfigSchema = z
     reserveTokens: PositiveIntegerSchema.optional(),
     keepRecentTokens: PositiveIntegerSchema.optional(),
   })
-  .strict();
+  .strip();
 
 function parseOptionalFields(
   data: Record<string, unknown>,
@@ -415,12 +394,6 @@ function validateConfigData(
   const config: Config = {};
   const errors: string[] = [];
 
-  const unknownKeys = Object.keys(data).filter((key) => !KNOWN_TOP_LEVEL_CONFIG_KEYS.has(key));
-  if (unknownKeys.length > 0) {
-    const keyLabel = unknownKeys.length === 1 ? "key" : "keys";
-    errors.push(`${sourceLabel}: unknown ${keyLabel} in config: ${unknownKeys.sort().join(", ")}.`);
-  }
-
   const apiKeysResult = parseApiKeysConfig(data.apiKeys, sourceLabel);
   assignParsedConfigValue(config, errors, "apiKeys", apiKeysResult.config, apiKeysResult.errors);
 
@@ -434,7 +407,6 @@ function validateConfigData(
   );
 
   const scalarResult = parseOptionalFields(data, sourceLabel, [
-    ["defaultRisk", RiskLevelSchema, "'defaultRisk' must be a valid risk level."],
     ["disableBuiltinPersonas", BooleanSchema, "'disableBuiltinPersonas' must be a boolean."],
     ["disableBuiltinThemes", BooleanSchema, "'disableBuiltinThemes' must be a boolean."],
     ["defaultTheme", NonEmptyStringSchema, "'defaultTheme' must be a non-empty string."],
@@ -994,10 +966,6 @@ function mergeConfigLevels(levels: ConfigLevel[], configs: Config[]): Config {
 
     if (config.defaultPersona !== undefined) {
       merged.defaultPersona = config.defaultPersona;
-    }
-
-    if (config.defaultRisk !== undefined) {
-      merged.defaultRisk = config.defaultRisk;
     }
 
     if (config.disableBuiltinPersonas !== undefined) {

--- a/src/core/config/schema.ts
+++ b/src/core/config/schema.ts
@@ -716,14 +716,6 @@ function parseAutoCompactConfig(
     if (parsed.error.issues.some((issue) => issue.path[0] === "keepRecentTokens")) {
       errors.add(`${sourceLabel}: autoCompact.keepRecentTokens must be a positive integer.`);
     }
-    for (const issue of parsed.error.issues) {
-      if (issue.code === "unrecognized_keys") {
-        const keyLabel = issue.keys.length === 1 ? "key" : "keys";
-        errors.add(
-          `${sourceLabel}: unknown ${keyLabel} in autoCompact: ${issue.keys.sort().join(", ")}.`,
-        );
-      }
-    }
     if (errors.size === 0) {
       errors.add(`${sourceLabel}: 'autoCompact' must be an object.`);
     }

--- a/src/core/config/skill_parser.ts
+++ b/src/core/config/skill_parser.ts
@@ -21,7 +21,7 @@ const skillFrontMatterSchema = z
     metadata: z.record(z.string(), z.string()).optional(),
     "allowed-tools": z.string().trim().min(1).optional(),
   })
-  .passthrough();
+  .strip();
 
 export function parseSkill(filePath: string, content: string): { skill?: Skill; error?: string } {
   const markdownResult = parseMarkdownFrontMatter(content);

--- a/src/core/config/virtual_defaults.ts
+++ b/src/core/config/virtual_defaults.ts
@@ -4,7 +4,6 @@ import { type Config, DEFAULT_AUTO_COMPACT_CONFIG } from "./schema.js";
 export function getVirtualConfigDefaults(): Config {
   return {
     defaultPersona: DEFAULT_BUILTIN_PERSONA_ID,
-    defaultRisk: "read-only",
     defaultTheme: "gold",
     autoCompact: { ...DEFAULT_AUTO_COMPACT_CONFIG },
   };

--- a/src/core/debug.ts
+++ b/src/core/debug.ts
@@ -8,7 +8,7 @@ import {
 } from "./subagents/registry.js";
 import type { SubagentPersonaConfig } from "./subagents/types.js";
 import type { ToolRegistry } from "./tools/registry.js";
-import type { Persona, RiskLevel, Skill } from "./types.js";
+import type { Persona, Skill } from "./types.js";
 import {
   buildBaseSystemPrompt,
   buildEnvironmentTag,
@@ -82,7 +82,6 @@ export function printDebugInfo(args: {
   skills: Skill[];
   selectedPersona?: Persona;
   noAgentContextFiles: boolean;
-  riskLevel?: RiskLevel;
   toolRegistry: ToolRegistry;
   virtualBundle?: VirtualBundle;
 }): void {
@@ -92,7 +91,6 @@ export function printDebugInfo(args: {
     skills,
     selectedPersona,
     noAgentContextFiles,
-    riskLevel,
     toolRegistry,
     virtualBundle,
   } = args;
@@ -109,11 +107,9 @@ export function printDebugInfo(args: {
     console.log("\n  (not available)");
   } else {
     const defaultPersona = virtualBundle.config.defaultPersona ?? "(none)";
-    const defaultRisk = virtualBundle.config.defaultRisk ?? "(none)";
     const personaIds = virtualBundle.personas.map((p) => p.id).join(", ") || "(none)";
     const promptIds = virtualBundle.prompts.map((p) => p.id).join(", ") || "(none)";
     console.log(`\n  defaultPersona: ${defaultPersona}`);
-    console.log(`  defaultRisk: ${defaultRisk}`);
     console.log(`  personas: ${personaIds}`);
     console.log(`  prompts: ${promptIds}`);
   }
@@ -176,10 +172,8 @@ export function printDebugInfo(args: {
   const projectContextBlock = !noAgentContextFiles
     ? buildProjectContextBlock({ cwd, home, readFile: deps.fs.readFile })
     : undefined;
-  const effectiveRiskLevel: RiskLevel = riskLevel ?? "read-only";
   const repoRoot = resolvePromptGitRoot({ cwd });
   const environmentTag = buildEnvironmentTag({
-    riskLevel: effectiveRiskLevel,
     cwd,
     repoRoot,
     datetime: new Date(deps.clock.now()).toISOString(),
@@ -213,13 +207,11 @@ export function printDebugInfo(args: {
       const effective = resolveSubagentEffectiveSettings({
         persona: selectedPersona,
         config: cfg,
-        riskLevel: effectiveRiskLevel,
       });
       console.log(`  model: ${effective.model.provider}:${effective.model.id}`);
       if (effective.settings) {
         console.log(`  settings: ${JSON.stringify(effective.settings)}`);
       }
-      console.log(`  riskLevel: ${effective.riskLevel}`);
       if (effective.tools.length > 0) {
         console.log(`  tools: ${effective.tools.join(", ")}`);
       }

--- a/src/core/diff_review/protocol.ts
+++ b/src/core/diff_review/protocol.ts
@@ -214,14 +214,14 @@ const diffReviewRequestEnvelopeSchema = z
     method: z.string(),
     params: z.unknown().optional(),
   })
-  .strict();
+  .strip();
 const diffReviewErrorSchema = z
   .object({
     code: z.string().trim().min(1),
     message: z.string(),
     data: z.unknown().optional(),
   })
-  .strict();
+  .strip();
 const diffReviewSuccessResponseSchema = z
   .object({
     version: z.literal(DIFF_REVIEW_PROTOCOL_VERSION),
@@ -230,7 +230,7 @@ const diffReviewSuccessResponseSchema = z
     ok: z.literal(true),
     result: z.unknown(),
   })
-  .strict();
+  .strip();
 const diffReviewErrorResponseSchema = z
   .object({
     version: z.literal(DIFF_REVIEW_PROTOCOL_VERSION),
@@ -239,38 +239,38 @@ const diffReviewErrorResponseSchema = z
     ok: z.literal(false),
     error: diffReviewErrorSchema,
   })
-  .strict();
+  .strip();
 const diffReviewResponseSchema = z.union([
   diffReviewSuccessResponseSchema,
   diffReviewErrorResponseSchema,
 ]);
-const diffReviewIdFieldSchema = z.object({ id: z.unknown() }).passthrough();
-const diffReviewVersionFieldSchema = z.object({ version: z.unknown() }).passthrough();
-const diffReviewTypeFieldSchema = z.object({ type: z.unknown() }).passthrough();
-const emptyObjectSchema = z.object({}).strict();
+const diffReviewIdFieldSchema = z.object({ id: z.unknown() }).strip();
+const diffReviewVersionFieldSchema = z.object({ version: z.unknown() }).strip();
+const diffReviewTypeFieldSchema = z.object({ type: z.unknown() }).strip();
+const emptyObjectSchema = z.object({}).strip();
 
 const initializeParamsSchema = z
   .object({
     token: z.string().trim().min(1),
   })
-  .strict();
+  .strip();
 const sessionGetDiffParamsSchema = z
   .object({
     path: z.string().min(1).optional(),
   })
-  .strict();
+  .strip();
 const sessionSetUiTextParamsSchema = z
   .object({
     text: z.string(),
   })
-  .strict();
+  .strip();
 const threadSubmitMessageParamsSchema = z
   .object({
     threadId: z.string().trim().min(1).optional(),
     forkFromThreadId: z.string().trim().min(1).optional(),
     message: z.string().trim().min(1),
   })
-  .strict()
+  .strip()
   .superRefine((value, context) => {
     if (value.threadId && value.forkFromThreadId) {
       context.addIssue({
@@ -284,7 +284,7 @@ const sessionReturnReviewParamsSchema = z
   .object({
     review: z.string().trim().min(1),
   })
-  .strict();
+  .strip();
 
 export function createDiffReviewError(
   code: DiffReviewErrorCode,

--- a/src/core/diff_review/review_thread.ts
+++ b/src/core/diff_review/review_thread.ts
@@ -106,7 +106,6 @@ export class DiffReviewThread {
       options.promptComposition ??
       composeSessionPrompts({
         persona,
-        riskLevel: "read-only",
         cwd: promptBootstrap!.promptContext.cwd,
         datetime: new Date(deps.clock.now()).toISOString(),
         platform: deps.env.platform(),
@@ -124,7 +123,6 @@ export class DiffReviewThread {
       persona,
       systemPrompt: promptComposition.baseSystemPrompt,
       subagentPrompts: promptComposition.subagentPrompts,
-      riskLevel: "read-only",
       toolRegistry,
       config: options.config,
       deps,

--- a/src/core/diff_review/tool.ts
+++ b/src/core/diff_review/tool.ts
@@ -61,7 +61,7 @@ const diffReviewArgsSchema = z
     patchFiles: z.array(z.string().trim().min(1)).optional(),
     label: z.string().trim().min(1).optional(),
   })
-  .strip()
+  .strict()
   .superRefine((value, context) => {
     if (value.source === "patch_files" && (!value.patchFiles || value.patchFiles.length === 0)) {
       context.addIssue({

--- a/src/core/diff_review/tool.ts
+++ b/src/core/diff_review/tool.ts
@@ -61,7 +61,7 @@ const diffReviewArgsSchema = z
     patchFiles: z.array(z.string().trim().min(1)).optional(),
     label: z.string().trim().min(1).optional(),
   })
-  .strict()
+  .strip()
   .superRefine((value, context) => {
     if (value.source === "patch_files" && (!value.patchFiles || value.patchFiles.length === 0)) {
       context.addIssue({

--- a/src/core/events/parser.ts
+++ b/src/core/events/parser.ts
@@ -39,7 +39,7 @@ export function safeParseCoreEvent(value: unknown): CoreEventParseResult<CoreEve
     return fail("invalid core event payload");
   }
 
-  return { ok: true, value: value as CoreEvent };
+  return { ok: true, value: stripCoreEvent(value) };
 }
 
 export function parseCoreEventEnvelope(value: unknown): CoreEventEnvelope {
@@ -53,16 +53,6 @@ export function safeParseCoreEventEnvelope(
 ): CoreEventParseResult<CoreEventEnvelope> {
   if (!isRecord(value)) {
     return fail("core event envelope must be an object");
-  }
-
-  const envelopeKeys = Object.keys(value);
-  const unsupportedEnvelopeKeys = envelopeKeys.filter(
-    (key) => key !== "version" && key !== "event",
-  );
-  if (unsupportedEnvelopeKeys.length > 0) {
-    return fail(
-      `core event envelope contains unsupported fields: ${unsupportedEnvelopeKeys.join(", ")}`,
-    );
   }
 
   if (!isCoreEventVersion(value.version)) {
@@ -87,55 +77,119 @@ export function isCoreEventVersion(value: unknown): value is CoreEventVersion {
   return value === CORE_EVENT_VERSION;
 }
 
+function stripCoreEvent(value: UnknownRecord): CoreEvent {
+  switch (value.type) {
+    case "assistant_start":
+      return { type: "assistant_start", historyEntryId: value.historyEntryId as string };
+    case "assistant_final":
+      return {
+        type: "assistant_final",
+        historyEntryId: value.historyEntryId as string,
+        message: value.message as Extract<CoreEvent, { type: "assistant_final" }>["message"],
+      };
+    case "assistant_partial": {
+      const snapshot = value.snapshot as UnknownRecord;
+      return {
+        type: "assistant_partial",
+        historyEntryId: value.historyEntryId as string,
+        snapshot: {
+          text: snapshot.text as string,
+          thinking: snapshot.thinking as string,
+          hasTextStarted: snapshot.hasTextStarted as boolean,
+          hasAnyThinking: snapshot.hasAnyThinking as boolean,
+        },
+      };
+    }
+    case "notice":
+      return {
+        type: "notice",
+        severity: value.severity as Extract<CoreEvent, { type: "notice" }>["severity"],
+        text: value.text as string,
+      };
+    case "tool_ui":
+      return {
+        type: "tool_ui",
+        uiEvent: value.uiEvent as Extract<CoreEvent, { type: "tool_ui" }>["uiEvent"],
+      };
+    case "subagent_ui":
+      return {
+        type: "subagent_ui",
+        event: value.event as Extract<CoreEvent, { type: "subagent_ui" }>["event"],
+        originHistoryEntryId: value.originHistoryEntryId as string,
+      };
+    case "tool_result":
+      return {
+        type: "tool_result",
+        historyEntryId: value.historyEntryId as string,
+        message: value.message as Extract<CoreEvent, { type: "tool_result" }>["message"],
+      };
+    case "compaction_start":
+      return { type: "compaction_start", reason: "threshold" };
+    case "compaction_end":
+      return stripCompactionEndEvent(value);
+    default:
+      throw new Error("invalid core event payload");
+  }
+}
+
+function stripCompactionEndEvent(
+  value: UnknownRecord,
+): Extract<CoreEvent, { type: "compaction_end" }> {
+  switch (value.outcome) {
+    case "compacted": {
+      const result = value.result as UnknownRecord;
+      return {
+        type: "compaction_end",
+        reason: "threshold",
+        outcome: "compacted",
+        result: {
+          summaryHistoryEntryId: result.summaryHistoryEntryId as string,
+          continuationHistoryEntryId: result.continuationHistoryEntryId as string,
+          compactionMessage: result.compactionMessage as string,
+          cutType: result.cutType as "turn-boundary" | "split-turn",
+          retainedMessageCount: result.retainedMessageCount as number,
+        },
+      };
+    }
+    case "failed":
+      return {
+        type: "compaction_end",
+        reason: "threshold",
+        outcome: "failed",
+        errorMessage: value.errorMessage as string,
+      };
+    case "skipped":
+      return { type: "compaction_end", reason: "threshold", outcome: "skipped" };
+    case "aborted":
+      return { type: "compaction_end", reason: "threshold", outcome: "aborted" };
+    default:
+      throw new Error("invalid core event payload");
+  }
+}
+
 function isValidCoreEvent(value: UnknownRecord, eventType: string): boolean {
   switch (eventType) {
     case "assistant_start":
-      return (
-        hasOnlyKeys(value, ["type", "historyEntryId"]) && typeof value.historyEntryId === "string"
-      );
+      return typeof value.historyEntryId === "string";
     case "assistant_final":
-      return (
-        hasOnlyKeys(value, ["type", "historyEntryId", "message"]) &&
-        typeof value.historyEntryId === "string" &&
-        isAssistantMessage(value.message)
-      );
+      return typeof value.historyEntryId === "string" && isAssistantMessage(value.message);
     case "assistant_partial":
-      return (
-        hasOnlyKeys(value, ["type", "historyEntryId", "snapshot"]) &&
-        typeof value.historyEntryId === "string" &&
-        isAssistantPartialSnapshot(value.snapshot)
-      );
+      return typeof value.historyEntryId === "string" && isAssistantPartialSnapshot(value.snapshot);
     case "notice":
-      return (
-        hasOnlyKeys(value, ["type", "severity", "text"]) &&
-        isOneOf(value.severity, noticeSeverities) &&
-        typeof value.text === "string"
-      );
+      return isOneOf(value.severity, noticeSeverities) && typeof value.text === "string";
     case "tool_ui":
-      return hasOnlyKeys(value, ["type", "uiEvent"]) && isToolUiEvent(value.uiEvent);
+      return isToolUiEvent(value.uiEvent);
     case "subagent_ui":
-      return (
-        hasOnlyKeys(value, ["type", "event", "originHistoryEntryId"]) &&
-        typeof value.originHistoryEntryId === "string" &&
-        isSubagentUiEvent(value.event)
-      );
+      return typeof value.originHistoryEntryId === "string" && isSubagentUiEvent(value.event);
     case "tool_result":
-      return (
-        hasOnlyKeys(value, ["type", "historyEntryId", "message"]) &&
-        typeof value.historyEntryId === "string" &&
-        isToolResultMessage(value.message)
-      );
+      return typeof value.historyEntryId === "string" && isToolResultMessage(value.message);
     case "compaction_start":
-      return hasOnlyKeys(value, ["type", "reason"]) && isOneOf(value.reason, compactionReasons);
+      return isOneOf(value.reason, compactionReasons);
     case "compaction_end":
       return isCompactionEndEvent(value);
     default:
       return false;
   }
-}
-
-function hasOnlyKeys(value: UnknownRecord, allowedKeys: readonly string[]): boolean {
-  return Object.keys(value).every((key) => allowedKeys.includes(key));
 }
 
 function isCompactionEndEvent(value: UnknownRecord): boolean {
@@ -145,24 +199,12 @@ function isCompactionEndEvent(value: UnknownRecord): boolean {
 
   switch (value.outcome) {
     case "compacted":
-      return (
-        hasOnlyKeys(value, ["type", "reason", "outcome", "result"]) &&
-        value.errorMessage === undefined &&
-        isCompactionResult(value.result)
-      );
+      return value.errorMessage === undefined && isCompactionResult(value.result);
     case "failed":
-      return (
-        hasOnlyKeys(value, ["type", "reason", "outcome", "errorMessage"]) &&
-        value.result === undefined &&
-        typeof value.errorMessage === "string"
-      );
+      return value.result === undefined && typeof value.errorMessage === "string";
     case "skipped":
     case "aborted":
-      return (
-        hasOnlyKeys(value, ["type", "reason", "outcome"]) &&
-        value.result === undefined &&
-        value.errorMessage === undefined
-      );
+      return value.result === undefined && value.errorMessage === undefined;
   }
 }
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -122,6 +122,6 @@ export { createTerminateAgentToolDefinition } from "./tools/terminate_agent.js";
 export { createViewImageToolDefinition } from "./tools/view_image.js";
 export { createWaitForAgentsToolDefinition } from "./tools/wait_for_agents.js";
 export { createWriteToolDefinition } from "./tools/write.js";
-export type { Persona, ReasoningEffort, RiskLevel, Skill } from "./types.js";
+export type { Persona, ReasoningEffort, Skill } from "./types.js";
 export { REASONING_LEVELS } from "./types.js";
 export { printUsageHelp, runUsageCommand, UsageCliError } from "./usage/cli.js";

--- a/src/core/models/catalog.ts
+++ b/src/core/models/catalog.ts
@@ -51,7 +51,7 @@ const CostTierSchema = z
     cacheRead: z.number().nonnegative(),
     cacheWrite: z.number().nonnegative(),
   })
-  .strict();
+  .strip();
 
 const CostSchema = z
   .object({
@@ -77,7 +77,7 @@ const ModelSchema = z
     maxTokens: z.number().int().positive().optional(),
     compat: z.unknown().optional(),
   })
-  .passthrough();
+  .strip();
 
 const ProviderSchema = z
   .object({
@@ -87,13 +87,13 @@ const ProviderSchema = z
     compat: z.unknown().optional(),
     models: z.array(ModelSchema).optional(),
   })
-  .passthrough();
+  .strip();
 
 const ModelsFileSchema = z
   .object({
     providers: z.record(z.string(), ProviderSchema),
   })
-  .passthrough();
+  .strip();
 
 type ParsedModelsFile = z.infer<typeof ModelsFileSchema>;
 type ParsedModel = z.infer<typeof ModelSchema>;

--- a/src/core/personas.ts
+++ b/src/core/personas.ts
@@ -53,7 +53,7 @@ const BLOCK_TOOL_USE_GUIDELINES = `
 
 **Restraint**: Don't race ahead with bash commands. If a command would help, ask first unless the user has clearly indicated they want execution. Never use bash just to print text; respond directly instead. Don't speculate about how long tasks will take.
 
-**Safety**: File modification tools require read-write risk level. If permissions don't match, stop and tell the user. When a request is ambiguous, clarify before running anything that mutates state.
+**Safety**: When a request is ambiguous, clarify before running anything that mutates state.
 `.trim();
 
 const BLOCK_TOOL_USE_GUIDELINES_CODER = `
@@ -65,7 +65,7 @@ const BLOCK_TOOL_USE_GUIDELINES_CODER = `
 
 **Bias toward action**: When the user asks you to implement, fix, or modify code, do the work directly rather than asking for permission. Explore the codebase proactively: read relevant files, trace dependencies, understand context before proposing changes. Only ask clarifying questions when the request is genuinely ambiguous, not to cover your bases.
 
-**Safety**: File modification tools require read-write risk level. If permissions don't match, stop and tell the user. For destructive operations (deleting files, dropping data, force-pushing), confirm intent even if the user seems confident.
+**Safety**: For destructive operations (deleting files, dropping data, force-pushing), confirm intent even if the user seems confident.
 `.trim();
 
 const BLOCK_CODER_PROGRESS_UPDATES = `
@@ -163,17 +163,6 @@ const BLOCK_PROJECT_CONTEXT = `
 If an AGENTS.md file is present, read it early. Treat it as the baseline for project-specific conventions, build commands, and architecture notes. User instructions always take precedence, including when they conflict with AGENTS.md. If the contents are already provided in the conversation context, do not re-read it unless the user asks.
 `.trim();
 
-const BLOCK_RISK_LEVELS = `
-### Risk levels and tools
-
-Your available tools depend on the current risk level (shown in the <environment> tag or in the latest system notification):
-
-- **read-only**: Shell commands that don't modify state. Background tasks and sub-agents available.
-- **read-write**: Full access including file modifications and write operations.
-
-Bash-specific guidance in this prompt (ripgrep, fd, sed, etc.) applies when bash is available.
-`.trim();
-
 const BLOCK_HIDDEN_SYSTEM_INSTRUCTIONS = `
 ### Hidden Tau system instructions
 
@@ -186,7 +175,6 @@ const BASIC_SYSTEM_PROMPT = [
   BLOCK_GENERAL_PURPOSE_PREAMBLE,
   BLOCK_OUTPUT_STYLE_GUIDELINES,
   BLOCK_TOOL_USE_GUIDELINES,
-  BLOCK_RISK_LEVELS,
   BLOCK_HIDDEN_SYSTEM_INSTRUCTIONS,
   BLOCK_FILE_MENTIONS,
   BLOCK_FILE_EDIT_GUIDELINES,
@@ -199,7 +187,6 @@ const CODER_SYSTEM_PROMPT = [
   BLOCK_OUTPUT_STYLE_GUIDELINES,
   BLOCK_TOOL_USE_GUIDELINES_CODER,
   BLOCK_CODER_PROGRESS_UPDATES,
-  BLOCK_RISK_LEVELS,
   BLOCK_HIDDEN_SYSTEM_INSTRUCTIONS,
   BLOCK_FILE_MENTIONS,
   BLOCK_FILE_EDIT_GUIDELINES,

--- a/src/core/runtime/chat_runtime.ts
+++ b/src/core/runtime/chat_runtime.ts
@@ -1,7 +1,7 @@
 import type { Config } from "../config/index.js";
 import { CoreSession } from "../session/core_session.js";
 import type { ToolDefinition, ToolRegistry } from "../tools/registry.js";
-import type { Persona, ReasoningEffort, RiskLevel } from "../types.js";
+import type { Persona, ReasoningEffort } from "../types.js";
 import {
   type ConversationTurnResult,
   ConversationTurnRuntime,
@@ -26,7 +26,6 @@ export type ChatRuntimeEnvironment = {
 export type ChatRuntimeOptions = {
   session: CoreSession;
   persona: Persona;
-  riskLevel: RiskLevel;
   promptContext: ChatRuntimePromptContext;
   environment: ChatRuntimeEnvironment;
   initialPromptComposition?: SessionPromptComposition;
@@ -34,7 +33,6 @@ export type ChatRuntimeOptions = {
 
 export type CreateChatRuntimeOptions = {
   persona: Persona;
-  riskLevel: RiskLevel;
   toolRegistry: ToolRegistry;
   clientToolDefinitions?: (sessionId: string) => ToolDefinition[];
   promptContext: ChatRuntimePromptContext;
@@ -48,7 +46,6 @@ export class ChatRuntime {
   private readonly sessionInstance: CoreSession;
   private readonly turnRuntime: ConversationTurnRuntime;
   private currentPersona: Persona;
-  private riskLevel: RiskLevel;
   private promptContext: ChatRuntimePromptContext;
   private readonly environment: ChatRuntimeEnvironment;
   private latestPromptComposition: SessionPromptComposition;
@@ -58,7 +55,6 @@ export class ChatRuntime {
       options.initialPromptComposition ??
       composeSessionPrompts({
         persona: options.persona,
-        riskLevel: options.riskLevel,
         cwd: options.promptContext.cwd,
         datetime: new Date(options.environment.now()).toISOString(),
         platform: options.environment.platform(),
@@ -71,7 +67,6 @@ export class ChatRuntime {
       persona: options.persona,
       systemPrompt: promptComposition.baseSystemPrompt,
       subagentPrompts: promptComposition.subagentPrompts,
-      riskLevel: options.riskLevel,
       toolRegistry: options.toolRegistry,
       clientToolDefinitions: options.clientToolDefinitions,
       config: options.config,
@@ -84,7 +79,6 @@ export class ChatRuntime {
     return new ChatRuntime({
       session,
       persona: options.persona,
-      riskLevel: options.riskLevel,
       promptContext: options.promptContext,
       environment: options.environment,
       initialPromptComposition: promptComposition,
@@ -95,7 +89,6 @@ export class ChatRuntime {
     this.sessionInstance = options.session;
     this.turnRuntime = new ConversationTurnRuntime(this.sessionInstance);
     this.currentPersona = options.persona;
-    this.riskLevel = options.riskLevel;
     this.promptContext = { ...options.promptContext };
     this.environment = options.environment;
 
@@ -124,10 +117,6 @@ export class ChatRuntime {
 
   get persona(): Persona {
     return this.currentPersona;
-  }
-
-  get currentRiskLevel(): RiskLevel {
-    return this.riskLevel;
   }
 
   runTurn(
@@ -161,16 +150,6 @@ export class ChatRuntime {
       },
     };
     this.sessionInstance.setReasoning(reasoning);
-  }
-
-  setRiskLevel(level: RiskLevel): void {
-    const previous = this.riskLevel;
-    this.riskLevel = level;
-    this.sessionInstance.setRiskLevel(level);
-
-    if (previous !== level) {
-      this.rebuildSubagentPrompts();
-    }
   }
 
   setPersona(persona: Persona, options?: { skillsBlock?: string }): void {
@@ -224,7 +203,6 @@ export class ChatRuntime {
   private composePromptSet(skillsBlock?: string): SessionPromptComposition {
     return composeSessionPrompts({
       persona: this.currentPersona,
-      riskLevel: this.riskLevel,
       cwd: this.promptContext.cwd,
       datetime: new Date(this.environment.now()).toISOString(),
       platform: this.environment.platform(),

--- a/src/core/runtime/chat_runtime.ts
+++ b/src/core/runtime/chat_runtime.ts
@@ -182,24 +182,6 @@ export class ChatRuntime {
     );
   }
 
-  rebuildSubagentPrompts(options?: { skillsBlock?: string }): void {
-    if (options?.skillsBlock !== undefined) {
-      this.promptContext.skillsBlock = options.skillsBlock;
-    }
-
-    const nextPromptComposition = this.composePromptSet(options?.skillsBlock);
-    this.latestPromptComposition = {
-      ...this.latestPromptComposition,
-      subagentPrompts: nextPromptComposition.subagentPrompts,
-    };
-
-    this.sessionInstance.setPersona(
-      this.currentPersona,
-      this.latestPromptComposition.baseSystemPrompt,
-      this.latestPromptComposition.subagentPrompts,
-    );
-  }
-
   private composePromptSet(skillsBlock?: string): SessionPromptComposition {
     return composeSessionPrompts({
       persona: this.currentPersona,

--- a/src/core/runtime/session_prompt_composer.ts
+++ b/src/core/runtime/session_prompt_composer.ts
@@ -1,11 +1,10 @@
 import { formatSubagentsForPrompt, getSubagentBasePrompt } from "../subagents/registry.js";
-import type { Persona, RiskLevel } from "../types.js";
+import type { Persona } from "../types.js";
 import { buildBaseSystemPrompt, buildEnvironmentTag } from "../utils/context.js";
 import { resolvePromptGitRoot } from "../utils/git.js";
 
 export type ComposeSessionPromptsArgs = {
   persona: Persona;
-  riskLevel: RiskLevel;
   cwd: string;
   datetime: string;
   platform: NodeJS.Platform;
@@ -24,7 +23,6 @@ export function composeSessionPrompts(args: ComposeSessionPromptsArgs): SessionP
   const repoRoot = resolvePromptGitRoot({ cwd: args.cwd });
 
   const environmentTag = buildEnvironmentTag({
-    riskLevel: args.riskLevel,
     cwd: args.cwd,
     repoRoot,
     datetime: args.datetime,
@@ -51,7 +49,6 @@ export function composeSessionPrompts(args: ComposeSessionPromptsArgs): SessionP
       });
 
       const subagentEnvironmentTag = buildEnvironmentTag({
-        riskLevel: config.riskLevel ?? args.riskLevel,
         cwd: args.cwd,
         repoRoot,
         datetime: args.datetime,

--- a/src/core/session/core_session.ts
+++ b/src/core/session/core_session.ts
@@ -3,7 +3,7 @@ import type { Config } from "../config/index.js";
 import type { CoreEvent, CoreSubagentUiEvent } from "../events/types.js";
 import type { CoreDeps } from "../runtime/deps.js";
 import type { ToolDefinition, ToolRegistry } from "../tools/registry.js";
-import type { Persona, ReasoningEffort, RiskLevel } from "../types.js";
+import type { Persona, ReasoningEffort } from "../types.js";
 import {
   type HistoryEntry,
   type ProcessTurnResult,
@@ -33,7 +33,6 @@ export type CoreSessionOptions = {
   persona: Persona;
   systemPrompt: string;
   subagentPrompts: Record<string, string>;
-  riskLevel: RiskLevel;
   toolRegistry: ToolRegistry;
   clientToolDefinitions?: (sessionId: string) => ToolDefinition[];
   config?: Config;
@@ -72,10 +71,6 @@ export class CoreSession {
 
   setReasoning(reasoning: ReasoningEffort): void {
     this.engine.setReasoning(reasoning);
-  }
-
-  setRiskLevel(level: RiskLevel): void {
-    this.engine.setRiskLevel(level);
   }
 
   setConfig(config: Config): void {

--- a/src/core/session/runner.ts
+++ b/src/core/session/runner.ts
@@ -21,7 +21,6 @@ import type {
   ToolDispatchResultWithPhases,
   ToolRegistry,
 } from "../tools/registry.js";
-import type { RiskLevel } from "../types.js";
 import { createToolError } from "../utils/messages.js";
 import type { ModelRuntime } from "../utils/model_stream.js";
 import type { TauStreamOptions } from "../utils/streaming_settings.js";
@@ -182,7 +181,6 @@ export type RunToolCallsOptions = {
   toolRegistry: ToolRegistry;
   extraToolDefinitions?: ToolDefinition[];
   enabledTools: Tool[];
-  riskLevel: RiskLevel;
   signal: AbortSignal;
   dispatchContext: ToolDispatchContext;
   toolErrorMessages?: {
@@ -281,7 +279,6 @@ export async function* runToolCalls(
     toolRegistry,
     enabledTools,
     extraToolDefinitions = [],
-    riskLevel,
     signal,
     dispatchContext,
     toolErrorMessages,
@@ -343,7 +340,7 @@ export async function* runToolCalls(
     const { index, toolCall, def } = entry;
     let result: ToolDispatchResult | ToolDispatchResultWithPhases;
     try {
-      result = await def.dispatch(toolCall, riskLevel, signal, dispatchContext);
+      result = await def.dispatch(toolCall, signal, dispatchContext);
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
       const toolError = createToolError(

--- a/src/core/session/session_engine.ts
+++ b/src/core/session/session_engine.ts
@@ -23,7 +23,7 @@ import { SubagentControlPlane } from "../subagents/control_plane.js";
 import type { SubagentUiEvent } from "../subagents/types.js";
 import type { ToolDefinition, ToolDispatchContext, ToolRegistry } from "../tools/registry.js";
 import { TOOL_NAME_NOOK } from "../tools/tool_names.js";
-import type { Persona, ReasoningEffort, RiskLevel } from "../types.js";
+import type { Persona, ReasoningEffort } from "../types.js";
 import { appendUsageLogEntry, getUsageCostTotal, getUsageTotals } from "../usage/logs.js";
 import { shouldAutoRetry } from "../utils/auto_retry.js";
 import { CODEX_ORIGINATOR, CODEX_USER_AGENT } from "../utils/codex.js";
@@ -70,7 +70,6 @@ export type SessionEngineOptions = {
   persona: Persona;
   systemPrompt: string;
   subagentPrompts: Record<string, string>;
-  riskLevel: RiskLevel;
   toolRegistry: ToolRegistry;
   clientToolDefinitions?: (sessionId: string) => ToolDefinition[];
   config?: Config;
@@ -130,7 +129,6 @@ export class SessionEngine {
   private persona: Persona;
   private systemPrompt: string;
   private subagentPrompts: Record<string, string>;
-  private riskLevel: RiskLevel;
   private readonly toolRegistry: ToolRegistry;
   private readonly clientToolDefinitions?: (sessionId: string) => ToolDefinition[];
   private config: Config;
@@ -151,7 +149,6 @@ export class SessionEngine {
     this.persona = options.persona;
     this.systemPrompt = options.systemPrompt;
     this.subagentPrompts = options.subagentPrompts;
-    this.riskLevel = options.riskLevel;
     this.toolRegistry = options.toolRegistry;
     this.clientToolDefinitions = options.clientToolDefinitions;
     this.config = options.config ?? {};
@@ -224,10 +221,6 @@ export class SessionEngine {
         reasoning,
       },
     };
-  }
-
-  setRiskLevel(level: RiskLevel): void {
-    this.riskLevel = level;
   }
 
   setConfig(config: Config): void {
@@ -780,7 +773,6 @@ export class SessionEngine {
           ...turnSettings.clientToolDefinitions,
         ],
         enabledTools,
-        riskLevel: this.riskLevel,
         signal,
         dispatchContext,
       })) {

--- a/src/core/subagents/registry.ts
+++ b/src/core/subagents/registry.ts
@@ -6,7 +6,7 @@ import {
   TOOL_NAME_WEB_SEARCH,
   TOOL_NAME_WRITE,
 } from "../tools/tool_names.js";
-import type { Persona, RiskLevel } from "../types.js";
+import type { Persona } from "../types.js";
 import { buildDefaultSubagentSystemPrompt, DEFAULT_SUBAGENT_DESCRIPTION } from "./default.js";
 import {
   DEFAULT_SUBAGENT_NAME,
@@ -51,15 +51,11 @@ function getInheritedSubagentTools(persona: Persona): SubagentToolName[] {
   return normalizeTools(selected);
 }
 
-export type SubagentEffectiveSettings = Pick<
-  SubagentRuntimeConfig,
-  "model" | "settings" | "tools" | "riskLevel"
->;
+export type SubagentEffectiveSettings = Pick<SubagentRuntimeConfig, "model" | "settings" | "tools">;
 
 export function resolveSubagentEffectiveSettings(args: {
   persona: Persona;
   config: SubagentPersonaConfig;
-  riskLevel: RiskLevel;
   launchModel?: SubagentLaunchModel;
 }): SubagentEffectiveSettings {
   const model = args.launchModel?.model ?? args.config.model ?? args.persona.model;
@@ -73,12 +69,10 @@ export function resolveSubagentEffectiveSettings(args: {
   const tools = args.config.tools
     ? normalizeTools(args.config.tools)
     : getInheritedSubagentTools(args.persona);
-  const riskLevel = args.config.riskLevel ?? args.riskLevel;
   return {
     model,
     settings: Object.keys(mergedSettings).length > 0 ? mergedSettings : undefined,
     tools,
-    riskLevel,
   };
 }
 

--- a/src/core/subagents/subagent_engine.ts
+++ b/src/core/subagents/subagent_engine.ts
@@ -17,7 +17,6 @@ import type {
   ToolRegistry,
   ToolUiEvent,
 } from "../tools/registry.js";
-import type { RiskLevel } from "../types.js";
 import { appendUsageLogEntry, getUsageCostTotal, getUsageTotals } from "../usage/logs.js";
 import { shouldAutoRetry } from "../utils/auto_retry.js";
 import { CODEX_ORIGINATOR, CODEX_USER_AGENT } from "../utils/codex.js";
@@ -288,8 +287,6 @@ export async function runSubagent(options: {
       return finish();
     }
 
-    const riskLevel = runtimeConfig.riskLevel as RiskLevel;
-
     const handleUi = (uiEvent: ToolUiEvent | undefined) => {
       if (!uiEvent) return;
 
@@ -325,7 +322,6 @@ export async function runSubagent(options: {
       toolCalls: messageToolCalls,
       toolRegistry,
       enabledTools: toolRegistry.getEnabledToolSchemas(),
-      riskLevel,
       signal,
       dispatchContext,
       toolErrorMessages: {

--- a/src/core/subagents/types.ts
+++ b/src/core/subagents/types.ts
@@ -7,7 +7,7 @@ import {
   TOOL_NAME_WEB_SEARCH,
   TOOL_NAME_WRITE,
 } from "../tools/tool_names.js";
-import type { PersonaSettings, ReasoningEffort, RiskLevel } from "../types.js";
+import type { PersonaSettings, ReasoningEffort } from "../types.js";
 
 export const DEFAULT_SUBAGENT_NAME = "default";
 
@@ -24,8 +24,6 @@ export const SUBAGENT_TOOL_NAMES = [
 
 export type SubagentToolName = (typeof SUBAGENT_TOOL_NAMES)[number];
 
-export type SubagentRiskLevel = RiskLevel;
-
 export type SubagentLaunchModel = {
   model: Model<Api>;
   reasoning: ReasoningEffort;
@@ -38,7 +36,6 @@ export type SubagentPersonaConfig = {
   model?: Model<Api>;
   settings?: PersonaSettings;
   tools?: SubagentToolName[];
-  riskLevel?: SubagentRiskLevel;
   launchModels?: string[];
 };
 
@@ -94,6 +91,5 @@ export type SubagentRuntimeConfig = {
   model: Model<Api>;
   settings?: PersonaSettings;
   tools: SubagentToolName[];
-  riskLevel: SubagentRiskLevel;
   workingDirectory: string;
 };

--- a/src/core/telegram/adapter.ts
+++ b/src/core/telegram/adapter.ts
@@ -776,7 +776,7 @@ function formatSessionHeadline(sessionId: string, label: string): string {
   return `(${sessionId}) ${label}`;
 }
 
-const telegramObject = <Shape extends z.ZodRawShape>(shape: Shape) => z.object(shape).passthrough();
+const telegramObject = <Shape extends z.ZodRawShape>(shape: Shape) => z.object(shape).strip();
 
 const telegramPartialObject = <Shape extends z.ZodRawShape>(shape: Shape) =>
   telegramObject(shape).partial();

--- a/src/core/telegram/config.ts
+++ b/src/core/telegram/config.ts
@@ -104,12 +104,6 @@ function createProjectSchema(configDir: string) {
     .strip();
 }
 
-function formatUnknownKeysError(sourceLabel: string, fieldPath: string, keys: string[]): string {
-  const unknownKeys = [...keys].sort();
-  const keyLabel = unknownKeys.length === 1 ? "key" : "keys";
-  return `${sourceLabel}: unknown ${keyLabel} in ${fieldPath}: ${unknownKeys.join(", ")}.`;
-}
-
 function formatSectionZodErrors(
   error: z.ZodError,
   sourceLabel: string,
@@ -117,11 +111,6 @@ function formatSectionZodErrors(
 ): string[] {
   const errors: string[] = [];
   for (const issue of error.issues) {
-    if (issue.code === "unrecognized_keys") {
-      errors.push(formatUnknownKeysError(sourceLabel, fieldPath, issue.keys));
-      continue;
-    }
-
     const issuePath = issue.path.length > 0 ? `.${issue.path.join(".")}` : "";
     errors.push(`${sourceLabel}: ${fieldPath}${issuePath} ${issue.message}`);
   }

--- a/src/core/telegram/config.ts
+++ b/src/core/telegram/config.ts
@@ -49,7 +49,7 @@ const telegramTopLevelSchema = z
     bots: z.unknown().optional(),
     projects: z.unknown().optional(),
   })
-  .strict();
+  .strip();
 
 const telegramBotSchema = z
   .object({
@@ -62,7 +62,7 @@ const telegramBotSchema = z
     pollIntervalMs: positiveIntegerSchema.optional(),
     requestTimeoutSeconds: positiveIntegerSchema.optional(),
   })
-  .strict();
+  .strip();
 
 function createProjectSchema(configDir: string) {
   return z
@@ -99,10 +99,9 @@ function createProjectSchema(configDir: string) {
         .min(1, "must be a non-empty string array.")
         .optional(),
       persona: z.string().optional(),
-      riskLevel: z.enum(["read-only", "read-write"]).optional(),
       noAgentContextFiles: z.boolean().optional(),
     })
-    .strict();
+    .strip();
 }
 
 function formatUnknownKeysError(sourceLabel: string, fieldPath: string, keys: string[]): string {

--- a/src/core/telegram/session_manager.ts
+++ b/src/core/telegram/session_manager.ts
@@ -16,7 +16,6 @@ import type {
   SessionProtocolUnobserveResult,
 } from "../../protocol/session_protocol.js";
 import type { TelegramProjectConfig } from "../config/schema.js";
-import type { RiskLevel } from "../types.js";
 import { extractAssistantText } from "../utils/messages.js";
 import { formatTauUserText } from "../utils/user_metadata.js";
 import {
@@ -85,14 +84,14 @@ const persistedTelegramSessionRecordSchema = z
     updatedAt: z.string().datetime(),
     tauSessionId: z.string().min(1).optional(),
   })
-  .strict();
+  .strip();
 
 const telegramSessionStateSchema = z
   .object({
     version: z.literal(1),
     sessions: z.array(persistedTelegramSessionRecordSchema),
   })
-  .strict();
+  .strip();
 
 type PersistedTelegramSessionRecord = z.infer<typeof persistedTelegramSessionRecordSchema>;
 
@@ -200,7 +199,6 @@ export type TelegramSessionSubmitOptions = {
 export type TelegramSessionClientOptions = {
   cwd: string;
   persona?: string;
-  riskLevel?: RiskLevel;
   noAgentContextFiles?: boolean;
 };
 
@@ -923,9 +921,6 @@ class TelegramSessionManagerImpl implements TelegramSessionManager {
     const options: TelegramSessionClientOptions = { cwd };
     if (entry.project.persona) {
       options.persona = entry.project.persona;
-    }
-    if (entry.project.riskLevel) {
-      options.riskLevel = entry.project.riskLevel;
     }
     if (entry.project.noAgentContextFiles !== undefined) {
       options.noAgentContextFiles = entry.project.noAgentContextFiles;

--- a/src/core/tools/bash.ts
+++ b/src/core/tools/bash.ts
@@ -327,12 +327,14 @@ function resolveBashWorkingDirectory(args: {
   return args.workingDirectory ? resolve(baseCwd, args.workingDirectory) : baseCwd;
 }
 
-const bashArgsSchema = z.object({
-  command: z.string().trim().min(1),
-  workingDirectory: z.string().trim().min(1).optional(),
-  timeout: z.number().positive().optional(),
-  maxOutputTokens: z.number().int().positive().optional(),
-});
+const bashArgsSchema = z
+  .object({
+    command: z.string().trim().min(1),
+    workingDirectory: z.string().trim().min(1).optional(),
+    timeout: z.number().positive().optional(),
+    maxOutputTokens: z.number().int().positive().optional(),
+  })
+  .strict();
 
 function parseBashArgs(raw: unknown):
   | {

--- a/src/core/tools/bash.ts
+++ b/src/core/tools/bash.ts
@@ -3,7 +3,6 @@ import type { Tool, ToolCall, ToolResultMessage } from "@earendil-works/pi-ai";
 import stripAnsi from "strip-ansi";
 import { Type } from "typebox";
 import { z } from "zod";
-import type { RiskLevel } from "../types.js";
 import { formatCwd } from "../utils/format.js";
 import { createToolError, createToolResult } from "../utils/messages.js";
 import { bytesToTokens, formatTokenEstimate } from "../utils/token.js";
@@ -75,18 +74,9 @@ export const BASH_DEFAULT_TIMEOUT_MS = 60_000;
 const BASH_DESCRIPTION = [
   "Execute a shell command in the current working directory and return its output.",
   "Interactive commands are not supported (no TTY/stdin); commands that prompt or open editors will hang or fail.",
-  "CRITICAL: Always evaluate and provide an accurate safetyLevel assessment.",
 ].join(" ");
 
 const BASH_COMMAND_DESCRIPTION = "The shell command to execute.";
-
-const BASH_SAFETY_LEVEL_DESCRIPTION = [
-  "Safety classification: 'read' (query-only, no side effects) or 'write' (modifies or has the potential to modify system state).",
-  "Use 'read' for: queries (ls, rg, cat, fd, find, ps, df, etc), information gathering (curl for APIs, git log, etc), analysis (wc, sort, sha256sum, etc).",
-  "Use 'write' for: filesystem changes (cp, mv, rm, mkdir, touch, echo >, etc), file modifications (sed -i, tee, chmod, chown, etc), process management (kill, pkill, etc), package management (apt, npm, etc), network changes (firewall, DNS, interfaces, etc), or any command that creates/deletes/modifies resources.",
-  "When in doubt, default to 'write' to be conservative. The system will enforce appropriate access controls based on your declared safetyLevel.",
-  "Always respect and strictly adhere to user-defined risk tolerance levels; never exceed the configured risk level under any circumstances.",
-].join(" ");
 
 const BASH_WORKING_DIRECTORY_DESCRIPTION =
   "Working directory for the command. If omitted, uses the current working directory. Prefer this over `cd` in the command.";
@@ -111,10 +101,6 @@ export const BASH_TOOL: Tool = {
       command: Type.String({
         description: BASH_COMMAND_DESCRIPTION,
       }),
-      safetyLevel: Type.String({
-        description: BASH_SAFETY_LEVEL_DESCRIPTION,
-        enum: ["read", "write"],
-      }),
       workingDirectory: Type.Optional(
         Type.String({
           description: BASH_WORKING_DIRECTORY_DESCRIPTION,
@@ -136,8 +122,6 @@ export const BASH_TOOL: Tool = {
     { additionalProperties: false },
   ),
 };
-
-export type BashSafetyLevel = "read" | "write";
 
 export interface BashTruncationInfo {
   output: string;
@@ -345,7 +329,6 @@ function resolveBashWorkingDirectory(args: {
 
 const bashArgsSchema = z.object({
   command: z.string().trim().min(1),
-  safetyLevel: z.enum(["read", "write"]),
   workingDirectory: z.string().trim().min(1).optional(),
   timeout: z.number().positive().optional(),
   maxOutputTokens: z.number().int().positive().optional(),
@@ -356,7 +339,6 @@ function parseBashArgs(raw: unknown):
       ok: true;
       data: {
         command: string;
-        safetyLevel: BashSafetyLevel;
         workingDirectory?: string;
         timeout?: number;
         maxOutputTokens?: number;
@@ -386,7 +368,6 @@ function parseBashArgs(raw: unknown):
     ok: true,
     data: {
       command: parsed.data.command,
-      safetyLevel: parsed.data.safetyLevel as BashSafetyLevel,
       workingDirectory: parsed.data.workingDirectory,
       timeout: parsed.data.timeout,
       maxOutputTokens: clampOutputTokens(parsed.data.maxOutputTokens),
@@ -401,7 +382,6 @@ export function createBashToolDefinition(backend: ToolExecutionBackend): ToolDef
     schema: BASH_TOOL,
     async dispatch(
       toolCall: ToolCall,
-      riskLevel: RiskLevel,
       signal: AbortSignal,
       context: ToolDispatchContext,
     ): Promise<ToolDispatchResult | ToolDispatchResultWithPhases> {
@@ -427,20 +407,8 @@ export function createBashToolDefinition(backend: ToolExecutionBackend): ToolDef
         return blocked(`Invalid arguments: ${parsedArgs.error}`);
       }
 
-      const {
-        command,
-        safetyLevel,
-        workingDirectory,
-        timeout,
-        maxOutputTokens,
-        hasMaxOutputTokens,
-      } = parsedArgs.data;
-
-      if (riskLevel === "read-only" && safetyLevel === "write") {
-        return blocked(
-          "Blocked because the risk level is set to 'read-only'. The declared safetyLevel 'write' exceeds the current risk level. Ask the user to enable it with /risk:read-write or revise to a read-only command.",
-        );
-      }
+      const { command, workingDirectory, timeout, maxOutputTokens, hasMaxOutputTokens } =
+        parsedArgs.data;
 
       const effectiveWorkingDirectory = resolveBashWorkingDirectory({
         contextCwd: context.cwd,

--- a/src/core/tools/edit.ts
+++ b/src/core/tools/edit.ts
@@ -1,7 +1,6 @@
 import type { Tool, ToolCall } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import { z } from "zod";
-import type { RiskLevel } from "../types.js";
 import { buildLineDiff } from "../utils/line_diff.js";
 import { createToolError, createToolSuccess } from "../utils/messages.js";
 import { formatZodError } from "../utils/zod.js";
@@ -122,7 +121,7 @@ function buildEditUiText(args: {
 export function createEditToolDefinition(backend: ToolExecutionBackend): ToolDefinition {
   return {
     schema: EDIT_TOOL,
-    async dispatch(toolCall: ToolCall, riskLevel: RiskLevel): Promise<ToolDispatchResult> {
+    async dispatch(toolCall: ToolCall): Promise<ToolDispatchResult> {
       const parsedArgs = parseEditArgs(toolCall.arguments);
       const path = parsedArgs.ok ? parsedArgs.data.path : "";
       const headerTarget = path || "(invalid arguments)";
@@ -144,12 +143,6 @@ export function createEditToolDefinition(backend: ToolExecutionBackend): ToolDef
       }
 
       const { oldText, newText } = parsedArgs.data;
-
-      if (riskLevel !== "read-write") {
-        return blocked(
-          `Requires risk level 'read-write', but the current level is '${riskLevel}'. Ask the user to run /risk:read-write.`,
-        );
-      }
 
       let content: string;
       try {

--- a/src/core/tools/emit_output.ts
+++ b/src/core/tools/emit_output.ts
@@ -1,7 +1,6 @@
 import type { Tool, ToolCall } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import { z } from "zod";
-import type { RiskLevel } from "../types.js";
 import { createToolError, createToolSuccess } from "../utils/messages.js";
 import { formatZodError } from "../utils/zod.js";
 import {
@@ -52,7 +51,6 @@ export function createEmitOutputToolDefinition(): ToolDefinition {
     schema: EMIT_OUTPUT_TOOL,
     async dispatch(
       toolCall: ToolCall,
-      _riskLevel: RiskLevel,
       _signal: AbortSignal,
       context: ToolDispatchContext,
     ): Promise<ToolDispatchResult> {

--- a/src/core/tools/grep.ts
+++ b/src/core/tools/grep.ts
@@ -1,7 +1,6 @@
 import type { Tool, ToolCall, ToolResultMessage } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import { z } from "zod";
-import type { RiskLevel } from "../types.js";
 import { createToolError, createToolResult } from "../utils/messages.js";
 import { buildHeadTailPreviewLines } from "../utils/tool_preview.js";
 import { TRUNCATION_MARKER, type TruncationResult, truncateForTokens } from "../utils/truncate.js";
@@ -232,7 +231,6 @@ export function createGrepToolDefinition(backend: ToolExecutionBackend): ToolDef
     schema: GREP_TOOL,
     async dispatch(
       toolCall: ToolCall,
-      _riskLevel: RiskLevel,
       signal?: AbortSignal,
     ): Promise<ToolDispatchResult | ToolDispatchResultWithPhases> {
       const parsedArgs = parseGrepArgs(toolCall.arguments);

--- a/src/core/tools/list.ts
+++ b/src/core/tools/list.ts
@@ -1,7 +1,6 @@
 import type { Tool, ToolCall, ToolResultMessage } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import { z } from "zod";
-import type { RiskLevel } from "../types.js";
 import { createToolError, createToolResult } from "../utils/messages.js";
 import { buildHeadTailPreviewLines } from "../utils/tool_preview.js";
 import { TRUNCATION_MARKER } from "../utils/truncate.js";
@@ -100,7 +99,7 @@ function buildListUiText(args: {
 export function createListToolDefinition(backend: ToolExecutionBackend): ToolDefinition {
   return {
     schema: LIST_TOOL,
-    async dispatch(toolCall: ToolCall, _riskLevel: RiskLevel): Promise<ToolDispatchResult> {
+    async dispatch(toolCall: ToolCall): Promise<ToolDispatchResult> {
       const parsedArgs = parseListArgs(toolCall.arguments);
       const path = parsedArgs.ok ? parsedArgs.data.path : "";
       const headerTarget = path || "(invalid arguments)";

--- a/src/core/tools/nook.ts
+++ b/src/core/tools/nook.ts
@@ -6,7 +6,6 @@ import {
   buildNookDeployManifestFromBackend,
   buildNookTemplateManifestFromBackend,
 } from "../nook/deploy.js";
-import type { RiskLevel } from "../types.js";
 import { createToolError, createToolSuccess } from "../utils/messages.js";
 import { buildHeadTailPreviewLines } from "../utils/tool_preview.js";
 import { formatZodError } from "../utils/zod.js";
@@ -27,7 +26,6 @@ const NOOK_DESCRIPTION = [
   "If the user asks to deploy a static artifact or mini-app, this is usually the right deployment target.",
   "When preparing site files for deployment, write the complete site directory under a fresh mktemp directory and deploy that directory; do not scatter generated site files into the project tree.",
   "Sites and templates can be copied to an existing empty destination directory. Edit/build copied files normally, then deploy a built static directory separately.",
-  "All operations require read-write risk.",
   "Input keys by operation: read_skill, list_sites, and list_templates need only operation; deploy_site and copy_site need site and directory, with public optional only for deploy_site; delete_site needs site; template copy/save/delete operations need template, and copy/save also need directory; get_kv and delete_kv need site and key; put_kv needs site, key, and value; list_kv needs site, with prefix optional.",
 ].join(" ");
 
@@ -181,22 +179,12 @@ export function createNookToolDefinition(backend: ToolExecutionBackend): ToolDef
     schema: NOOK_TOOL,
     async dispatch(
       toolCall: ToolCall,
-      riskLevel: RiskLevel,
       _signal: AbortSignal,
       context: ToolDispatchContext,
     ): Promise<ToolDispatchResult> {
       const parsed = nookArgsSchema.safeParse(toolCall.arguments);
       if (!parsed.success) {
         const message = `Invalid arguments: ${formatZodError(parsed.error)}`;
-        return {
-          kind: "single",
-          toolResult: createToolError(toolCall, message),
-          uiEvent: buildUiEvent(toolCall, "error", message),
-        };
-      }
-
-      if (riskLevel !== "read-write") {
-        const message = `Requires risk level 'read-write', but the current level is '${riskLevel}'. Ask the user to run /risk:read-write.`;
         return {
           kind: "single",
           toolResult: createToolError(toolCall, message),

--- a/src/core/tools/read.ts
+++ b/src/core/tools/read.ts
@@ -1,7 +1,6 @@
 import type { Tool, ToolCall, ToolResultMessage } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import { z } from "zod";
-import type { RiskLevel } from "../types.js";
 import { createToolError, createToolResult } from "../utils/messages.js";
 import { buildHeadTailPreviewLines } from "../utils/tool_preview.js";
 import {
@@ -135,7 +134,7 @@ function buildReadUiText(args: {
 export function createReadToolDefinition(backend: ToolExecutionBackend): ToolDefinition {
   return {
     schema: READ_TOOL,
-    async dispatch(toolCall: ToolCall, _riskLevel: RiskLevel): Promise<ToolDispatchResult> {
+    async dispatch(toolCall: ToolCall): Promise<ToolDispatchResult> {
       const parsedArgs = parseReadArgs(toolCall.arguments);
       const path = parsedArgs.ok ? parsedArgs.data.path : "";
       const headerTarget = path || "(invalid arguments)";

--- a/src/core/tools/registry.ts
+++ b/src/core/tools/registry.ts
@@ -3,7 +3,7 @@ import type { Config } from "../config/index.js";
 import type { ModelResolver } from "../models/catalog.js";
 import type { SubagentControlPlane } from "../subagents/control_plane.js";
 import type { SubagentName, SubagentStatus } from "../subagents/types.js";
-import type { Persona, RiskLevel } from "../types.js";
+import type { Persona } from "../types.js";
 import type { BashTruncationInfo } from "./bash.js";
 import type { ToolName } from "./tool_names.js";
 
@@ -323,7 +323,6 @@ export interface ToolDefinition {
   readonly schema: Tool;
   dispatch(
     toolCall: ToolCall,
-    riskLevel: RiskLevel,
     signal: AbortSignal,
     context: ToolDispatchContext,
   ): Promise<ToolDispatchResult | ToolDispatchResultWithPhases>;

--- a/src/core/tools/send_input_to_agent.ts
+++ b/src/core/tools/send_input_to_agent.ts
@@ -2,7 +2,6 @@ import type { Tool, ToolCall, ToolResultMessage } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import { z } from "zod";
 import type { SubagentStateSnapshot } from "../subagents/types.js";
-import type { RiskLevel } from "../types.js";
 import { createToolError, createToolResult } from "../utils/messages.js";
 import { parseToolArgs } from "../utils/zod.js";
 import type { ToolExecutionBackend } from "./execution_backend.js";
@@ -63,7 +62,6 @@ export function createSendInputToAgentToolDefinition(
     schema: SEND_INPUT_TO_AGENT_TOOL,
     async dispatch(
       toolCall: ToolCall,
-      _riskLevel: RiskLevel,
       signal: AbortSignal,
       context: ToolDispatchContext,
     ): Promise<ToolDispatchResult | ToolDispatchResultWithPhases> {

--- a/src/core/tools/spawn_agent.ts
+++ b/src/core/tools/spawn_agent.ts
@@ -9,7 +9,7 @@ import { composeSessionPrompts } from "../runtime/session_prompt_composer.js";
 import { parseSubagentLaunchModel } from "../subagents/launch_model.js";
 import { getSubagentDescription, resolveSubagentEffectiveSettings } from "../subagents/registry.js";
 import type { SubagentLaunchModel, SubagentRuntimeConfig } from "../subagents/types.js";
-import type { Persona, RiskLevel } from "../types.js";
+import type { Persona } from "../types.js";
 import { formatCwd } from "../utils/format.js";
 import { createToolError, createToolResult } from "../utils/messages.js";
 import { parseToolArgs } from "../utils/zod.js";
@@ -109,7 +109,6 @@ function formatAllowedLaunchModels(launchModels: string[]): string {
 async function buildSubagentSystemPrompt(args: {
   name: string;
   persona: Persona;
-  riskLevel: RiskLevel;
   config: ToolDispatchContext["config"];
   cwd: string;
   home: string;
@@ -147,7 +146,6 @@ async function buildSubagentSystemPrompt(args: {
 
   const composition = composeSessionPrompts({
     persona: args.persona,
-    riskLevel: args.riskLevel,
     cwd: args.cwd,
     datetime: new Date().toISOString(),
     platform: process.platform,
@@ -164,7 +162,6 @@ export function createSpawnAgentToolDefinition(backend: ToolExecutionBackend): T
     schema: SPAWN_AGENT_TOOL,
     async dispatch(
       toolCall: ToolCall,
-      riskLevel: RiskLevel,
       signal: AbortSignal,
       context: ToolDispatchContext,
     ): Promise<ToolDispatchResult | ToolDispatchResultWithPhases> {
@@ -270,7 +267,6 @@ export function createSpawnAgentToolDefinition(backend: ToolExecutionBackend): T
           systemPrompt = await buildSubagentSystemPrompt({
             name,
             persona,
-            riskLevel,
             config,
             cwd,
             home: baseHome,
@@ -298,7 +294,6 @@ export function createSpawnAgentToolDefinition(backend: ToolExecutionBackend): T
       const effectiveSettings = resolveSubagentEffectiveSettings({
         persona,
         config: personaConfig,
-        riskLevel,
         launchModel: launchModelOverride,
       });
       const runtimeConfig: SubagentRuntimeConfig = {

--- a/src/core/tools/terminate_agent.ts
+++ b/src/core/tools/terminate_agent.ts
@@ -2,7 +2,6 @@ import type { Tool, ToolCall } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import { z } from "zod";
 import type { SubagentResult } from "../subagents/control_plane.js";
-import type { RiskLevel } from "../types.js";
 import { createToolError, createToolResult } from "../utils/messages.js";
 import { parseToolArgs } from "../utils/zod.js";
 import {
@@ -79,7 +78,6 @@ export function createTerminateAgentToolDefinition(): ToolDefinition {
     schema: TERMINATE_AGENT_TOOL,
     async dispatch(
       toolCall: ToolCall,
-      _riskLevel: RiskLevel,
       signal: AbortSignal,
       context: ToolDispatchContext,
     ): Promise<ToolDispatchResult | ToolDispatchResultWithPhases> {

--- a/src/core/tools/view_image.ts
+++ b/src/core/tools/view_image.ts
@@ -3,7 +3,6 @@ import { fileTypeFromBuffer } from "file-type";
 import sharp from "sharp";
 import { Type } from "typebox";
 import { z } from "zod";
-import type { RiskLevel } from "../types.js";
 import { createToolError } from "../utils/messages.js";
 import { formatBytes } from "../utils/truncate.js";
 import { formatZodError } from "../utils/zod.js";
@@ -228,7 +227,7 @@ function buildViewImageUiText(args: { mimeType: string; fullText: string }): Too
 export function createViewImageToolDefinition(backend: ToolExecutionBackend): ToolDefinition {
   return {
     schema: VIEW_IMAGE_TOOL,
-    async dispatch(toolCall: ToolCall, _riskLevel: RiskLevel): Promise<ToolDispatchResult> {
+    async dispatch(toolCall: ToolCall): Promise<ToolDispatchResult> {
       const parsedArgs = parseViewImageArgs(toolCall.arguments);
       const path = parsedArgs.ok ? parsedArgs.data.path : "";
       const headerTarget = path || "(invalid arguments)";

--- a/src/core/tools/wait_for_agents.ts
+++ b/src/core/tools/wait_for_agents.ts
@@ -2,7 +2,6 @@ import type { Tool, ToolCall } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import { z } from "zod";
 import type { SubagentResult } from "../subagents/control_plane.js";
-import type { RiskLevel } from "../types.js";
 import { createToolError, createToolResult } from "../utils/messages.js";
 import { truncateForTokens } from "../utils/truncate.js";
 import { parseToolArgs } from "../utils/zod.js";
@@ -132,7 +131,6 @@ export function createWaitForAgentsToolDefinition(): ToolDefinition {
     schema: WAIT_FOR_AGENTS_TOOL,
     async dispatch(
       toolCall: ToolCall,
-      _riskLevel: RiskLevel,
       signal: AbortSignal,
       context: ToolDispatchContext,
     ): Promise<ToolDispatchResult | ToolDispatchResultWithPhases> {

--- a/src/core/tools/web_fetch.ts
+++ b/src/core/tools/web_fetch.ts
@@ -3,7 +3,6 @@ import { Type } from "typebox";
 import { z } from "zod";
 import type { Config } from "../config/index.js";
 import { getParallelApiKey } from "../config/index.js";
-import type { RiskLevel } from "../types.js";
 import { createToolError, createToolResult } from "../utils/messages.js";
 import {
   extractParallelErrorMessage,
@@ -206,7 +205,6 @@ export function createWebFetchToolDefinition(config: Config): ToolDefinition {
     schema: WEB_FETCH_TOOL,
     async dispatch(
       toolCall: ToolCall,
-      _riskLevel: RiskLevel,
       signal?: AbortSignal,
     ): Promise<ToolDispatchResult | ToolDispatchResultWithPhases> {
       const parsedArgs = parseArgs(toolCall.arguments);

--- a/src/core/tools/web_search.ts
+++ b/src/core/tools/web_search.ts
@@ -3,7 +3,6 @@ import { Type } from "typebox";
 import { z } from "zod";
 import type { Config } from "../config/index.js";
 import { getParallelApiKey } from "../config/index.js";
-import type { RiskLevel } from "../types.js";
 import { createToolError, createToolResult } from "../utils/messages.js";
 import {
   extractParallelErrorMessage,
@@ -178,7 +177,6 @@ export function createWebSearchToolDefinition(config: Config): ToolDefinition {
     schema: WEB_SEARCH_TOOL,
     async dispatch(
       toolCall: ToolCall,
-      _riskLevel: RiskLevel,
       signal?: AbortSignal,
     ): Promise<ToolDispatchResult | ToolDispatchResultWithPhases> {
       const parsedArgs = parseArgs(toolCall.arguments);

--- a/src/core/tools/write.ts
+++ b/src/core/tools/write.ts
@@ -1,7 +1,6 @@
 import type { Tool, ToolCall } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import { z } from "zod";
-import type { RiskLevel } from "../types.js";
 import { createToolError, createToolSuccess } from "../utils/messages.js";
 import { formatTokenEstimate } from "../utils/token.js";
 import {
@@ -95,7 +94,7 @@ function buildWriteUiText(args: {
 export function createWriteToolDefinition(backend: ToolExecutionBackend): ToolDefinition {
   return {
     schema: WRITE_TOOL,
-    async dispatch(toolCall: ToolCall, riskLevel: RiskLevel): Promise<ToolDispatchResult> {
+    async dispatch(toolCall: ToolCall): Promise<ToolDispatchResult> {
       const parsedArgs = parseWriteArgs(toolCall.arguments);
       const path = parsedArgs.ok ? parsedArgs.data.path : "";
       const headerTarget = path || "(invalid arguments)";
@@ -117,12 +116,6 @@ export function createWriteToolDefinition(backend: ToolExecutionBackend): ToolDe
       }
 
       const { content } = parsedArgs.data;
-
-      if (riskLevel !== "read-write") {
-        return blocked(
-          `Requires risk level 'read-write', but the current level is '${riskLevel}'. Ask the user to run /risk:read-write.`,
-        );
-      }
 
       try {
         const { bytes, lines } = await backend.writeFile(path, content);

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -3,9 +3,6 @@ import { z } from "zod";
 import type { SubagentConfigMap } from "./subagents/types.js";
 import type { ToolName } from "./tools/tool_names.js";
 
-export const RiskLevelSchema = z.enum(["read-only", "read-write"]);
-export type RiskLevel = z.infer<typeof RiskLevelSchema>;
-
 export type ReasoningEffort = ThinkingLevel | "none";
 export type ServiceTier = "priority" | "flex";
 

--- a/src/core/utils/context.ts
+++ b/src/core/utils/context.ts
@@ -9,6 +9,4 @@ export {
   buildEnvironmentTag,
   buildProjectContextBlock,
   buildSkillsIndexBlock,
-  describeRiskLevel,
-  formatRiskLevelChangeNotice,
 } from "./context_builder.js";

--- a/src/core/utils/context_builder.ts
+++ b/src/core/utils/context_builder.ts
@@ -1,6 +1,5 @@
-import type { RiskLevel, Skill } from "../types.js";
+import type { Skill } from "../types.js";
 import { findAgentsFilesInScope, findChildAgentsFiles } from "./agents_files.js";
-import { formatTauHiddenSystemBlock } from "./user_metadata.js";
 
 function escapeXml(value: string): string {
   return value
@@ -121,24 +120,13 @@ export function buildProjectContextBlock(args: {
   return out.trim() ? out : undefined;
 }
 
-export function describeRiskLevel(level: RiskLevel): string {
-  switch (level) {
-    case "read-only":
-      return "Model may use tools in read-only mode; bash safetyLevel must be 'read' and write/edit tools are blocked.";
-    case "read-write":
-      return "Model may use all tools and bash for read or write commands (safetyLevel='read' or 'write').";
-  }
-}
-
 export function buildEnvironmentTag(args: {
   datetime: string;
   cwd: string;
   repoRoot?: string;
-  riskLevel: RiskLevel;
   platform: NodeJS.Platform;
   nodeVersion: string;
 }): string {
-  const riskDesc = describeRiskLevel(args.riskLevel);
   const nodeVersion = args.nodeVersion;
   const platform = args.platform;
   const lines = [
@@ -152,19 +140,10 @@ export function buildEnvironmentTag(args: {
   }
 
   lines.push(
-    `  <risk-level level="${args.riskLevel}">${riskDesc}</risk-level>`,
     `  <node>${nodeVersion}</node>`,
     `  <platform>${platform}</platform>`,
-    "  <notes>This environment tag reflects the current session environment. If the user changes risk level, you will be informed in a <system> tag at the start of the next user message.</notes>",
     "</environment>",
   );
 
   return lines.join("\n");
-}
-
-export function formatRiskLevelChangeNotice(change: { from: RiskLevel; to: RiskLevel }): string {
-  const toDesc = describeRiskLevel(change.to);
-  return formatTauHiddenSystemBlock(
-    `Risk level changed by user from '${change.from}' to '${change.to}'. ${toDesc} This overrides the initial risk level described in the system prompt.`,
-  );
 }

--- a/src/core/utils/user_metadata.ts
+++ b/src/core/utils/user_metadata.ts
@@ -99,20 +99,6 @@ function parseMetadataRecord(value: unknown): TauUserMetadata {
   }
 }
 
-function assertMetadataKeys(
-  record: Record<string, unknown>,
-  expectedKeys: readonly string[],
-): void {
-  const expected = new Set(expectedKeys);
-  const unknownKeys = Object.keys(record).filter((key) => !expected.has(key));
-  if (unknownKeys.length > 0) {
-    const keyLabel = unknownKeys.length === 1 ? "key" : "keys";
-    throw new Error(
-      `invalid tau user metadata: unknown ${keyLabel}: ${unknownKeys.sort().join(", ")}`,
-    );
-  }
-}
-
 function parsePreservedUserMessages(value: unknown): TauPreservedUserMessage[] {
   if (!Array.isArray(value)) {
     throw new Error("invalid tau user metadata: preserved user messages must be an array");
@@ -127,7 +113,6 @@ function parsePreservedUserMessages(value: unknown): TauPreservedUserMessage[] {
     }
 
     const record = item as Record<string, unknown>;
-    assertMetadataKeys(record, ["id", "text"]);
     if (typeof record.id !== "string" || record.id.trim() === "") {
       throw new Error(
         `invalid tau user metadata: preserved user message ${index} id must be a non-empty string`,
@@ -150,7 +135,6 @@ function parsePreservedUserMessages(value: unknown): TauPreservedUserMessage[] {
 }
 
 function parseCompactionMetadataRecord(record: Record<string, unknown>): TauCompactionUserMetadata {
-  assertMetadataKeys(record, ["type", "version", "summary", "preservedUserMessages"]);
   if (record.version !== 1) {
     throw new Error("invalid tau user metadata: unsupported compaction metadata version");
   }
@@ -168,14 +152,6 @@ function parseCompactionMetadataRecord(record: Record<string, unknown>): TauComp
 function parseAutoCompactionMetadataRecord(
   record: Record<string, unknown>,
 ): TauAutoCompactionUserMetadata {
-  assertMetadataKeys(record, [
-    "type",
-    "version",
-    "summary",
-    "preservedUserMessages",
-    "cutType",
-    "retainedMessageCount",
-  ]);
   if (record.version !== 1) {
     throw new Error("invalid tau user metadata: unsupported auto-compaction metadata version");
   }
@@ -209,7 +185,6 @@ function parseAutoCompactionMetadataRecord(
 function parseAutoCompactionContinuationMetadataRecord(
   record: Record<string, unknown>,
 ): TauAutoCompactionContinuationUserMetadata {
-  assertMetadataKeys(record, ["type", "version"]);
   if (record.version !== 1) {
     throw new Error(
       "invalid tau user metadata: unsupported auto-compaction continuation metadata version",

--- a/src/host/client_tool_broker.ts
+++ b/src/host/client_tool_broker.ts
@@ -7,7 +7,6 @@ import type {
   ToolUiEvent,
   ToolUiText,
 } from "../core/tools/registry.js";
-import type { RiskLevel } from "../core/types.js";
 import { createToolError, createToolResult } from "../core/utils/messages.js";
 import { formatTokenEstimate } from "../core/utils/token.js";
 import { buildHeadTailPreviewLines } from "../core/utils/tool_preview.js";
@@ -363,7 +362,6 @@ function createClientToolDefinition(
     schema,
     async dispatch(
       toolCall: ToolCall,
-      _riskLevel: RiskLevel,
       signal: AbortSignal,
       _context: ToolDispatchContext,
     ): Promise<ToolDispatchResult> {

--- a/src/host/hosted_ephemeral_agent_session.ts
+++ b/src/host/hosted_ephemeral_agent_session.ts
@@ -18,7 +18,6 @@ import {
 } from "../core/utils/subagent_utils.js";
 import type { ExecutionEnvironment } from "../execution/execution_environment.js";
 import type {
-  SessionProtocolEphemeralCreateParams,
   SessionProtocolEphemeralMessage,
   SessionProtocolEphemeralSubmitParams,
   SessionProtocolEphemeralSubmitResult,
@@ -53,7 +52,6 @@ export type HostedEphemeralAgentSessionOptions = {
   executionEnvironment: ExecutionEnvironment;
   instructions: string;
   tools: SubagentToolName[];
-  riskLevel: SessionProtocolEphemeralCreateParams["riskLevel"];
   emitUpdate: (
     threadId: string,
     update: SessionProtocolEphemeralMessage["event"]["update"],
@@ -74,7 +72,6 @@ export class HostedEphemeralAgentSession {
   private readonly executionEnvironment: ExecutionEnvironment;
   private readonly instructions: string;
   private readonly tools: SubagentToolName[];
-  private readonly riskLevel: SessionProtocolEphemeralCreateParams["riskLevel"];
   private readonly emitUpdate: HostedEphemeralAgentSessionOptions["emitUpdate"];
   private readonly threads = new Map<string, HostedEphemeralAgentThreadRecord>();
   private disposed = false;
@@ -88,7 +85,6 @@ export class HostedEphemeralAgentSession {
     this.executionEnvironment = options.executionEnvironment;
     this.instructions = options.instructions;
     this.tools = [...options.tools];
-    this.riskLevel = options.riskLevel;
     this.emitUpdate = options.emitUpdate;
   }
 
@@ -162,7 +158,6 @@ export class HostedEphemeralAgentSession {
     const promptContext = runtimeContext.promptBootstrap.promptContext;
     const promptComposition = composeSessionPrompts({
       persona: this.persona,
-      riskLevel: this.riskLevel,
       cwd: promptContext.cwd,
       datetime: new Date(deps.clock.now()).toISOString(),
       platform: deps.env.platform(),
@@ -180,7 +175,6 @@ export class HostedEphemeralAgentSession {
       deps,
       backend: this.executionEnvironment.getToolExecutionBackend(),
       tools: this.tools,
-      riskLevel: this.riskLevel,
       cwd: promptContext.cwd,
       home: promptContext.home ?? deps.env.home(),
       includeAgentContext: promptContext.includeAgentContext ?? this.includeAgentContext,
@@ -205,7 +199,6 @@ type EphemeralAgentThreadOptions = {
   deps: ReturnType<typeof createDefaultCoreDeps>;
   backend: ToolExecutionBackend;
   tools: SubagentToolName[];
-  riskLevel: SessionProtocolEphemeralCreateParams["riskLevel"];
   cwd: string;
   home: string;
   includeAgentContext: boolean;
@@ -242,7 +235,6 @@ class EphemeralAgentThread {
       persona,
       systemPrompt,
       subagentPrompts: options.subagentPrompts,
-      riskLevel: options.riskLevel,
       toolRegistry: ToolCatalog.createSubagentRegistry(
         options.tools,
         options.config,

--- a/src/host/local_session_host.ts
+++ b/src/host/local_session_host.ts
@@ -10,7 +10,7 @@ import type { SessionPromptComposition } from "../core/runtime/session_prompt_co
 import type { CoreSession } from "../core/session/core_session.js";
 import type { SubagentUiEvent } from "../core/subagents/types.js";
 import type { ToolUiEvent } from "../core/tools/registry.js";
-import type { Persona, ReasoningEffort, RiskLevel, Skill } from "../core/types.js";
+import type { Persona, ReasoningEffort, Skill } from "../core/types.js";
 import {
   filterProjectPathAutocompleteEntries,
   loadProjectPathAutocompleteEntriesWithBackend,
@@ -75,7 +75,6 @@ const PATH_AUTOCOMPLETE_CACHE_TTL_MS = 5_000;
 
 export type LocalSessionHostSessionOptions = {
   persona: Persona;
-  riskLevel: RiskLevel;
   discoveredSkills: Skill[];
   personas: Persona[];
   prompts: PromptTemplate[];
@@ -93,7 +92,6 @@ export type LocalSessionHostOptions = LocalSessionHostSessionOptions & {
 
 export type LocalSessionResolvedBootstrap = {
   persona: Persona;
-  riskLevel: RiskLevel;
   discoveredSkills: Skill[];
   personas: Persona[];
   prompts: PromptTemplate[];
@@ -271,7 +269,6 @@ export class LocalSessionHost implements TauSessionHost {
   ): LocalHostedSessionHandle {
     const runtime = ChatRuntime.create({
       persona: bootstrap.persona,
-      riskLevel: bootstrap.riskLevel,
       toolRegistry: runtimeContext.toolRegistry,
       clientToolDefinitions: (sessionId) => this.clientToolBroker.getToolDefinitions(sessionId),
       promptContext: runtimeContext.promptBootstrap.promptContext,
@@ -326,7 +323,6 @@ export class LocalSessionHost implements TauSessionHost {
     if (snapshot.settings.serviceTier !== undefined) {
       bootstrap.persona.settings.serviceTier = snapshot.settings.serviceTier;
     }
-    bootstrap.riskLevel = snapshot.settings.riskLevel;
     return bootstrap;
   }
 
@@ -348,16 +344,11 @@ export class LocalSessionHost implements TauSessionHost {
     if (createParams.reasoning !== undefined) {
       bootstrap.persona.settings.reasoning = createParams.reasoning;
     }
-
-    if (createParams.riskLevel !== undefined) {
-      bootstrap.riskLevel = createParams.riskLevel;
-    }
   }
 
   private defaultSessionBootstrap(): LocalSessionResolvedBootstrap {
     return cloneResolvedBootstrap({
       persona: this.sessionOptions.persona,
-      riskLevel: this.sessionOptions.riskLevel,
       discoveredSkills: this.sessionOptions.discoveredSkills,
       personas: this.sessionOptions.personas,
       prompts: this.sessionOptions.prompts,
@@ -670,14 +661,6 @@ class LocalHostedSessionHandle implements LocalHostedSession {
     });
   }
 
-  async setRiskLevel(level: RiskLevel): Promise<SessionProtocolSnapshot> {
-    this.assertActive();
-    this.runtime.setRiskLevel(level);
-    const snapshot = await this.commitSnapshot();
-    this.emitSnapshotReset("configuration", snapshot);
-    return snapshot;
-  }
-
   async setReasoning(reasoning: ReasoningEffort): Promise<SessionProtocolSettingsUpdateResult> {
     this.assertActive();
     const fromRevision = this.committedSnapshot?.revision;
@@ -729,7 +712,6 @@ class LocalHostedSessionHandle implements LocalHostedSession {
     });
     this.bootstrap = {
       persona: clonePersona(selectedPersona),
-      riskLevel: this.runtime.currentRiskLevel,
       discoveredSkills: structuredClone(runtimeConfig.skills),
       personas: personas.map(clonePersona),
       prompts: structuredClone(runtimeConfig.prompts),
@@ -768,7 +750,6 @@ class LocalHostedSessionHandle implements LocalHostedSession {
     });
     this.bootstrap = {
       persona: clonePersona(nextPersona),
-      riskLevel: this.runtime.currentRiskLevel,
       discoveredSkills: structuredClone(runtimeConfig.skills),
       personas: personas.map(clonePersona),
       prompts: structuredClone(runtimeConfig.prompts),
@@ -928,7 +909,6 @@ class LocalHostedSessionHandle implements LocalHostedSession {
       executionEnvironment: this.executionEnvironment,
       instructions: options.instructions,
       tools: options.tools,
-      riskLevel: options.riskLevel,
       emitUpdate: (threadId, update) => {
         this.emitEphemeral(
           createSessionProtocolEphemeralMessage({
@@ -1091,7 +1071,6 @@ class LocalHostedSessionHandle implements LocalHostedSession {
       costTotal: this.costTotal,
       settings: {
         personaId: this.runtime.persona.id,
-        riskLevel: this.runtime.currentRiskLevel,
         ...(this.runtime.persona.settings.reasoning !== undefined
           ? { reasoning: this.runtime.persona.settings.reasoning }
           : {}),
@@ -1929,7 +1908,6 @@ function cloneResolvedBootstrap(
 ): LocalSessionResolvedBootstrap {
   return {
     persona: clonePersona(bootstrap.persona),
-    riskLevel: bootstrap.riskLevel,
     discoveredSkills: structuredClone(bootstrap.discoveredSkills),
     personas: bootstrap.personas.map(clonePersona),
     prompts: structuredClone(bootstrap.prompts),
@@ -2007,7 +1985,6 @@ function subagentSnapshotsFromConfig(
     snapshots[name] = {
       ...(config.description !== undefined ? { description: config.description } : {}),
       ...(config.tools ? { tools: [...config.tools] } : {}),
-      ...(config.riskLevel !== undefined ? { riskLevel: config.riskLevel } : {}),
       ...(config.launchModels ? { launchModels: [...config.launchModels] } : {}),
     };
   }

--- a/src/host/session_host.ts
+++ b/src/host/session_host.ts
@@ -29,7 +29,6 @@ import type {
   SessionProtocolSessionSummary,
   SessionProtocolSetPersonaParams,
   SessionProtocolSetReasoningParams,
-  SessionProtocolSetRiskParams,
   SessionProtocolSettingsUpdateResult,
   SessionProtocolSnapshot,
   SessionProtocolTerminateSubagentResult,
@@ -54,7 +53,6 @@ export type TauHostedSession = {
       signal?: AbortSignal;
     },
   ): Promise<SessionProtocolExecResult>;
-  setRiskLevel(level: SessionProtocolSetRiskParams["riskLevel"]): Promise<SessionProtocolSnapshot>;
   setReasoning(
     reasoning: SessionProtocolSetReasoningParams["reasoning"],
   ): Promise<SessionProtocolSettingsUpdateResult>;

--- a/src/host/session_protocol_handler.ts
+++ b/src/host/session_protocol_handler.ts
@@ -141,7 +141,6 @@ type SessionProtocolMutationRequest = Extract<
   {
     method:
       | "session.record"
-      | "session.setRisk"
       | "session.setPersona"
       | "session.reload"
       | "session.compact"
@@ -219,9 +218,6 @@ export class SessionProtocolHandler {
           return;
         case "session.snapshot":
           await this.handleSnapshot(request);
-          return;
-        case "session.setRisk":
-          await this.handleSetRisk(request);
           return;
         case "session.setReasoning":
           await this.handleSetReasoning(request);
@@ -1090,17 +1086,6 @@ export class SessionProtocolHandler {
     );
   }
 
-  private async handleSetRisk(
-    request: Extract<SessionProtocolRequestMessage, { method: "session.setRisk" }>,
-  ): Promise<void> {
-    await this.withSessionMutation(request, "session risk level changed", async (state) => {
-      const snapshot = await state.session.setRiskLevel(request.params.riskLevel);
-      this.sendMessage(
-        createSessionProtocolSuccessResponse(request.id, "session.setRisk", snapshot),
-      );
-    });
-  }
-
   private async handleSetReasoning(
     request: Extract<SessionProtocolRequestMessage, { method: "session.setReasoning" }>,
   ): Promise<void> {
@@ -1228,7 +1213,6 @@ export class SessionProtocolHandler {
       const result = await mutationState.session.createEphemeralContext({
         instructions: request.params.instructions,
         tools: request.params.tools,
-        riskLevel: request.params.riskLevel,
       });
       this.sendMessage(
         createSessionProtocolSuccessResponse(request.id, "session.ephemeral.create", result),

--- a/src/main.ts
+++ b/src/main.ts
@@ -442,8 +442,9 @@ function printServeHelp(): void {
       "  --auth-token <token> require tau attach / SDK websocket clients to provide this token.",
       "  --help, -h           show this help and exit.",
       "",
-      "",
       "examples:",
+      "  tau serve",
+      "  tau serve --host 0.0.0.0 --port 8787 --auth-token $TAU_WS_AUTH_TOKEN",
     ].join("\n"),
   );
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,6 @@ import type {
   Persona,
   PromptTemplate,
   ReasoningEffort,
-  RiskLevel,
   RuntimeBootstrap,
   Skill,
   ThemeDefinition,
@@ -422,9 +421,6 @@ function printAttachHelp(): void {
       "  tau attach --new --execution-kind cloudflare-sandbox --cloudflare-bridge default --cloudflare-sandbox sandbox-1 --cwd /workspace/repo ws://127.0.0.1:8787",
       "  tau attach --new --execution-kind fly-sprite --fly-api default --fly-sprite sprite-1 --cwd /home/sprite/repo ws://127.0.0.1:8787",
       "  tau attach --session 0195d6e4-4cf9-7f44-a2d8-f8f7f49ee9d3 --auth-token $TAU_WS_AUTH_TOKEN ws://vps:8787",
-      "  tau attach -- tau rpc --risk read-only",
-      "  tau attach --new --cwd /repo -- tau rpc --risk read-only",
-      "  tau attach --session 0195d6e4-4cf9-7f44-a2d8-f8f7f49ee9d3 -- ssh vps 'cd /repo && tau rpc --risk read-only'",
       "",
       "without --session or --new, attach lists hosted sessions and prompts for a selection.",
       "stdio commands and websocket servers both speak Tau's session protocol.",
@@ -446,11 +442,8 @@ function printServeHelp(): void {
       "  --auth-token <token> require tau attach / SDK websocket clients to provide this token.",
       "  --help, -h           show this help and exit.",
       "",
-      "tau session options such as --risk and --persona are accepted too.",
       "",
       "examples:",
-      "  tau serve --risk read-only",
-      "  tau serve --host 0.0.0.0 --port 8787 --auth-token $TAU_WS_AUTH_TOKEN --risk read-only",
     ].join("\n"),
   );
 }
@@ -497,7 +490,6 @@ async function resolveHostedSessionBootstrap(options: {
   cwd: string;
 }): Promise<{
   persona: Persona;
-  riskLevel: RiskLevel;
   discoveredSkills: Skill[];
   personas: Persona[];
   prompts: RuntimeConfigResult["prompts"];
@@ -539,7 +531,6 @@ async function resolveHostedSessionBootstrap(options: {
 
   return {
     persona,
-    riskLevel: options.cli.riskLevel ?? runtime.config.defaultRisk ?? "read-only",
     discoveredSkills: runtime.skills,
     personas: runtime.personas.map(clonePersonaForSession),
     prompts: runtime.prompts,
@@ -551,7 +542,6 @@ function createLocalSessionHost(options: {
   cli: CliOptions;
   config: Config;
   persona: Persona;
-  riskLevel: RiskLevel;
   skills: Skill[];
 }): LocalSessionHost {
   const deps = createDefaultCoreDeps();
@@ -584,7 +574,6 @@ function createLocalSessionHost(options: {
   return new LocalSessionHost({
     store: new FileSessionStore({ directory: getDefaultSessionStoreDirectory(home) }),
     persona,
-    riskLevel: options.riskLevel,
     discoveredSkills: options.skills,
     personas: [persona],
     prompts: [],
@@ -613,7 +602,6 @@ async function runRpcMode(options: {
   cli: CliOptions;
   config: Config;
   persona: Persona;
-  riskLevel: RiskLevel;
   skills: Skill[];
 }): Promise<void> {
   const sessionHost = createLocalSessionHost(options);
@@ -1051,8 +1039,6 @@ if (cli.personaId) {
   }
 }
 
-const initialRiskLevel = cli.riskLevel ?? config.defaultRisk;
-
 if (cli.debug) {
   let debugPersona: Persona | undefined;
   if (personas.length > 0) {
@@ -1066,7 +1052,6 @@ if (cli.debug) {
     }
   }
 
-  const debugRiskLevel = initialRiskLevel;
   const virtualBundle = runtimeBootstrap?.virtualBundle;
   const debugToolRegistry = ToolCatalog.createRegistry(createLocalToolExecutionBackend());
   printDebugInfo({
@@ -1076,7 +1061,6 @@ if (cli.debug) {
     virtualBundle,
     selectedPersona: debugPersona,
     noAgentContextFiles: cli.noAgentContextFiles,
-    riskLevel: debugRiskLevel,
     toolRegistry: debugToolRegistry,
   });
   process.exit(0);
@@ -1099,14 +1083,11 @@ if (reasoningOverride !== undefined) {
   initialPersona.settings.reasoning = reasoningOverride;
 }
 
-const effectiveRiskLevel: RiskLevel = initialRiskLevel ?? "read-only";
-
 if (isServeSubcommand) {
   const sessionHost = createLocalSessionHost({
     cli,
     config,
     persona: initialPersona,
-    riskLevel: effectiveRiskLevel,
     skills,
   });
 
@@ -1150,7 +1131,6 @@ if (isRpcSubcommand) {
       cli,
       config,
       persona: initialPersona,
-      riskLevel: effectiveRiskLevel,
       skills,
     });
     process.exit(0);
@@ -1175,7 +1155,6 @@ const sessionClient = await createTauSdkClient({
   cwd,
   persona: initialPersonaId,
   reasoning: reasoningOverride,
-  riskLevel: effectiveRiskLevel,
   noAgentContextFiles: cli.noAgentContextFiles,
   initialize: { client: { name: "tau-tui", version: "1" } },
   clientTools: createTuiClientTools({ getController: () => sessionChatApp?.getController() }),
@@ -1188,7 +1167,6 @@ const app = await SessionChatApp.open({
     input: {
       executionEnvironment: { kind: "local", cwd },
       ...(initialPersonaId !== undefined ? { personaId: initialPersonaId } : {}),
-      riskLevel: effectiveRiskLevel,
       ...(reasoningOverride !== undefined ? { reasoning: reasoningOverride } : {}),
     },
   },

--- a/src/nook/README.md
+++ b/src/nook/README.md
@@ -120,4 +120,4 @@ tau nook kv delete demo settings
 tau nook kv list demo --prefix todos/
 ```
 
-The assistant-facing model tool named `nook` appears automatically when Tau config contains `nook`. All tool operations require `read-write` risk.
+The assistant-facing model tool named `nook` appears automatically when Tau config contains `nook`. Enabled operations execute directly.

--- a/src/protocol/index.ts
+++ b/src/protocol/index.ts
@@ -99,7 +99,6 @@ export type {
   SessionProtocolSessionSummary,
   SessionProtocolSetPersonaParams,
   SessionProtocolSetReasoningParams,
-  SessionProtocolSetRiskParams,
   SessionProtocolSettingsSnapshot,
   SessionProtocolSkillSnapshot,
   SessionProtocolSnapshot,

--- a/src/protocol/session_protocol.ts
+++ b/src/protocol/session_protocol.ts
@@ -2484,17 +2484,6 @@ export function parseSessionProtocolRequestLine(line: string): SessionProtocolPa
       };
     }
 
-    if (hasIssue(requestEnvelope.error, [], "unrecognized_keys")) {
-      return {
-        ok: false,
-        id: requestId,
-        error: createSessionProtocolError(
-          SESSION_PROTOCOL_ERROR_CODES.invalidRequest,
-          "request contains unsupported top-level fields",
-        ),
-      };
-    }
-
     if (hasIssue(requestEnvelope.error, ["version"])) {
       const parsedVersionField = sessionProtocolVersionFieldSchema.safeParse(parsed);
       const version = parsedVersionField.success ? parsedVersionField.data.version : undefined;
@@ -2981,11 +2970,9 @@ function validateSessionIdParams<
   if (!parsed.success) {
     const message = hasIssue(parsed.error, [], "invalid_type")
       ? `${method} params must be an object`
-      : hasIssue(parsed.error, [], "unrecognized_keys")
-        ? `${method} params only support sessionId`
-        : hasIssue(parsed.error, ["sessionId"])
-          ? `${method} params.sessionId must be a non-empty string`
-          : `${method} params are invalid: ${formatZodError(parsed.error)}`;
+      : hasIssue(parsed.error, ["sessionId"])
+        ? `${method} params.sessionId must be a non-empty string`
+        : `${method} params are invalid: ${formatZodError(parsed.error)}`;
     return invalidParams(message);
   }
 
@@ -3004,7 +2991,7 @@ function validateInitializeParams(
   if (!parsed.success) {
     const message = hasIssue(parsed.error, [], "invalid_type")
       ? "initialize params must be an object with client metadata"
-      : hasIssue(parsed.error, ["client"]) || hasIssue(parsed.error, [], "unrecognized_keys")
+      : hasIssue(parsed.error, ["client"])
         ? "initialize.client must be an object with name/version strings and optional tools"
         : hasIssue(parsed.error, ["client", "name"])
           ? "initialize.client.name must be a non-empty string"
@@ -3034,15 +3021,13 @@ function validateUserMessageParams(
   if (!parsed.success) {
     const message = hasIssue(parsed.error, [], "invalid_type")
       ? `${method} params must be an object`
-      : hasIssue(parsed.error, [], "unrecognized_keys")
-        ? `${method} params only support sessionId, text, and optional historyEntryId`
-        : hasIssue(parsed.error, ["sessionId"])
-          ? `${method} params.sessionId must be a non-empty string`
-          : hasIssue(parsed.error, ["text"])
-            ? `${method} params.text must be a string`
-            : hasIssue(parsed.error, ["historyEntryId"])
-              ? `${method} params.historyEntryId must be a non-empty string when provided`
-              : `${method} params are invalid: ${formatZodError(parsed.error)}`;
+      : hasIssue(parsed.error, ["sessionId"])
+        ? `${method} params.sessionId must be a non-empty string`
+        : hasIssue(parsed.error, ["text"])
+          ? `${method} params.text must be a string`
+          : hasIssue(parsed.error, ["historyEntryId"])
+            ? `${method} params.historyEntryId must be a non-empty string when provided`
+            : `${method} params are invalid: ${formatZodError(parsed.error)}`;
     return invalidParams(message);
   }
 
@@ -3065,15 +3050,13 @@ function validateRecordParams(
   if (!parsed.success) {
     const message = hasIssue(parsed.error, [], "invalid_type")
       ? "session.record params must be an object"
-      : hasIssue(parsed.error, [], "unrecognized_keys")
-        ? "session.record params only support sessionId, text, and optional historyEntryId"
-        : hasIssue(parsed.error, ["sessionId"])
-          ? "session.record params.sessionId must be a non-empty string"
-          : hasIssue(parsed.error, ["text"])
-            ? "session.record params.text must be a string"
-            : hasIssue(parsed.error, ["historyEntryId"])
-              ? "session.record params.historyEntryId must be a non-empty string when provided"
-              : `session.record params are invalid: ${formatZodError(parsed.error)}`;
+      : hasIssue(parsed.error, ["sessionId"])
+        ? "session.record params.sessionId must be a non-empty string"
+        : hasIssue(parsed.error, ["text"])
+          ? "session.record params.text must be a string"
+          : hasIssue(parsed.error, ["historyEntryId"])
+            ? "session.record params.historyEntryId must be a non-empty string when provided"
+            : `session.record params are invalid: ${formatZodError(parsed.error)}`;
     return invalidParams(message);
   }
 
@@ -3096,17 +3079,15 @@ function validateExecParams(
   if (!parsed.success) {
     const message = hasIssue(parsed.error, [], "invalid_type")
       ? "session.exec params must be an object"
-      : hasIssue(parsed.error, [], "unrecognized_keys")
-        ? "session.exec params only support sessionId, command, optional cwd, and optional timeoutMs"
-        : hasIssue(parsed.error, ["sessionId"])
-          ? "session.exec params.sessionId must be a non-empty string"
-          : hasIssue(parsed.error, ["command"])
-            ? "session.exec params.command must be a non-empty string"
-            : hasIssue(parsed.error, ["cwd"])
-              ? "session.exec params.cwd must be a non-empty string when provided"
-              : hasIssue(parsed.error, ["timeoutMs"])
-                ? "session.exec params.timeoutMs must be a positive integer when provided"
-                : `session.exec params are invalid: ${formatZodError(parsed.error)}`;
+      : hasIssue(parsed.error, ["sessionId"])
+        ? "session.exec params.sessionId must be a non-empty string"
+        : hasIssue(parsed.error, ["command"])
+          ? "session.exec params.command must be a non-empty string"
+          : hasIssue(parsed.error, ["cwd"])
+            ? "session.exec params.cwd must be a non-empty string when provided"
+            : hasIssue(parsed.error, ["timeoutMs"])
+              ? "session.exec params.timeoutMs must be a positive integer when provided"
+              : `session.exec params are invalid: ${formatZodError(parsed.error)}`;
     return invalidParams(message);
   }
 
@@ -3128,13 +3109,11 @@ function validateSetReasoningParams(
   if (!parsed.success) {
     const message = hasIssue(parsed.error, [], "invalid_type")
       ? "session.setReasoning params must be an object"
-      : hasIssue(parsed.error, [], "unrecognized_keys")
-        ? "session.setReasoning params only support sessionId and reasoning"
-        : hasIssue(parsed.error, ["sessionId"])
-          ? "session.setReasoning params.sessionId must be a non-empty string"
-          : hasIssue(parsed.error, ["reasoning"])
-            ? "session.setReasoning params.reasoning must be one of none, minimal, low, medium, high, xhigh, or max"
-            : `session.setReasoning params are invalid: ${formatZodError(parsed.error)}`;
+      : hasIssue(parsed.error, ["sessionId"])
+        ? "session.setReasoning params.sessionId must be a non-empty string"
+        : hasIssue(parsed.error, ["reasoning"])
+          ? "session.setReasoning params.reasoning must be one of none, minimal, low, medium, high, xhigh, or max"
+          : `session.setReasoning params are invalid: ${formatZodError(parsed.error)}`;
     return invalidParams(message);
   }
 
@@ -3154,13 +3133,11 @@ function validateSetPersonaParams(
   if (!parsed.success) {
     const message = hasIssue(parsed.error, [], "invalid_type")
       ? "session.setPersona params must be an object"
-      : hasIssue(parsed.error, [], "unrecognized_keys")
-        ? "session.setPersona params only support sessionId and personaId"
-        : hasIssue(parsed.error, ["sessionId"])
-          ? "session.setPersona params.sessionId must be a non-empty string"
-          : hasIssue(parsed.error, ["personaId"])
-            ? "session.setPersona params.personaId must be a non-empty string"
-            : `session.setPersona params are invalid: ${formatZodError(parsed.error)}`;
+      : hasIssue(parsed.error, ["sessionId"])
+        ? "session.setPersona params.sessionId must be a non-empty string"
+        : hasIssue(parsed.error, ["personaId"])
+          ? "session.setPersona params.personaId must be a non-empty string"
+          : `session.setPersona params are invalid: ${formatZodError(parsed.error)}`;
     return invalidParams(message);
   }
 
@@ -3180,13 +3157,11 @@ function validateResolvePromptParams(
   if (!parsed.success) {
     const message = hasIssue(parsed.error, [], "invalid_type")
       ? "session.resolvePrompt params must be an object"
-      : hasIssue(parsed.error, [], "unrecognized_keys")
-        ? "session.resolvePrompt params only support sessionId and promptId"
-        : hasIssue(parsed.error, ["sessionId"])
-          ? "session.resolvePrompt params.sessionId must be a non-empty string"
-          : hasIssue(parsed.error, ["promptId"])
-            ? "session.resolvePrompt params.promptId must be a non-empty string"
-            : `session.resolvePrompt params are invalid: ${formatZodError(parsed.error)}`;
+      : hasIssue(parsed.error, ["sessionId"])
+        ? "session.resolvePrompt params.sessionId must be a non-empty string"
+        : hasIssue(parsed.error, ["promptId"])
+          ? "session.resolvePrompt params.promptId must be a non-empty string"
+          : `session.resolvePrompt params are invalid: ${formatZodError(parsed.error)}`;
     return invalidParams(message);
   }
 
@@ -3206,15 +3181,13 @@ function validateAutocompletePathsParams(
   if (!parsed.success) {
     const message = hasIssue(parsed.error, [], "invalid_type")
       ? "session.autocompletePaths params must be an object"
-      : hasIssue(parsed.error, [], "unrecognized_keys")
-        ? "session.autocompletePaths params only support sessionId, query, and limit"
-        : hasIssue(parsed.error, ["sessionId"])
-          ? "session.autocompletePaths params.sessionId must be a non-empty string"
-          : hasIssue(parsed.error, ["query"])
-            ? "session.autocompletePaths params.query must be a string"
-            : hasIssue(parsed.error, ["limit"])
-              ? "session.autocompletePaths params.limit must be a positive integer up to 100"
-              : `session.autocompletePaths params are invalid: ${formatZodError(parsed.error)}`;
+      : hasIssue(parsed.error, ["sessionId"])
+        ? "session.autocompletePaths params.sessionId must be a non-empty string"
+        : hasIssue(parsed.error, ["query"])
+          ? "session.autocompletePaths params.query must be a string"
+          : hasIssue(parsed.error, ["limit"])
+            ? "session.autocompletePaths params.limit must be a positive integer up to 100"
+            : `session.autocompletePaths params are invalid: ${formatZodError(parsed.error)}`;
     return invalidParams(message);
   }
 
@@ -3235,15 +3208,13 @@ function validateCompactParams(
   if (!parsed.success) {
     const message = hasIssue(parsed.error, [], "invalid_type")
       ? "session.compact params must be an object"
-      : hasIssue(parsed.error, [], "unrecognized_keys")
-        ? "session.compact params only support sessionId, mode, and optional guidance"
-        : hasIssue(parsed.error, ["sessionId"])
-          ? "session.compact params.sessionId must be a non-empty string"
-          : hasIssue(parsed.error, ["mode"])
-            ? "session.compact params.mode must be 'summary-only' or 'summary-and-last'"
-            : hasIssue(parsed.error, ["guidance"])
-              ? "session.compact params.guidance must be a string when provided"
-              : `session.compact params are invalid: ${formatZodError(parsed.error)}`;
+      : hasIssue(parsed.error, ["sessionId"])
+        ? "session.compact params.sessionId must be a non-empty string"
+        : hasIssue(parsed.error, ["mode"])
+          ? "session.compact params.mode must be 'summary-only' or 'summary-and-last'"
+          : hasIssue(parsed.error, ["guidance"])
+            ? "session.compact params.guidance must be a string when provided"
+            : `session.compact params are invalid: ${formatZodError(parsed.error)}`;
     return invalidParams(message);
   }
 
@@ -3264,17 +3235,15 @@ function validatePruneParams(
   if (!parsed.success) {
     const message = hasIssue(parsed.error, [], "invalid_type")
       ? "session.prune params must be an object"
-      : hasIssue(parsed.error, [], "unrecognized_keys")
-        ? "session.prune params only support sessionId, strategy, fraction, and optional guidance"
-        : hasIssue(parsed.error, ["sessionId"])
-          ? "session.prune params.sessionId must be a non-empty string"
-          : hasIssue(parsed.error, ["strategy"])
-            ? "session.prune params.strategy must be 'earliest', 'largest', or 'smart'"
-            : hasIssue(parsed.error, ["fraction"])
-              ? "session.prune params.fraction must be a number between 0 and 1"
-              : hasIssue(parsed.error, ["guidance"])
-                ? "session.prune params.guidance must be a string when provided"
-                : `session.prune params are invalid: ${formatZodError(parsed.error)}`;
+      : hasIssue(parsed.error, ["sessionId"])
+        ? "session.prune params.sessionId must be a non-empty string"
+        : hasIssue(parsed.error, ["strategy"])
+          ? "session.prune params.strategy must be 'earliest', 'largest', or 'smart'"
+          : hasIssue(parsed.error, ["fraction"])
+            ? "session.prune params.fraction must be a number between 0 and 1"
+            : hasIssue(parsed.error, ["guidance"])
+              ? "session.prune params.guidance must be a string when provided"
+              : `session.prune params are invalid: ${formatZodError(parsed.error)}`;
     return invalidParams(message);
   }
 
@@ -3296,13 +3265,11 @@ function validateRewindParams(
   if (!parsed.success) {
     const message = hasIssue(parsed.error, [], "invalid_type")
       ? "session.rewind params must be an object"
-      : hasIssue(parsed.error, [], "unrecognized_keys")
-        ? "session.rewind params only support sessionId and historyEntryId"
-        : hasIssue(parsed.error, ["sessionId"])
-          ? "session.rewind params.sessionId must be a non-empty string"
-          : hasIssue(parsed.error, ["historyEntryId"])
-            ? "session.rewind params.historyEntryId must be a non-empty string"
-            : `session.rewind params are invalid: ${formatZodError(parsed.error)}`;
+      : hasIssue(parsed.error, ["sessionId"])
+        ? "session.rewind params.sessionId must be a non-empty string"
+        : hasIssue(parsed.error, ["historyEntryId"])
+          ? "session.rewind params.historyEntryId must be a non-empty string"
+          : `session.rewind params are invalid: ${formatZodError(parsed.error)}`;
     return invalidParams(message);
   }
 
@@ -3322,13 +3289,11 @@ function validateTerminateSubagentParams(
   if (!parsed.success) {
     const message = hasIssue(parsed.error, [], "invalid_type")
       ? "session.terminateSubagent params must be an object"
-      : hasIssue(parsed.error, [], "unrecognized_keys")
-        ? "session.terminateSubagent params only support sessionId and subagentId"
-        : hasIssue(parsed.error, ["sessionId"])
-          ? "session.terminateSubagent params.sessionId must be a non-empty string"
-          : hasIssue(parsed.error, ["subagentId"])
-            ? "session.terminateSubagent params.subagentId must be a non-empty string"
-            : `session.terminateSubagent params are invalid: ${formatZodError(parsed.error)}`;
+      : hasIssue(parsed.error, ["sessionId"])
+        ? "session.terminateSubagent params.sessionId must be a non-empty string"
+        : hasIssue(parsed.error, ["subagentId"])
+          ? "session.terminateSubagent params.subagentId must be a non-empty string"
+          : `session.terminateSubagent params are invalid: ${formatZodError(parsed.error)}`;
     return invalidParams(message);
   }
 
@@ -3348,15 +3313,13 @@ function validateEphemeralCreateParams(
   if (!parsed.success) {
     const message = hasIssue(parsed.error, [], "invalid_type")
       ? "session.ephemeral.create params must be an object"
-      : hasIssue(parsed.error, [], "unrecognized_keys")
-        ? "session.ephemeral.create params only support sessionId, instructions, and tools"
-        : hasIssue(parsed.error, ["sessionId"])
-          ? "session.ephemeral.create params.sessionId must be a non-empty string"
-          : hasIssue(parsed.error, ["instructions"])
-            ? "session.ephemeral.create params.instructions must be a non-empty string"
-            : hasIssue(parsed.error, ["tools"])
-              ? "session.ephemeral.create params.tools are invalid"
-              : `session.ephemeral.create params are invalid: ${formatZodError(parsed.error)}`;
+      : hasIssue(parsed.error, ["sessionId"])
+        ? "session.ephemeral.create params.sessionId must be a non-empty string"
+        : hasIssue(parsed.error, ["instructions"])
+          ? "session.ephemeral.create params.instructions must be a non-empty string"
+          : hasIssue(parsed.error, ["tools"])
+            ? "session.ephemeral.create params.tools are invalid"
+            : `session.ephemeral.create params are invalid: ${formatZodError(parsed.error)}`;
     return invalidParams(message);
   }
 
@@ -3370,19 +3333,17 @@ function validateEphemeralSubmitParams(
   if (!parsed.success) {
     const message = hasIssue(parsed.error, [], "invalid_type")
       ? "session.ephemeral.submit params must be an object"
-      : hasIssue(parsed.error, [], "unrecognized_keys")
-        ? "session.ephemeral.submit params only support sessionId, contextId, threadId, optional forkFromThreadId, and message"
-        : hasIssue(parsed.error, ["sessionId"])
-          ? "session.ephemeral.submit params.sessionId must be a non-empty string"
-          : hasIssue(parsed.error, ["contextId"])
-            ? "session.ephemeral.submit params.contextId must be a non-empty string"
-            : hasIssue(parsed.error, ["threadId"])
-              ? "session.ephemeral.submit params.threadId must be a non-empty string"
-              : hasIssue(parsed.error, ["forkFromThreadId"])
-                ? "session.ephemeral.submit params.forkFromThreadId must be a non-empty string when provided"
-                : hasIssue(parsed.error, ["message"])
-                  ? "session.ephemeral.submit params.message must be a non-empty string"
-                  : `session.ephemeral.submit params are invalid: ${formatZodError(parsed.error)}`;
+      : hasIssue(parsed.error, ["sessionId"])
+        ? "session.ephemeral.submit params.sessionId must be a non-empty string"
+        : hasIssue(parsed.error, ["contextId"])
+          ? "session.ephemeral.submit params.contextId must be a non-empty string"
+          : hasIssue(parsed.error, ["threadId"])
+            ? "session.ephemeral.submit params.threadId must be a non-empty string"
+            : hasIssue(parsed.error, ["forkFromThreadId"])
+              ? "session.ephemeral.submit params.forkFromThreadId must be a non-empty string when provided"
+              : hasIssue(parsed.error, ["message"])
+                ? "session.ephemeral.submit params.message must be a non-empty string"
+                : `session.ephemeral.submit params are invalid: ${formatZodError(parsed.error)}`;
     return invalidParams(message);
   }
 
@@ -3407,13 +3368,11 @@ function validateEphemeralCloseParams(
   if (!parsed.success) {
     const message = hasIssue(parsed.error, [], "invalid_type")
       ? "session.ephemeral.close params must be an object"
-      : hasIssue(parsed.error, [], "unrecognized_keys")
-        ? "session.ephemeral.close params only support sessionId and contextId"
-        : hasIssue(parsed.error, ["sessionId"])
-          ? "session.ephemeral.close params.sessionId must be a non-empty string"
-          : hasIssue(parsed.error, ["contextId"])
-            ? "session.ephemeral.close params.contextId must be a non-empty string"
-            : `session.ephemeral.close params are invalid: ${formatZodError(parsed.error)}`;
+      : hasIssue(parsed.error, ["sessionId"])
+        ? "session.ephemeral.close params.sessionId must be a non-empty string"
+        : hasIssue(parsed.error, ["contextId"])
+          ? "session.ephemeral.close params.contextId must be a non-empty string"
+          : `session.ephemeral.close params are invalid: ${formatZodError(parsed.error)}`;
     return invalidParams(message);
   }
 
@@ -3427,13 +3386,11 @@ function validateClientToolAckParams(
   if (!parsed.success) {
     const message = hasIssue(parsed.error, [], "invalid_type")
       ? "session.clientTool.ack params must be an object"
-      : hasIssue(parsed.error, [], "unrecognized_keys")
-        ? "session.clientTool.ack params only support sessionId and callId"
-        : hasIssue(parsed.error, ["sessionId"])
-          ? "session.clientTool.ack params.sessionId must be a non-empty string"
-          : hasIssue(parsed.error, ["callId"])
-            ? "session.clientTool.ack params.callId must be a non-empty string"
-            : `session.clientTool.ack params are invalid: ${formatZodError(parsed.error)}`;
+      : hasIssue(parsed.error, ["sessionId"])
+        ? "session.clientTool.ack params.sessionId must be a non-empty string"
+        : hasIssue(parsed.error, ["callId"])
+          ? "session.clientTool.ack params.callId must be a non-empty string"
+          : `session.clientTool.ack params are invalid: ${formatZodError(parsed.error)}`;
     return invalidParams(message);
   }
 
@@ -3447,13 +3404,11 @@ function validateClientToolResultParams(
   if (!parsed.success) {
     const message = hasIssue(parsed.error, [], "invalid_type")
       ? "session.clientTool.result params must be an object"
-      : hasIssue(parsed.error, [], "unrecognized_keys")
-        ? "session.clientTool.result params only support sessionId, callId, ok, content, and error"
-        : hasIssue(parsed.error, ["sessionId"])
-          ? "session.clientTool.result params.sessionId must be a non-empty string"
-          : hasIssue(parsed.error, ["callId"])
-            ? "session.clientTool.result params.callId must be a non-empty string"
-            : `session.clientTool.result params are invalid: ${formatZodError(parsed.error)}`;
+      : hasIssue(parsed.error, ["sessionId"])
+        ? "session.clientTool.result params.sessionId must be a non-empty string"
+        : hasIssue(parsed.error, ["callId"])
+          ? "session.clientTool.result params.callId must be a non-empty string"
+          : `session.clientTool.result params are invalid: ${formatZodError(parsed.error)}`;
     return invalidParams(message);
   }
 
@@ -3467,19 +3422,17 @@ function validateCreateParams(
   if (!parsed.success) {
     const message = hasIssue(parsed.error, [], "invalid_type")
       ? "session.create params must be an object"
-      : hasIssue(parsed.error, [], "unrecognized_keys")
-        ? "session.create params only support executionEnvironment, personaId, and reasoning"
-        : hasIssue(parsed.error, ["executionEnvironment"])
-          ? "session.create params.executionEnvironment must be an object"
-          : hasIssue(parsed.error, ["executionEnvironment", "kind"])
-            ? "session.create params.executionEnvironment.kind must be 'local', 'cloudflare-sandbox', or 'fly-sprite'"
-            : hasIssue(parsed.error, ["executionEnvironment", "cwd"])
-              ? "session.create params.executionEnvironment.cwd must be an absolute path"
-              : hasIssue(parsed.error, ["personaId"])
-                ? "session.create params.personaId must be a non-empty string"
-                : hasIssue(parsed.error, ["reasoning"])
-                  ? "session.create params.reasoning must be one of none, minimal, low, medium, high, xhigh, or max"
-                  : `session.create params are invalid: ${formatZodError(parsed.error)}`;
+      : hasIssue(parsed.error, ["executionEnvironment"])
+        ? "session.create params.executionEnvironment must be an object"
+        : hasIssue(parsed.error, ["executionEnvironment", "kind"])
+          ? "session.create params.executionEnvironment.kind must be 'local', 'cloudflare-sandbox', or 'fly-sprite'"
+          : hasIssue(parsed.error, ["executionEnvironment", "cwd"])
+            ? "session.create params.executionEnvironment.cwd must be an absolute path"
+            : hasIssue(parsed.error, ["personaId"])
+              ? "session.create params.personaId must be a non-empty string"
+              : hasIssue(parsed.error, ["reasoning"])
+                ? "session.create params.reasoning must be one of none, minimal, low, medium, high, xhigh, or max"
+                : `session.create params are invalid: ${formatZodError(parsed.error)}`;
     return invalidParams(message);
   }
 
@@ -3555,10 +3508,6 @@ function parseSessionProtocolDeltaMessage(payload: unknown): SessionProtocolOutg
 
   const deltaMessage = sessionProtocolDeltaMessageSchema.safeParse(payload);
   if (!deltaMessage.success) {
-    if (hasIssue(deltaMessage.error, [], "unrecognized_keys")) {
-      return fail("session.delta message contains unsupported fields");
-    }
-
     if (hasIssue(deltaMessage.error, ["sessionId"])) {
       return fail("session.delta.sessionId must be a non-empty string");
     }
@@ -3608,9 +3557,6 @@ function parseSessionProtocolClientToolMessage(
 
   const message = sessionProtocolClientToolMessageSchema.safeParse(payload);
   if (!message.success) {
-    if (hasIssue(message.error, [], "unrecognized_keys")) {
-      return fail(`${String(messageType)} message contains unsupported fields`);
-    }
     return fail(`invalid ${String(messageType)} message: ${formatZodError(message.error)}`);
   }
 
@@ -3633,9 +3579,6 @@ function parseSessionProtocolEphemeralMessage(
 
   const ephemeralMessage = sessionProtocolEphemeralMessageSchema.safeParse(payload);
   if (!ephemeralMessage.success) {
-    if (hasIssue(ephemeralMessage.error, [], "unrecognized_keys")) {
-      return fail("session.ephemeral message contains unsupported fields");
-    }
     if (hasIssue(ephemeralMessage.error, ["sessionId"])) {
       return fail("session.ephemeral.sessionId must be a non-empty string");
     }
@@ -3664,9 +3607,6 @@ function parseSessionProtocolPendingUserMessagesMessage(
 
   const message = sessionProtocolPendingUserMessagesMessageSchema.safeParse(payload);
   if (!message.success) {
-    if (hasIssue(message.error, [], "unrecognized_keys")) {
-      return fail("session.pendingUserMessages message contains unsupported fields");
-    }
     if (hasIssue(message.error, ["sessionId"])) {
       return fail("session.pendingUserMessages.sessionId must be a non-empty string");
     }
@@ -3712,10 +3652,6 @@ function parseSessionProtocolResponseMessage(payload: unknown): SessionProtocolO
   if (ok === true) {
     const successResponse = sessionProtocolResponseSuccessSchema.safeParse(payload);
     if (!successResponse.success) {
-      if (hasIssue(successResponse.error, [], "unrecognized_keys")) {
-        return fail("successful response must only include result payload");
-      }
-
       if (hasIssue(successResponse.error, ["result"], "invalid_type")) {
         return fail("successful response must include result");
       }
@@ -3745,10 +3681,6 @@ function parseSessionProtocolResponseMessage(payload: unknown): SessionProtocolO
 
   const errorResponse = sessionProtocolResponseErrorSchema.safeParse(payload);
   if (!errorResponse.success) {
-    if (hasIssue(errorResponse.error, [], "unrecognized_keys")) {
-      return fail("error response must only include error payload");
-    }
-
     if (hasIssue(errorResponse.error, ["error"])) {
       return fail("error response.error must be an object");
     }

--- a/src/protocol/session_protocol.ts
+++ b/src/protocol/session_protocol.ts
@@ -18,7 +18,6 @@ export const SESSION_PROTOCOL_METHODS = [
   "session.exec",
   "session.interrupt",
   "session.snapshot",
-  "session.setRisk",
   "session.setReasoning",
   "session.setPersona",
   "session.resolvePrompt",
@@ -117,7 +116,6 @@ export type SessionProtocolExecutionEnvironmentInput =
 export type SessionProtocolCreateParams = {
   executionEnvironment: SessionProtocolExecutionEnvironmentInput;
   personaId?: string;
-  riskLevel?: "read-only" | "read-write";
   reasoning?: SessionProtocolReasoningEffort;
 };
 export type SessionProtocolListParams = Record<string, never>;
@@ -145,9 +143,6 @@ export type SessionProtocolExecParams = SessionProtocolSessionIdParams & {
   timeoutMs?: number;
 };
 
-export type SessionProtocolSetRiskParams = SessionProtocolSessionIdParams & {
-  riskLevel: "read-only" | "read-write";
-};
 export type SessionProtocolSetReasoningParams = SessionProtocolSessionIdParams & {
   reasoning: SessionProtocolReasoningEffort;
 };
@@ -191,7 +186,6 @@ export type SessionProtocolEphemeralAgentTool =
 export type SessionProtocolEphemeralCreateParams = SessionProtocolSessionIdParams & {
   instructions: string;
   tools: SessionProtocolEphemeralAgentTool[];
-  riskLevel: "read-only" | "read-write";
 };
 export type SessionProtocolEphemeralSubmitParams = SessionProtocolSessionIdParams & {
   contextId: string;
@@ -233,7 +227,6 @@ export type SessionProtocolParamsByMethod = {
   "session.exec": SessionProtocolExecParams;
   "session.interrupt": SessionProtocolSessionIdParams;
   "session.snapshot": SessionProtocolSessionIdParams;
-  "session.setRisk": SessionProtocolSetRiskParams;
   "session.setReasoning": SessionProtocolSetReasoningParams;
   "session.setPersona": SessionProtocolSetPersonaParams;
   "session.resolvePrompt": SessionProtocolResolvePromptParams;
@@ -431,7 +424,6 @@ export type SessionProtocolPersonaSettingsSnapshot = {
 export type SessionProtocolSubagentSnapshot = {
   description?: string;
   tools?: string[];
-  riskLevel?: "read-only" | "read-write";
   launchModels?: string[];
 };
 
@@ -471,7 +463,6 @@ export type SessionProtocolContentCatalogSnapshot = {
 
 export type SessionProtocolSettingsSnapshot = {
   personaId: string;
-  riskLevel: "read-only" | "read-write";
   reasoning?: SessionProtocolReasoningEffort;
   serviceTier?: SessionProtocolServiceTier;
 };
@@ -666,7 +657,6 @@ export type SessionProtocolResultByMethod = {
   "session.exec": SessionProtocolExecResult;
   "session.interrupt": SessionProtocolInterruptResult;
   "session.snapshot": SessionProtocolSnapshot;
-  "session.setRisk": SessionProtocolSnapshot;
   "session.setReasoning": SessionProtocolSettingsUpdateResult;
   "session.setPersona": SessionProtocolSnapshot;
   "session.resolvePrompt": SessionProtocolResolvePromptResult;
@@ -945,7 +935,7 @@ const sessionProtocolReadyMessageSchema = z
     type: z.literal("ready"),
     methods: sessionProtocolMethodListSchema,
   })
-  .strict();
+  .strip();
 
 const sessionProtocolClientToolCallMessageSchema = z
   .object({
@@ -958,7 +948,7 @@ const sessionProtocolClientToolCallMessageSchema = z
     ackDeadlineMs: z.number().int().positive(),
     executionDeadlineMs: z.number().int().positive(),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolClientToolCancelMessageSchema = z
   .object({
@@ -968,7 +958,7 @@ const sessionProtocolClientToolCancelMessageSchema = z
     callId: nonEmptyStringSchema,
     reason: z.enum(["aborted", "timeout", "client-detached"]),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolClientToolMessageSchema = z.discriminatedUnion("type", [
   sessionProtocolClientToolCallMessageSchema,
@@ -983,7 +973,7 @@ const sessionProtocolRequestEnvelopeSchema = z
     method: z.string(),
     params: z.unknown(),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolOutgoingRoutingSchema = z
   .object({
@@ -998,12 +988,12 @@ const sessionProtocolOutgoingRoutingSchema = z
       "response",
     ]),
   })
-  .passthrough();
+  .strip();
 
-const sessionProtocolIdFieldSchema = z.object({ id: z.unknown() }).passthrough();
-const sessionProtocolOkFieldSchema = z.object({ ok: z.unknown() }).passthrough();
-const sessionProtocolVersionFieldSchema = z.object({ version: z.unknown() }).passthrough();
-const sessionProtocolTypeFieldSchema = z.object({ type: z.unknown() }).passthrough();
+const sessionProtocolIdFieldSchema = z.object({ id: z.unknown() }).strip();
+const sessionProtocolOkFieldSchema = z.object({ ok: z.unknown() }).strip();
+const sessionProtocolVersionFieldSchema = z.object({ version: z.unknown() }).strip();
+const sessionProtocolTypeFieldSchema = z.object({ type: z.unknown() }).strip();
 
 const sessionProtocolResponseSuccessSchema = z
   .object({
@@ -1013,7 +1003,7 @@ const sessionProtocolResponseSuccessSchema = z
     ok: z.literal(true),
     result: z.unknown(),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolResponseErrorSchema = z
   .object({
@@ -1027,9 +1017,9 @@ const sessionProtocolResponseErrorSchema = z
         message: z.string(),
         data: z.unknown().optional(),
       })
-      .strict(),
+      .strip(),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolClientToolDefinitionSchema = z
   .object({
@@ -1038,7 +1028,7 @@ const sessionProtocolClientToolDefinitionSchema = z
     parameters: z.unknown(),
     executionTimeoutMs: z.number().int().positive().optional(),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolInitializeParamsSchema = z
   .object({
@@ -1048,9 +1038,9 @@ const sessionProtocolInitializeParamsSchema = z
         version: nonEmptyStringSchema,
         tools: z.array(sessionProtocolClientToolDefinitionSchema).optional(),
       })
-      .strict(),
+      .strip(),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolUserMessageParamsSchema = z
   .object({
@@ -1058,7 +1048,7 @@ const sessionProtocolUserMessageParamsSchema = z
     text: z.string(),
     historyEntryId: nonEmptyStringSchema.optional(),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolRecordParamsSchema = sessionProtocolUserMessageParamsSchema;
 
@@ -1069,20 +1059,13 @@ const sessionProtocolExecParamsSchema = z
     cwd: nonEmptyStringSchema.optional(),
     timeoutMs: z.number().int().positive().optional(),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolSessionIdParamsSchema = z
   .object({
     sessionId: nonEmptyStringSchema,
   })
-  .strict();
-
-const sessionProtocolSetRiskParamsSchema = z
-  .object({
-    sessionId: nonEmptyStringSchema,
-    riskLevel: z.enum(["read-only", "read-write"]),
-  })
-  .strict();
+  .strip();
 
 const sessionProtocolReasoningEffortSchema = z.enum([
   "none",
@@ -1099,21 +1082,21 @@ const sessionProtocolSetReasoningParamsSchema = z
     sessionId: nonEmptyStringSchema,
     reasoning: sessionProtocolReasoningEffortSchema,
   })
-  .strict();
+  .strip();
 
 const sessionProtocolSetPersonaParamsSchema = z
   .object({
     sessionId: nonEmptyStringSchema,
     personaId: nonEmptyStringSchema,
   })
-  .strict();
+  .strip();
 
 const sessionProtocolResolvePromptParamsSchema = z
   .object({
     sessionId: nonEmptyStringSchema,
     promptId: nonEmptyStringSchema,
   })
-  .strict();
+  .strip();
 
 const sessionProtocolAutocompletePathsParamsSchema = z
   .object({
@@ -1121,7 +1104,7 @@ const sessionProtocolAutocompletePathsParamsSchema = z
     query: z.string(),
     limit: z.number().int().positive().max(100),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolCompactParamsSchema = z
   .object({
@@ -1129,7 +1112,7 @@ const sessionProtocolCompactParamsSchema = z
     mode: z.enum(["summary-only", "summary-and-last"]),
     guidance: z.string().optional(),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolPruneParamsSchema = z
   .object({
@@ -1138,21 +1121,21 @@ const sessionProtocolPruneParamsSchema = z
     fraction: z.number().min(0).max(1),
     guidance: z.string().optional(),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolRewindParamsSchema = z
   .object({
     sessionId: nonEmptyStringSchema,
     historyEntryId: nonEmptyStringSchema,
   })
-  .strict();
+  .strip();
 
 const sessionProtocolTerminateSubagentParamsSchema = z
   .object({
     sessionId: nonEmptyStringSchema,
     subagentId: nonEmptyStringSchema,
   })
-  .strict();
+  .strip();
 
 const sessionProtocolEphemeralAgentToolSchema = z.enum([
   "bash",
@@ -1168,9 +1151,8 @@ const sessionProtocolEphemeralCreateParamsSchema = z
     sessionId: nonEmptyStringSchema,
     instructions: nonEmptyStringSchema,
     tools: z.array(sessionProtocolEphemeralAgentToolSchema),
-    riskLevel: z.enum(["read-only", "read-write"]),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolEphemeralSubmitParamsSchema = z
   .object({
@@ -1180,21 +1162,21 @@ const sessionProtocolEphemeralSubmitParamsSchema = z
     forkFromThreadId: nonEmptyStringSchema.optional(),
     message: nonEmptyStringSchema,
   })
-  .strict();
+  .strip();
 
 const sessionProtocolEphemeralCloseParamsSchema = z
   .object({
     sessionId: nonEmptyStringSchema,
     contextId: nonEmptyStringSchema,
   })
-  .strict();
+  .strip();
 
 const sessionProtocolClientToolAckParamsSchema = z
   .object({
     sessionId: nonEmptyStringSchema,
     callId: nonEmptyStringSchema,
   })
-  .strict();
+  .strip();
 
 const sessionProtocolClientToolResultParamsSchema = z.discriminatedUnion("ok", [
   z
@@ -1204,7 +1186,7 @@ const sessionProtocolClientToolResultParamsSchema = z.discriminatedUnion("ok", [
       ok: z.literal(true),
       content: z.string(),
     })
-    .strict(),
+    .strip(),
   z
     .object({
       sessionId: nonEmptyStringSchema,
@@ -1212,7 +1194,7 @@ const sessionProtocolClientToolResultParamsSchema = z.discriminatedUnion("ok", [
       ok: z.literal(false),
       error: z.string(),
     })
-    .strict(),
+    .strip(),
 ]);
 
 const absolutePathSchema = nonEmptyStringSchema.refine((value) => value.startsWith("/"));
@@ -1222,7 +1204,7 @@ const sessionProtocolLocalExecutionEnvironmentInputSchema = z
     kind: z.literal("local"),
     cwd: absolutePathSchema,
   })
-  .strict();
+  .strip();
 
 const sessionProtocolCloudflareSandboxExecutionEnvironmentInputSchema = z
   .object({
@@ -1231,7 +1213,7 @@ const sessionProtocolCloudflareSandboxExecutionEnvironmentInputSchema = z
     sandboxId: nonEmptyStringSchema,
     cwd: absolutePathSchema,
   })
-  .strict();
+  .strip();
 
 const sessionProtocolFlySpriteExecutionEnvironmentInputSchema = z
   .object({
@@ -1240,7 +1222,7 @@ const sessionProtocolFlySpriteExecutionEnvironmentInputSchema = z
     spriteName: nonEmptyStringSchema,
     cwd: absolutePathSchema,
   })
-  .strict();
+  .strip();
 
 const sessionProtocolExecutionEnvironmentInputSchema = z.discriminatedUnion("kind", [
   sessionProtocolLocalExecutionEnvironmentInputSchema,
@@ -1252,19 +1234,18 @@ const sessionProtocolCreateParamsSchema = z
   .object({
     executionEnvironment: sessionProtocolExecutionEnvironmentInputSchema,
     personaId: nonEmptyStringSchema.optional(),
-    riskLevel: z.enum(["read-only", "read-write"]).optional(),
     reasoning: sessionProtocolReasoningEffortSchema.optional(),
   })
-  .strict();
+  .strip();
 
-const sessionProtocolEmptyParamsSchema = z.object({}).strict();
+const sessionProtocolEmptyParamsSchema = z.object({}).strip();
 
 const sessionProtocolSessionSummarySchema = z
   .object({
     sessionId: nonEmptyStringSchema,
     lifecycle: sessionProtocolSessionLifecycleSchema,
   })
-  .strict();
+  .strip();
 
 const sessionProtocolServiceTierSchema = z.enum(["priority", "flex"]);
 
@@ -1299,16 +1280,16 @@ const sessionProtocolModelSnapshotSchema = z
                 cacheRead: z.number().nonnegative(),
                 cacheWrite: z.number().nonnegative(),
               })
-              .strict(),
+              .strip(),
           )
           .optional(),
       })
-      .strict(),
+      .strip(),
     contextWindow: z.number().int().positive(),
     maxTokens: z.number().int().positive(),
     compat: z.unknown().optional(),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolPersonaSettingsSnapshotSchema = z
   .object({
@@ -1316,16 +1297,15 @@ const sessionProtocolPersonaSettingsSnapshotSchema = z
     interleavedThinking: z.boolean().optional(),
     serviceTier: sessionProtocolServiceTierSchema.optional(),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolSubagentSnapshotSchema = z
   .object({
     description: z.string().optional(),
     tools: z.array(nonEmptyStringSchema).optional(),
-    riskLevel: z.enum(["read-only", "read-write"]).optional(),
     launchModels: z.array(nonEmptyStringSchema).optional(),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolPersonaSnapshotSchema = z
   .object({
@@ -1338,7 +1318,7 @@ const sessionProtocolPersonaSnapshotSchema = z
     skills: z.union([z.literal("*"), z.array(nonEmptyStringSchema)]),
     source: z.enum(["builtin", "user", "project"]),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolPromptTemplateSnapshotSchema = z
   .object({
@@ -1346,7 +1326,7 @@ const sessionProtocolPromptTemplateSnapshotSchema = z
     label: z.string().optional(),
     description: z.string().optional(),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolSkillSnapshotSchema = z
   .object({
@@ -1354,7 +1334,7 @@ const sessionProtocolSkillSnapshotSchema = z
     description: nonEmptyStringSchema,
     path: nonEmptyStringSchema,
   })
-  .strict();
+  .strip();
 
 const sessionProtocolContentCatalogSnapshotSchema = z
   .object({
@@ -1362,16 +1342,15 @@ const sessionProtocolContentCatalogSnapshotSchema = z
     prompts: z.array(sessionProtocolPromptTemplateSnapshotSchema),
     skills: z.array(sessionProtocolSkillSnapshotSchema),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolSettingsSnapshotSchema = z
   .object({
     personaId: nonEmptyStringSchema,
-    riskLevel: z.enum(["read-only", "read-write"]),
     reasoning: sessionProtocolReasoningEffortSchema.optional(),
     serviceTier: sessionProtocolServiceTierSchema.optional(),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolBootstrapSnapshotSchema = z
   .object({
@@ -1381,9 +1360,9 @@ const sessionProtocolBootstrapSnapshotSchema = z
         environmentTag: nonEmptyStringSchema,
         subagentPrompts: z.record(z.string(), z.string()),
       })
-      .strict(),
+      .strip(),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolLocalExecutionEnvironmentSnapshotSchema = z
   .object({
@@ -1391,7 +1370,7 @@ const sessionProtocolLocalExecutionEnvironmentSnapshotSchema = z
     cwd: nonEmptyStringSchema,
     home: nonEmptyStringSchema,
   })
-  .strict();
+  .strip();
 
 const sessionProtocolCloudflareSandboxExecutionEnvironmentSnapshotSchema = z
   .object({
@@ -1401,7 +1380,7 @@ const sessionProtocolCloudflareSandboxExecutionEnvironmentSnapshotSchema = z
     cwd: nonEmptyStringSchema,
     home: nonEmptyStringSchema,
   })
-  .strict();
+  .strip();
 
 const sessionProtocolFlySpriteExecutionEnvironmentSnapshotSchema = z
   .object({
@@ -1411,7 +1390,7 @@ const sessionProtocolFlySpriteExecutionEnvironmentSnapshotSchema = z
     cwd: nonEmptyStringSchema,
     home: nonEmptyStringSchema,
   })
-  .strict();
+  .strip();
 
 const sessionProtocolExecutionEnvironmentSnapshotSchema = z.discriminatedUnion("kind", [
   sessionProtocolLocalExecutionEnvironmentSnapshotSchema,
@@ -1425,7 +1404,7 @@ const sessionProtocolSystemMessageSchema = z
     content: z.string(),
     timestamp: z.number().finite(),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolDraftAssistantMessageSchema = z
   .object({
@@ -1433,7 +1412,7 @@ const sessionProtocolDraftAssistantMessageSchema = z
     content: z.array(z.unknown()),
     timestamp: z.number().finite(),
   })
-  .strict() as z.ZodType<SessionProtocolDraftAssistantMessage>;
+  .strip() as z.ZodType<SessionProtocolDraftAssistantMessage>;
 
 const sessionProtocolMessagePayloadSchema = z.union([
   sessionProtocolSystemMessageSchema,
@@ -1448,7 +1427,7 @@ const sessionProtocolMessageSchema = z
     modelVisible: z.boolean(),
     message: sessionProtocolMessagePayloadSchema,
   })
-  .strict() as z.ZodType<SessionProtocolMessage>;
+  .strip() as z.ZodType<SessionProtocolMessage>;
 
 const sessionProtocolNoticeSchema = z
   .object({
@@ -1456,7 +1435,7 @@ const sessionProtocolNoticeSchema = z
     text: z.string(),
     timestamp: z.number().finite(),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolOperationSchema = z
   .object({
@@ -1468,7 +1447,7 @@ const sessionProtocolOperationSchema = z
     error: z.string().optional(),
     data: z.record(z.string(), z.unknown()).optional(),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolTimelineItemSchema = z.discriminatedUnion("type", [
   z
@@ -1477,21 +1456,21 @@ const sessionProtocolTimelineItemSchema = z.discriminatedUnion("type", [
       id: nonEmptyStringSchema,
       messageId: nonEmptyStringSchema,
     })
-    .strict(),
+    .strip(),
   z
     .object({
       type: z.literal("notice"),
       id: nonEmptyStringSchema,
       notice: sessionProtocolNoticeSchema,
     })
-    .strict(),
+    .strip(),
   z
     .object({
       type: z.literal("operation"),
       id: nonEmptyStringSchema,
       operation: sessionProtocolOperationSchema,
     })
-    .strict(),
+    .strip(),
 ]);
 
 const sessionProtocolToolRunSchema = z
@@ -1504,7 +1483,7 @@ const sessionProtocolToolRunSchema = z
         messageId: nonEmptyStringSchema,
         contentIndex: z.number().int().nonnegative(),
       })
-      .strict(),
+      .strip(),
     status: z.enum(["queued", "running", "succeeded", "failed", "blocked", "cancelled"]),
     startedAt: z.number().finite().optional(),
     finishedAt: z.number().finite().optional(),
@@ -1513,7 +1492,7 @@ const sessionProtocolToolRunSchema = z
     error: z.string().optional(),
     facetIds: z.array(nonEmptyStringSchema),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolAgentUsageSchema = z
   .object({
@@ -1524,7 +1503,7 @@ const sessionProtocolAgentUsageSchema = z
     contextWindowUsageTokens: z.number().finite(),
     contextWindow: z.number().finite(),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolAgentRunSchema = z
   .object({
@@ -1545,14 +1524,14 @@ const sessionProtocolAgentRunSchema = z
     finalText: z.string().optional(),
     error: z.string().optional(),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolFacetSubjectSchema = z.discriminatedUnion("type", [
-  z.object({ type: z.literal("session") }).strict(),
-  z.object({ type: z.literal("message"), id: nonEmptyStringSchema }).strict(),
-  z.object({ type: z.literal("tool"), id: nonEmptyStringSchema }).strict(),
-  z.object({ type: z.literal("agent"), id: nonEmptyStringSchema }).strict(),
-  z.object({ type: z.literal("operation"), id: nonEmptyStringSchema }).strict(),
+  z.object({ type: z.literal("session") }).strip(),
+  z.object({ type: z.literal("message"), id: nonEmptyStringSchema }).strip(),
+  z.object({ type: z.literal("tool"), id: nonEmptyStringSchema }).strip(),
+  z.object({ type: z.literal("agent"), id: nonEmptyStringSchema }).strip(),
+  z.object({ type: z.literal("operation"), id: nonEmptyStringSchema }).strip(),
 ]);
 
 const sessionProtocolFacetSchema = z
@@ -1563,7 +1542,7 @@ const sessionProtocolFacetSchema = z
     version: z.number().int().positive(),
     data: z.record(z.string(), z.unknown()),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolSnapshotSchema = z
   .object({
@@ -1581,7 +1560,7 @@ const sessionProtocolSnapshotSchema = z
     agents: z.record(nonEmptyStringSchema, sessionProtocolAgentRunSchema),
     facets: z.record(nonEmptyStringSchema, sessionProtocolFacetSchema),
   })
-  .strict()
+  .strip()
   .superRefine((snapshot, ctx) => {
     const messageIds = new Set<string>();
     for (const message of snapshot.messages) {
@@ -1634,32 +1613,32 @@ const sessionProtocolChangeSchema = z.discriminatedUnion("type", [
       type: z.literal("lifecycle.set"),
       lifecycle: sessionProtocolSessionLifecycleSchema,
     })
-    .strict(),
+    .strip(),
   z
     .object({
       type: z.literal("cost.set"),
       costTotal: z.number().nonnegative(),
     })
-    .strict(),
+    .strip(),
   z
     .object({
       type: z.literal("settings.set"),
       settings: sessionProtocolSettingsSnapshotSchema,
     })
-    .strict(),
+    .strip(),
   z
     .object({
       type: z.literal("message.append"),
       message: sessionProtocolMessageSchema,
       timelineItem: sessionProtocolTimelineItemSchema.optional(),
     })
-    .strict(),
+    .strip(),
   z
     .object({
       type: z.literal("message.replace"),
       message: sessionProtocolMessageSchema,
     })
-    .strict(),
+    .strip(),
   z
     .object({
       type: z.literal("message.content.append"),
@@ -1668,61 +1647,61 @@ const sessionProtocolChangeSchema = z.discriminatedUnion("type", [
       thinking: z.string().optional(),
       timestamp: z.number().finite(),
     })
-    .strict(),
+    .strip(),
   z
     .object({
       type: z.literal("timeline.append"),
       item: sessionProtocolTimelineItemSchema,
     })
-    .strict(),
+    .strip(),
   z
     .object({
       type: z.literal("timeline.replace"),
       item: sessionProtocolTimelineItemSchema,
     })
-    .strict(),
+    .strip(),
   z
     .object({
       type: z.literal("timeline.remove"),
       id: nonEmptyStringSchema,
     })
-    .strict(),
+    .strip(),
   z
     .object({
       type: z.literal("tool.set"),
       tool: sessionProtocolToolRunSchema,
     })
-    .strict(),
+    .strip(),
   z
     .object({
       type: z.literal("tool.remove"),
       id: nonEmptyStringSchema,
     })
-    .strict(),
+    .strip(),
   z
     .object({
       type: z.literal("agent.set"),
       agent: sessionProtocolAgentRunSchema,
     })
-    .strict(),
+    .strip(),
   z
     .object({
       type: z.literal("agent.remove"),
       id: nonEmptyStringSchema,
     })
-    .strict(),
+    .strip(),
   z
     .object({
       type: z.literal("facet.set"),
       facet: sessionProtocolFacetSchema,
     })
-    .strict(),
+    .strip(),
   z
     .object({
       type: z.literal("facet.remove"),
       id: nonEmptyStringSchema,
     })
-    .strict(),
+    .strip(),
 ]) as z.ZodType<SessionProtocolChange>;
 
 const sessionProtocolDeltaSchema = z.discriminatedUnion("type", [
@@ -1731,13 +1710,13 @@ const sessionProtocolDeltaSchema = z.discriminatedUnion("type", [
       type: z.literal("snapshot.patch"),
       changes: z.array(sessionProtocolChangeSchema),
     })
-    .strict(),
+    .strip(),
   z
     .object({
       type: z.literal("snapshot.reset"),
       snapshot: sessionProtocolSnapshotSchema,
     })
-    .strict(),
+    .strip(),
 ]) as z.ZodType<SessionProtocolDelta>;
 
 const sessionProtocolDeltaMessageSchema = z
@@ -1750,7 +1729,7 @@ const sessionProtocolDeltaMessageSchema = z
     reason: sessionProtocolDeltaReasonSchema,
     delta: sessionProtocolDeltaSchema,
   })
-  .strict()
+  .strip()
   .superRefine((message, ctx) => {
     if (message.delta.type === "snapshot.patch" && message.fromRevision === null) {
       ctx.addIssue({
@@ -1808,9 +1787,9 @@ const sessionProtocolEphemeralAgentThreadUpdateEventSchema = z
         usage: sessionProtocolAgentUsageSchema,
         lastActivityText: z.string().optional(),
       })
-      .strict(),
+      .strip(),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolEphemeralEventSchema = sessionProtocolEphemeralAgentThreadUpdateEventSchema;
 
@@ -1821,7 +1800,7 @@ const sessionProtocolEphemeralMessageSchema = z
     sessionId: nonEmptyStringSchema,
     event: sessionProtocolEphemeralEventSchema,
   })
-  .strict();
+  .strip();
 
 const sessionProtocolPendingUserMessageSchema = z
   .object({
@@ -1829,14 +1808,14 @@ const sessionProtocolPendingUserMessageSchema = z
     mode: z.enum(["queue", "steer"]),
     text: nonEmptyStringSchema,
   })
-  .strict();
+  .strip();
 
 const sessionProtocolPendingUserMessagesStateSchema = z
   .object({
     revision: z.number().int().positive(),
     messages: z.array(sessionProtocolPendingUserMessageSchema),
   })
-  .strict()
+  .strip()
   .superRefine((state, ctx) => {
     const ids = new Set<string>();
     for (const message of state.messages) {
@@ -1858,7 +1837,7 @@ const sessionProtocolPendingUserMessagesMessageSchema = z
     sessionId: nonEmptyStringSchema,
     state: sessionProtocolPendingUserMessagesStateSchema,
   })
-  .strict();
+  .strip();
 
 const sessionProtocolInitializeResultSchema = z
   .object({
@@ -1866,26 +1845,26 @@ const sessionProtocolInitializeResultSchema = z
     methods: sessionProtocolMethodListSchema,
     alreadyInitialized: z.boolean(),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolCreateResultSchema = z
   .object({
     sessionId: nonEmptyStringSchema,
   })
-  .strict();
+  .strip();
 
 const sessionProtocolObserveResultSchema = z
   .object({
     snapshot: sessionProtocolSnapshotSchema,
     pendingUserMessages: sessionProtocolPendingUserMessagesStateSchema,
   })
-  .strict();
+  .strip();
 
 const sessionProtocolListResultSchema = z
   .object({
     sessions: z.array(sessionProtocolSessionSummarySchema),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolSubmitResultSchema = z
   .object({
@@ -1897,12 +1876,12 @@ const sessionProtocolSubmitResultSchema = z
             reason: z.literal("auto-compaction-failed"),
             message: z.string(),
           })
-          .strict()
+          .strip()
           .optional(),
       })
-      .strict(),
+      .strip(),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolTurnResultSchema = sessionProtocolSubmitResultSchema;
 
@@ -1912,20 +1891,20 @@ const sessionProtocolSubmitWithUserResultSchema = sessionProtocolTurnResultSchem
   .extend({
     userHistoryEntryId: nonEmptyStringSchema,
   })
-  .strict();
+  .strip();
 
 const sessionProtocolCancelPendingMessagesResultSchema = z
   .object({
     cancelled: z.array(sessionProtocolPendingUserMessageSchema),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolRecordResultSchema = z
   .object({
     snapshot: sessionProtocolSnapshotSchema,
     userHistoryEntryId: nonEmptyStringSchema,
   })
-  .strict();
+  .strip();
 
 const sessionProtocolExecResultSchema = z
   .object({
@@ -1935,21 +1914,21 @@ const sessionProtocolExecResultSchema = z
     exitCode: z.number().int().nullable(),
     truncated: z.boolean(),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolInterruptResultSchema = z
   .object({
     interrupted: z.boolean(),
     isTurnRunning: z.boolean(),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolSettingsUpdateResultSchema = z
   .object({
     revision: z.number().int().positive(),
     settings: sessionProtocolSettingsSnapshotSchema,
   })
-  .strict();
+  .strip();
 
 const sessionProtocolCompactResultSchema = z
   .object({
@@ -1957,7 +1936,7 @@ const sessionProtocolCompactResultSchema = z
     compactionMessage: nonEmptyStringSchema,
     includedLastAssistant: z.boolean(),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolPruneResultSchema = z
   .object({
@@ -1969,7 +1948,7 @@ const sessionProtocolPruneResultSchema = z
     editResultsPruned: z.number().int().nonnegative(),
     bytesPruned: z.number().int().nonnegative(),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolRewindResultSchema = z
   .object({
@@ -1978,7 +1957,7 @@ const sessionProtocolRewindResultSchema = z
     text: z.string(),
     removedEntryIds: z.array(nonEmptyStringSchema),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolReloadResultSchema = z
   .object({
@@ -1990,65 +1969,65 @@ const sessionProtocolReloadResultSchema = z
         prompts: z.number().int().nonnegative(),
         skills: z.number().int().nonnegative(),
       })
-      .strict(),
+      .strip(),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolResolvePromptResultSchema = z
   .object({
     promptId: nonEmptyStringSchema,
     text: z.string(),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolAutocompletePathsResultSchema = z
   .object({
     paths: z.array(z.string()),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolUnobserveResultSchema = z
   .object({
     unobserved: z.literal(true),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolTerminateSubagentResultSchema = z
   .object({
     found: z.boolean(),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolEphemeralCreateResultSchema = z
   .object({
     contextId: nonEmptyStringSchema,
   })
-  .strict();
+  .strip();
 
 const sessionProtocolEphemeralSubmitResultSchema = z
   .object({
     threadId: nonEmptyStringSchema,
     response: z.string(),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolEphemeralCloseResultSchema = z
   .object({
     closed: z.boolean(),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolClientToolAckResultSchema = z
   .object({
     accepted: z.boolean(),
   })
-  .strict();
+  .strip();
 
 const sessionProtocolClientToolResultResultSchema = z
   .object({
     accepted: z.boolean(),
   })
-  .strict();
+  .strip();
 
 export function isSessionProtocolMethod(value: unknown): value is SessionProtocolMethod {
   return typeof value === "string" && SESSION_PROTOCOL_METHOD_SET.has(value);
@@ -2807,10 +2786,6 @@ export function validateSessionProtocolParams(
   params: unknown,
 ): SessionProtocolParamsValidationResult<SessionProtocolReloadParams>;
 export function validateSessionProtocolParams(
-  method: "session.setRisk",
-  params: unknown,
-): SessionProtocolParamsValidationResult<SessionProtocolSetRiskParams>;
-export function validateSessionProtocolParams(
   method: "session.setReasoning",
   params: unknown,
 ): SessionProtocolParamsValidationResult<SessionProtocolSetReasoningParams>;
@@ -2895,8 +2870,6 @@ export function validateSessionProtocolParams(
     case "session.snapshot":
     case "session.reload":
       return validateSessionIdParams(method, params);
-    case "session.setRisk":
-      return validateSetRiskParams(params);
     case "session.setReasoning":
       return validateSetReasoningParams(params);
     case "session.setPersona":
@@ -2942,7 +2915,6 @@ export function validateSessionProtocolResult(
     case "session.observe":
       return validateResult(method, result, sessionProtocolObserveResultSchema);
     case "session.snapshot":
-    case "session.setRisk":
     case "session.setPersona":
       return validateResult(method, result, sessionProtocolSnapshotSchema);
     case "session.setReasoning":
@@ -3145,32 +3117,6 @@ function validateExecParams(
       command: parsed.data.command,
       ...(parsed.data.cwd !== undefined ? { cwd: parsed.data.cwd } : {}),
       ...(parsed.data.timeoutMs !== undefined ? { timeoutMs: parsed.data.timeoutMs } : {}),
-    },
-  };
-}
-
-function validateSetRiskParams(
-  params: unknown,
-): SessionProtocolParamsValidationResult<SessionProtocolSetRiskParams> {
-  const parsed = sessionProtocolSetRiskParamsSchema.safeParse(params);
-  if (!parsed.success) {
-    const message = hasIssue(parsed.error, [], "invalid_type")
-      ? "session.setRisk params must be an object"
-      : hasIssue(parsed.error, [], "unrecognized_keys")
-        ? "session.setRisk params only support sessionId and riskLevel"
-        : hasIssue(parsed.error, ["sessionId"])
-          ? "session.setRisk params.sessionId must be a non-empty string"
-          : hasIssue(parsed.error, ["riskLevel"])
-            ? "session.setRisk params.riskLevel must be 'read-only' or 'read-write'"
-            : `session.setRisk params are invalid: ${formatZodError(parsed.error)}`;
-    return invalidParams(message);
-  }
-
-  return {
-    ok: true,
-    value: {
-      sessionId: parsed.data.sessionId,
-      riskLevel: parsed.data.riskLevel,
     },
   };
 }
@@ -3403,16 +3349,14 @@ function validateEphemeralCreateParams(
     const message = hasIssue(parsed.error, [], "invalid_type")
       ? "session.ephemeral.create params must be an object"
       : hasIssue(parsed.error, [], "unrecognized_keys")
-        ? "session.ephemeral.create params only support sessionId, instructions, tools, and riskLevel"
+        ? "session.ephemeral.create params only support sessionId, instructions, and tools"
         : hasIssue(parsed.error, ["sessionId"])
           ? "session.ephemeral.create params.sessionId must be a non-empty string"
           : hasIssue(parsed.error, ["instructions"])
             ? "session.ephemeral.create params.instructions must be a non-empty string"
             : hasIssue(parsed.error, ["tools"])
               ? "session.ephemeral.create params.tools are invalid"
-              : hasIssue(parsed.error, ["riskLevel"])
-                ? "session.ephemeral.create params.riskLevel must be read-only or read-write"
-                : `session.ephemeral.create params are invalid: ${formatZodError(parsed.error)}`;
+              : `session.ephemeral.create params are invalid: ${formatZodError(parsed.error)}`;
     return invalidParams(message);
   }
 
@@ -3524,7 +3468,7 @@ function validateCreateParams(
     const message = hasIssue(parsed.error, [], "invalid_type")
       ? "session.create params must be an object"
       : hasIssue(parsed.error, [], "unrecognized_keys")
-        ? "session.create params only support executionEnvironment, personaId, riskLevel, and reasoning"
+        ? "session.create params only support executionEnvironment, personaId, and reasoning"
         : hasIssue(parsed.error, ["executionEnvironment"])
           ? "session.create params.executionEnvironment must be an object"
           : hasIssue(parsed.error, ["executionEnvironment", "kind"])
@@ -3533,11 +3477,9 @@ function validateCreateParams(
               ? "session.create params.executionEnvironment.cwd must be an absolute path"
               : hasIssue(parsed.error, ["personaId"])
                 ? "session.create params.personaId must be a non-empty string"
-                : hasIssue(parsed.error, ["riskLevel"])
-                  ? "session.create params.riskLevel must be 'read-only' or 'read-write'"
-                  : hasIssue(parsed.error, ["reasoning"])
-                    ? "session.create params.reasoning must be one of none, minimal, low, medium, high, xhigh, or max"
-                    : `session.create params are invalid: ${formatZodError(parsed.error)}`;
+                : hasIssue(parsed.error, ["reasoning"])
+                  ? "session.create params.reasoning must be one of none, minimal, low, medium, high, xhigh, or max"
+                  : `session.create params are invalid: ${formatZodError(parsed.error)}`;
     return invalidParams(message);
   }
 

--- a/src/sdk/client.ts
+++ b/src/sdk/client.ts
@@ -78,7 +78,6 @@ async function createInProcessSdkHost(options: TauSdkClientOptions): Promise<Loc
   return new LocalSessionHost({
     store: new FileSessionStore({ directory: getDefaultSessionStoreDirectory(home) }),
     persona,
-    riskLevel: options.riskLevel ?? runtime.config.defaultRisk ?? "read-only",
     discoveredSkills: runtime.skills,
     personas: runtime.personas.map(clonePersonaForSession),
     prompts: runtime.prompts,
@@ -112,7 +111,6 @@ async function createInProcessSdkHost(options: TauSdkClientOptions): Promise<Loc
 
       return {
         persona: envPersona,
-        riskLevel: options.riskLevel ?? envRuntime.config.defaultRisk ?? "read-only",
         discoveredSkills: envRuntime.skills,
         personas: envRuntime.personas.map(clonePersonaForSession),
         prompts: envRuntime.prompts,

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -61,7 +61,6 @@ export type {
   TauSdkSessionRewindResult,
   TauSdkSessionSetPersonaResult,
   TauSdkSessionSetReasoningResult,
-  TauSdkSessionSetRiskResult,
   TauSdkSessionSnapshotResult,
   TauSdkSessionSteerResult,
   TauSdkSessionSubmitResult,

--- a/src/sdk/session.ts
+++ b/src/sdk/session.ts
@@ -262,13 +262,6 @@ class TauSdkClientImpl implements TauSdkClient {
     return this.transport.request("session.snapshot", { sessionId });
   }
 
-  sendSetRisk(
-    sessionId: string,
-    riskLevel: "read-only" | "read-write",
-  ): Promise<SessionProtocolResultByMethod["session.setRisk"]> {
-    return this.transport.request("session.setRisk", { sessionId, riskLevel });
-  }
-
   sendSetReasoning(
     sessionId: string,
     reasoning: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max",
@@ -364,14 +357,12 @@ class TauSdkClientImpl implements TauSdkClient {
     options: {
       instructions: string;
       tools: SessionProtocolEphemeralAgentTool[];
-      riskLevel: "read-only" | "read-write";
     },
   ): Promise<SessionProtocolResultByMethod["session.ephemeral.create"]> {
     return this.transport.request("session.ephemeral.create", {
       sessionId,
       instructions: options.instructions,
       tools: options.tools,
-      riskLevel: options.riskLevel,
     });
   }
 
@@ -598,14 +589,6 @@ class TauSdkSessionImpl implements TauSdkSession {
     return snapshot;
   }
 
-  async setRiskLevel(
-    riskLevel: "read-only" | "read-write",
-  ): Promise<SessionProtocolResultByMethod["session.setRisk"]> {
-    const snapshot = await this.client.sendSetRisk(this.activeSessionId(), riskLevel);
-    this.discardBufferedDeltasThrough(snapshot.revision);
-    return snapshot;
-  }
-
   async setReasoning(
     reasoning: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max",
   ): Promise<SessionProtocolResultByMethod["session.setReasoning"]> {
@@ -676,7 +659,6 @@ class TauSdkSessionImpl implements TauSdkSession {
   async createEphemeralContext(options: {
     instructions: string;
     tools: SessionProtocolEphemeralAgentTool[];
-    riskLevel: "read-only" | "read-write";
   }): Promise<SessionProtocolResultByMethod["session.ephemeral.create"]> {
     return await this.client.sendEphemeralCreate(this.activeSessionId(), options);
   }

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -53,7 +53,6 @@ export type TauSdkSessionRecordResult = SessionProtocolRecordResult;
 export type TauSdkSessionInterruptResult = SessionProtocolInterruptResult;
 export type TauSdkSessionExecResult = SessionProtocolExecResult;
 export type TauSdkSessionSnapshotResult = SessionProtocolSnapshot;
-export type TauSdkSessionSetRiskResult = SessionProtocolSnapshot;
 export type TauSdkSessionSetReasoningResult = SessionProtocolSettingsUpdateResult;
 export type TauSdkSessionSetPersonaResult = SessionProtocolSnapshot;
 export type TauSdkSessionCompactResult = SessionProtocolCompactResult;
@@ -96,7 +95,6 @@ export type TauSdkClientOptions = TauSdkTransportClientOptions & {
   cwd?: string;
   persona?: string;
   reasoning?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
-  riskLevel?: "read-only" | "read-write";
   noAgentContextFiles?: boolean;
 };
 
@@ -135,7 +133,6 @@ export type TauSdkSession = {
   ): Promise<TauSdkSessionExecResult>;
   interrupt(): Promise<TauSdkSessionInterruptResult>;
   snapshot(): Promise<TauSdkSessionSnapshotResult>;
-  setRiskLevel(riskLevel: "read-only" | "read-write"): Promise<TauSdkSessionSetRiskResult>;
   setReasoning(
     reasoning: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max",
   ): Promise<TauSdkSessionSetReasoningResult>;
@@ -159,7 +156,6 @@ export type TauSdkSession = {
   createEphemeralContext(options: {
     instructions: string;
     tools: TauSdkEphemeralAgentTool[];
-    riskLevel: "read-only" | "read-write";
   }): Promise<TauSdkEphemeralCreateResult>;
   submitEphemeralThread(options: {
     contextId: string;

--- a/src/tui/chat_controller/command_hints.ts
+++ b/src/tui/chat_controller/command_hints.ts
@@ -30,8 +30,6 @@ export function getCommandHint(command: Command): string | undefined {
       return "start microphone recording and transcribe to editor (macOS only)";
     case "speak":
       return "speak the last assistant message aloud (macOS only)";
-    case "risk":
-      return "set risk level: /risk:read-only or /risk:read-write";
     case "persona":
       return "switch persona: /persona:<id>";
     case "prompt":

--- a/src/tui/chat_view.ts
+++ b/src/tui/chat_view.ts
@@ -8,7 +8,7 @@ import {
 import type { SubagentUiEvent } from "../core/subagents/types.js";
 import type { BashTruncationInfo } from "../core/tools/bash.js";
 import type { ToolUiEvent, ToolUiText } from "../core/tools/registry.js";
-import type { ReasoningEffort, RiskLevel } from "../core/types.js";
+import type { ReasoningEffort } from "../core/types.js";
 import type { SessionProtocolPendingUserMessage } from "../protocol/session_protocol.js";
 import { createAppTerminal } from "./terminal.js";
 import { ToolUiRouter } from "./tool_ui_router.js";
@@ -31,7 +31,6 @@ export type ChatViewStatus = {
     contextUsage: string;
     sessionCost: string;
     duration: string;
-    riskLevel: RiskLevel;
     commandHint?: string;
   };
   editor: {
@@ -261,7 +260,6 @@ export class TuiChatView implements ChatView {
       contextUsage: status.footer.contextUsage,
       sessionCost: status.footer.sessionCost,
       duration: status.footer.duration,
-      riskLevel: status.footer.riskLevel,
       commandHint: status.footer.commandHint,
     });
 

--- a/src/tui/chat_view.ts
+++ b/src/tui/chat_view.ts
@@ -47,7 +47,6 @@ export type ChatViewInputHandlers = {
   onCtrlT?: () => void;
   onCtrlO?: () => void;
   onShiftTab?: () => void;
-  onCtrlR?: () => void;
   onCtrlP?: () => void;
   onCtrlS?: () => void;
   onCtrlY?: () => void;
@@ -389,7 +388,6 @@ export class TuiChatView implements ChatView {
     this.editor.onCtrlT = handlers.onCtrlT;
     this.editor.onCtrlO = handlers.onCtrlO;
     this.editor.onShiftTab = handlers.onShiftTab;
-    this.editor.onCtrlR = handlers.onCtrlR;
     this.editor.onCtrlP = handlers.onCtrlP;
     this.editor.onCtrlS = handlers.onCtrlS;
     this.editor.onCtrlY = handlers.onCtrlY;

--- a/src/tui/session_chat_app.ts
+++ b/src/tui/session_chat_app.ts
@@ -165,7 +165,6 @@ export class SessionChatApp implements ModeAdapter {
           },
           sources.skills,
           sources.subagents,
-          sources.riskLevels,
         ),
       );
       const handlers = controller.getInputHandlers();

--- a/src/tui/session_chat_controller.ts
+++ b/src/tui/session_chat_controller.ts
@@ -5,7 +5,6 @@ import {
   type CommandDispatchContext,
   type CommandRegistry,
   createCommandRegistry,
-  getRiskLevelDescription,
 } from "../core/commands/index.js";
 import { type Config, type DiffToolConfig, getGoogleApiKey } from "../core/config/index.js";
 import type {
@@ -26,7 +25,7 @@ import {
 } from "../core/session/pruning.js";
 import type { SubagentStatus, SubagentUiEvent } from "../core/subagents/types.js";
 import type { ToolUiEvent } from "../core/tools/registry.js";
-import { REASONING_LEVELS, type ReasoningEffort, type RiskLevel } from "../core/types.js";
+import { REASONING_LEVELS, type ReasoningEffort } from "../core/types.js";
 import { formatAdaptiveNumber, formatTokenWindow } from "../core/utils/format.js";
 import { extractAssistantText } from "../core/utils/messages.js";
 import { collectSpeechToTextContext } from "../core/utils/speech_to_text_context.js";
@@ -188,7 +187,6 @@ export class SessionChatController {
       reload: () => this.reloadContent(),
       listen: () => this.startListenCaptureFromCommand(),
       speak: () => this.speakLastAssistantMessage(),
-      risk: (level) => this.setRiskLevel(level),
       persona: (id) => this.setPersona(id),
       prompt: (id) => this.insertPrompt(id),
       theme: (id) => this.switchTheme(id),
@@ -251,7 +249,6 @@ export class SessionChatController {
       onCtrlT: () => this.toggleThinkingVisibility(),
       onCtrlO: () => this.toggleCompactToolUi(),
       onShiftTab: () => void this.cycleReasoningLevel(),
-      onCtrlR: () => void this.cycleRiskLevel(),
       onCtrlP: () => void this.cyclePersonality(),
       onCtrlS: () => void this.stashEditorToClipboard(),
       onCtrlY: () => void this.toggleListenCapture(),
@@ -395,7 +392,6 @@ export class SessionChatController {
       this.commandRegistry.buildHelpText({
         agentsFiles: this.getAgentsFilePaths(),
         skills: this.snapshot.catalog.skills,
-        riskLevels: ["read-only", "read-write"],
         themes: this.themeIds,
         formatPath: (path) =>
           formatPathForSessionDisplay(path, this.snapshot.executionEnvironment.home),
@@ -456,7 +452,6 @@ export class SessionChatController {
     autocompletePaths: (query: string, limit: number) => Promise<string[]>;
     skills: () => string[];
     subagents: () => string[];
-    riskLevels: () => Array<"read-only" | "read-write">;
   } {
     return {
       personas: () =>
@@ -474,7 +469,6 @@ export class SessionChatController {
         (await this.session.autocompletePaths({ query, limit })).paths,
       skills: () => this.snapshot.catalog.skills.map((skill) => skill.name),
       subagents: () => Object.keys(this.getCurrentPersonaSnapshot()?.subagents ?? {}),
-      riskLevels: () => ["read-only", "read-write"],
     };
   }
 
@@ -1018,7 +1012,6 @@ export class SessionChatController {
       const nextSession = await this.createSession({
         executionEnvironment: this.createExecutionEnvironmentInputFromSnapshot(),
         personaId: this.snapshot.settings.personaId,
-        riskLevel: this.snapshot.settings.riskLevel,
         ...(this.snapshot.settings.reasoning !== undefined
           ? { reasoning: this.snapshot.settings.reasoning }
           : {}),
@@ -1517,11 +1510,6 @@ export class SessionChatController {
     );
   }
 
-  private async cycleRiskLevel(): Promise<void> {
-    const next = this.snapshot.settings.riskLevel === "read-only" ? "read-write" : "read-only";
-    await this.setRiskLevel(next);
-  }
-
   private async cyclePersonality(): Promise<void> {
     const personas = this.snapshot.catalog.personas;
     if (personas.length === 0) {
@@ -1572,36 +1560,6 @@ export class SessionChatController {
     );
     const unique = [...new Set(normalized)];
     return unique.length ? unique : REASONING_LEVELS;
-  }
-
-  private async setRiskLevel(rawLevel: string): Promise<void> {
-    const riskLevel = rawLevel.trim();
-    if (riskLevel !== "read-only" && riskLevel !== "read-write") {
-      this.view.addSystemMessage(
-        `invalid risk level '${rawLevel}'. allowed: read-only, read-write`,
-        "error",
-      );
-      return;
-    }
-
-    if (this.isSessionOperationActive()) {
-      this.view.addSystemMessage("cannot change risk while a session turn is running", "warn");
-      return;
-    }
-
-    try {
-      this.snapshot = await this.session.setRiskLevel(riskLevel);
-      this.syncRenderedHistory(this.snapshot);
-      this.refreshStatus();
-      this.view.addSystemMessage(this.formatRiskLevelNotice(riskLevel), "success");
-    } catch (error) {
-      this.view.addSystemMessage(`risk change failed: ${(error as Error).message}`, "error");
-    }
-  }
-
-  private formatRiskLevelNotice(level: RiskLevel): string {
-    const details = getRiskLevelDescription(level);
-    return details ? `risk level set to ${level} (${details})` : `risk level set to ${level}`;
   }
 
   private async setPersona(rawId: string): Promise<void> {
@@ -1848,7 +1806,6 @@ export class SessionChatController {
         contextUsage: this.getContextUsageString(),
         sessionCost: this.getSessionCostString(),
         duration: this.getTurnDurationString(),
-        riskLevel: this.snapshot.settings.riskLevel,
         commandHint: this.diffReviewService.getCommandHint(
           this.getSessionOperationStatusHint() ?? this.speechStatusHint ?? this.commandHint,
         ),
@@ -2101,7 +2058,6 @@ export class SessionChatController {
     const ephemeral = await this.session.createEphemeralContext({
       instructions: buildDiffReviewInstructions(snapshot),
       tools: ["bash", "view_image"],
-      riskLevel: "read-only",
     });
     const bridge = new DiffReviewBridge({
       snapshot,

--- a/src/tui/ui/custom_editor.ts
+++ b/src/tui/ui/custom_editor.ts
@@ -29,7 +29,6 @@ export class CustomEditor extends Editor {
   public onCtrlO?: () => void;
   public onEscape?: () => void;
   public onShiftTab?: () => void;
-  public onCtrlR?: () => void;
   public onCtrlP?: () => void;
   public onCtrlS?: () => void;
   public onCtrlY?: () => void;
@@ -154,11 +153,6 @@ export class CustomEditor extends Editor {
 
     if (matchesKey(data, Key.ctrl("g")) && this.onCtrlG && !this.isShowingAutocomplete()) {
       this.onCtrlG();
-      return;
-    }
-
-    if (matchesKey(data, Key.ctrl("r")) && this.onCtrlR && !this.isShowingAutocomplete()) {
-      this.onCtrlR();
       return;
     }
 

--- a/src/tui/ui/footer.ts
+++ b/src/tui/ui/footer.ts
@@ -1,5 +1,4 @@
 import { type Component, type TUI, visibleWidth } from "@earendil-works/pi-tui";
-import type { RiskLevel } from "../../core/types.js";
 import { truncateFromEndByWidth } from "./components/one_line_segments.js";
 import type { SystemMessageKind } from "./system_message.js";
 import type { Theme } from "./theme/index.js";
@@ -7,7 +6,6 @@ import type { Theme } from "./theme/index.js";
 export interface FooterStatus {
   contextUsage: string;
   sessionCost: string;
-  riskLevel: RiskLevel;
   duration?: string;
   commandHint?: string;
 }
@@ -89,12 +87,7 @@ export class FooterComponent implements Component {
     const commandHint = this.status?.commandHint?.trim();
     const leftRaw = toast ? toast.text : commandHint || leftFull;
     const leftStyle = toast ? this.getToastStyle(toast.kind) : palette.textDim;
-    const rightPrefixRaw = "";
-    const { riskText, riskStyled } = this.status
-      ? this.formatRiskLabel(this.status.riskLevel)
-      : { riskText: "", riskStyled: "" };
-
-    const rightWidth = visibleWidth(`${rightPrefixRaw}${riskText}`);
+    const rightWidth = 0;
     const leftWidth = visibleWidth(leftRaw);
 
     let line: string;
@@ -105,7 +98,7 @@ export class FooterComponent implements Component {
       const availableLeft = Math.max(0, width - 1 - iconWidth - 1 - rightWidth - 1 - 1);
       const truncatedLeft = truncateFromEndByWidth(leftRaw, availableLeft);
       const leftStyled = leftStyle(truncatedLeft);
-      const rightStyled = `${palette.textDim(rightPrefixRaw)}${riskStyled}`;
+      const rightStyled = "";
 
       line = ` ${icon} ${leftStyled} ${rightStyled} `;
     } else {
@@ -114,7 +107,7 @@ export class FooterComponent implements Component {
       );
 
       const leftStyled = leftStyle(leftRaw);
-      const rightStyled = `${palette.textDim(rightPrefixRaw)}${riskStyled}`;
+      const rightStyled = "";
       line = ` ${icon} ${leftStyled + spaces}${rightStyled} `;
     }
 
@@ -127,21 +120,5 @@ export class FooterComponent implements Component {
     if (kind === "warn") return palette.toastWarn;
     if (kind === "muted") return palette.textMuted;
     return palette.toastSuccess;
-  }
-
-  private formatRiskLabel(riskLevel: RiskLevel): { riskText: string; riskStyled: string } {
-    const { palette } = this.theme;
-    switch (riskLevel) {
-      case "read-only":
-        return {
-          riskText: "read-only",
-          riskStyled: palette.riskReadOnlyText("read-only"),
-        };
-      case "read-write":
-        return {
-          riskText: "read-write",
-          riskStyled: palette.riskReadWriteText("read-write"),
-        };
-    }
   }
 }

--- a/src/tui/ui/footer.ts
+++ b/src/tui/ui/footer.ts
@@ -87,31 +87,11 @@ export class FooterComponent implements Component {
     const commandHint = this.status?.commandHint?.trim();
     const leftRaw = toast ? toast.text : commandHint || leftFull;
     const leftStyle = toast ? this.getToastStyle(toast.kind) : palette.textDim;
-    const rightWidth = 0;
-    const leftWidth = visibleWidth(leftRaw);
+    const availableWidth = Math.max(0, width - iconWidth - 3);
+    const left = truncateFromEndByWidth(leftRaw, availableWidth);
+    const padding = " ".repeat(Math.max(0, availableWidth - visibleWidth(left)));
 
-    let line: string;
-
-    const totalContentWidth = 1 + iconWidth + 1 + leftWidth + rightWidth + 1 + 1;
-
-    if (totalContentWidth > width) {
-      const availableLeft = Math.max(0, width - 1 - iconWidth - 1 - rightWidth - 1 - 1);
-      const truncatedLeft = truncateFromEndByWidth(leftRaw, availableLeft);
-      const leftStyled = leftStyle(truncatedLeft);
-      const rightStyled = "";
-
-      line = ` ${icon} ${leftStyled} ${rightStyled} `;
-    } else {
-      const spaces = " ".repeat(
-        Math.max(1, width - 1 - iconWidth - 1 - leftWidth - rightWidth - 1),
-      );
-
-      const leftStyled = leftStyle(leftRaw);
-      const rightStyled = "";
-      line = ` ${icon} ${leftStyled + spaces}${rightStyled} `;
-    }
-
-    return [line];
+    return [` ${icon} ${leftStyle(left)}${padding} `];
   }
 
   private getToastStyle(kind: SystemMessageKind): (text: string) => string {

--- a/src/tui/ui/slash_autocomplete.ts
+++ b/src/tui/ui/slash_autocomplete.ts
@@ -1,7 +1,5 @@
 import type { AutocompleteItem, AutocompleteProvider } from "@earendil-works/pi-tui";
 import type { CommandRegistry } from "../../core/commands/index.js";
-import { getRiskLevelAutocompleteOptions } from "../../core/commands/index.js";
-import type { RiskLevel } from "../../core/types.js";
 import { fuzzyFilter } from "../../core/utils/fuzzy.js";
 
 const MENTION_TOKEN_REGEX = /(?:^|[\t ])(@[^\t ]*)$/;
@@ -47,7 +45,6 @@ export class SlashAutocompleteProvider<Ctx = unknown> implements AutocompletePro
   private getPaths: (query: string, limit: number, signal: AbortSignal) => Promise<string[]>;
   private getSkills: () => string[];
   private getAgents: () => string[];
-  private getRiskLevels: () => RiskLevel[];
 
   constructor(
     commandRegistry: CommandRegistry<Ctx>,
@@ -61,7 +58,6 @@ export class SlashAutocompleteProvider<Ctx = unknown> implements AutocompletePro
     ) => Promise<string[]> = async () => [],
     skills: () => string[] = () => [],
     agents: () => string[] = () => [],
-    riskLevels: () => RiskLevel[] = () => ["read-only", "read-write"],
   ) {
     this.commandRegistry = commandRegistry;
     this.getPersonas = personas;
@@ -70,7 +66,6 @@ export class SlashAutocompleteProvider<Ctx = unknown> implements AutocompletePro
     this.getPaths = paths;
     this.getSkills = skills;
     this.getAgents = agents;
-    this.getRiskLevels = riskLevels;
   }
 
   async getSuggestions(
@@ -243,11 +238,6 @@ export class SlashAutocompleteProvider<Ctx = unknown> implements AutocompletePro
       return this.buildArgSuggestions(themeMatch[1] ?? "", this.getThemes());
     }
 
-    const riskMatch = afterSlash.match(/^risk:(.*)$/i);
-    if (riskMatch) {
-      return this.buildRiskSuggestions(riskMatch[1] ?? "");
-    }
-
     return null;
   }
 
@@ -260,21 +250,6 @@ export class SlashAutocompleteProvider<Ctx = unknown> implements AutocompletePro
       value: p.id,
       label: p.id,
       description: p.label,
-    }));
-
-    if (items.length === 0) return null;
-    return { items, prefix: argPrefix };
-  }
-
-  private buildRiskSuggestions(
-    argPrefix: string,
-  ): { items: AutocompleteItem[]; prefix: string } | null {
-    const options = getRiskLevelAutocompleteOptions(this.getRiskLevels());
-    const filtered = fuzzyFilter(options, argPrefix, (o) => `${o.id} ${o.description}`);
-    const items = filtered.map((o) => ({
-      value: o.id,
-      label: o.id,
-      description: o.description,
     }));
 
     if (items.length === 0) return null;
@@ -297,18 +272,6 @@ export class SlashAutocompleteProvider<Ctx = unknown> implements AutocompletePro
         item: { value, label: value, description },
         searchText: `${usage} ${description}`,
       });
-    }
-
-    const hasRisk = commandInfos.some((command) => command.argument === "risk");
-    if (hasRisk) {
-      const options = getRiskLevelAutocompleteOptions(this.getRiskLevels());
-      for (const option of options) {
-        const value = `risk:${option.id}`;
-        candidates.push({
-          item: { value, label: value, description: option.description },
-          searchText: `${value} ${option.description}`,
-        });
-      }
     }
 
     const hasPersona = commandInfos.some((command) => command.argument === "persona");
@@ -383,8 +346,7 @@ export class SlashAutocompleteProvider<Ctx = unknown> implements AutocompletePro
     const isArgCompletion =
       lowerBeforePrefix.endsWith("/persona:") ||
       lowerBeforePrefix.endsWith("/prompt:") ||
-      lowerBeforePrefix.endsWith("/theme:") ||
-      lowerBeforePrefix.endsWith("/risk:");
+      lowerBeforePrefix.endsWith("/theme:");
 
     if (isArgCompletion) {
       return item.value;

--- a/src/tui/ui/theme/palette.ts
+++ b/src/tui/ui/theme/palette.ts
@@ -75,8 +75,6 @@ const PALETTE_TEXT_TOKENS = [
   "userReviewText",
   "userReviewTextMuted",
   "userReviewTextDim",
-  "riskReadOnlyText",
-  "riskReadWriteText",
 ] as const satisfies readonly PaletteColorToken[];
 
 const PALETTE_BG_TOKENS = [

--- a/src/tui/ui/theme/theme.ts
+++ b/src/tui/ui/theme/theme.ts
@@ -68,10 +68,6 @@ export interface Palette {
   userReviewText: (text: string) => string;
   userReviewTextMuted: (text: string) => string;
   userReviewTextDim: (text: string) => string;
-
-  // Risk level indicators
-  riskReadOnlyText: (text: string) => string;
-  riskReadWriteText: (text: string) => string;
 }
 
 export interface Theme {

--- a/starter/skills/guided-review/SKILL.md
+++ b/starter/skills/guided-review/SKILL.md
@@ -106,7 +106,7 @@ Use the `diff_review` tool for each chunk when it is available.
 
 Prefer `source: "git_diff"` when a chunk can be represented cleanly with `git diff` arguments, especially path-limited scopes such as `["main...HEAD", "--", "src/foo.ts", "test/foo.test.ts"]` or `["--", "src/foo.ts"]`.
 
-Use `source: "patch_files"` only when path-limited `git diff` is not precise enough, such as selected hunks, hand-curated subsets, or multiple custom patches. Patch files must contain git unified diff sections with `diff --git` headers. If writing patch files would require read-write access that is not available, explain the limitation and either use a broader `git_diff` chunk or ask the user to switch risk level.
+Use `source: "patch_files"` only when path-limited `git diff` is not precise enough, such as selected hunks, hand-curated subsets, or multiple custom patches. Patch files must contain git unified diff sections with `diff --git` headers. If the available tools cannot write patch files, explain the limitation and use a broader `git_diff` chunk.
 
 ## Required preamble before each review
 

--- a/test/bash_output.test.js
+++ b/test/bash_output.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildBashUiText,
+  createBashToolDefinition,
   formatBashToolResultText,
   getBashOutputPolicy,
   prepareBashOutput,
@@ -25,6 +26,22 @@ const backend = {
 };
 
 describe("bash output policy", () => {
+  it("rejects removed and unknown execution arguments", async () => {
+    const tool = createBashToolDefinition(backend);
+    const result = await tool.dispatch(
+      {
+        id: "bash-1",
+        name: "bash",
+        arguments: { command: "pwd", safetyLevel: "read" },
+      },
+      new AbortController().signal,
+      { scope: "main" },
+    );
+
+    expect(result.kind).toBe("single");
+    expect(result.toolResult.isError).toBe(true);
+  });
+
   it("gates default output and includes maxOutputTokens instructions", async () => {
     const policy = getBashOutputPolicy({ mode: "model" });
     const output = "a".repeat(tokensToBytes(policy.maxTokens) + 12);

--- a/test/bash_output.test.js
+++ b/test/bash_output.test.js
@@ -26,13 +26,13 @@ const backend = {
 };
 
 describe("bash output policy", () => {
-  it("rejects removed and unknown execution arguments", async () => {
+  it("rejects unknown execution arguments", async () => {
     const tool = createBashToolDefinition(backend);
     const result = await tool.dispatch(
       {
         id: "bash-1",
         name: "bash",
-        arguments: { command: "pwd", safetyLevel: "read" },
+        arguments: { command: "pwd", unexpected: true },
       },
       new AbortController().signal,
       { scope: "main" },

--- a/test/chat_runtime.test.js
+++ b/test/chat_runtime.test.js
@@ -106,7 +106,6 @@ describe("ChatRuntime", () => {
         cwd: "/repo",
       },
       environment: createEnvironment(),
-      config: {},
     });
 
     runtime.session.addUserText("hello from create");

--- a/test/chat_runtime.test.js
+++ b/test/chat_runtime.test.js
@@ -16,7 +16,6 @@ function createPersona(overrides = {}) {
       researcher: {
         systemPrompt: "research subagent prompt",
         description: "deep research helper",
-        riskLevel: "read-write",
         launchModels: ["openai/gpt-5.4:high"],
       },
     },
@@ -26,7 +25,6 @@ function createPersona(overrides = {}) {
 
 function createStubSession(eventGenerator) {
   const setPersonaCalls = [];
-  const setRiskLevelCalls = [];
   const setConfigCalls = [];
   const setPromptContextCalls = [];
 
@@ -41,9 +39,6 @@ function createStubSession(eventGenerator) {
       setPersona(persona, systemPrompt, subagentPrompts) {
         setPersonaCalls.push({ persona, systemPrompt, subagentPrompts });
       },
-      setRiskLevel(level) {
-        setRiskLevelCalls.push(level);
-      },
       setConfig(config) {
         setConfigCalls.push(config);
       },
@@ -53,7 +48,6 @@ function createStubSession(eventGenerator) {
     },
     calls: {
       setPersonaCalls,
-      setRiskLevelCalls,
       setConfigCalls,
       setPromptContextCalls,
     },
@@ -84,7 +78,6 @@ describe("ChatRuntime", () => {
     runtime = new ChatRuntime({
       session,
       persona: createPersona(),
-      riskLevel: "read-only",
       promptContext: {
         cwd: "/repo",
       },
@@ -108,15 +101,12 @@ describe("ChatRuntime", () => {
 
     const runtime = ChatRuntime.create({
       persona: createPersona(),
-      riskLevel: "read-only",
       toolRegistry,
       promptContext: {
         cwd: "/repo",
       },
       environment: createEnvironment(),
-      config: {
-        defaultRisk: "read-only",
-      },
+      config: {},
     });
 
     runtime.session.addUserText("hello from create");
@@ -125,9 +115,6 @@ describe("ChatRuntime", () => {
     expect(runtime.session.history[0]?.role).toBe("user");
     expect(runtime.promptComposition.baseSystemPrompt).toContain("main system prompt");
     expect(runtime.promptComposition.baseSystemPrompt).toContain("<cwd>/repo</cwd>");
-    expect(runtime.promptComposition.subagentPrompts.default).toContain(
-      '<risk-level level="read-only">',
-    );
     expect(runtime.promptComposition.subagentPrompts.default).toContain("<inherited-instructions>");
     expect(runtime.promptComposition.subagentPrompts.default).toContain("main system prompt");
     expect(runtime.promptComposition.subagentPrompts.default).not.toContain(
@@ -148,7 +135,6 @@ describe("ChatRuntime", () => {
 
     const runtime = ChatRuntime.create({
       persona: createPersona(),
-      riskLevel: "read-only",
       toolRegistry,
       promptContext: {
         cwd: "/repo",
@@ -168,7 +154,6 @@ describe("ChatRuntime", () => {
     const runtime = new ChatRuntime({
       session,
       persona,
-      riskLevel: "read-only",
       promptContext: {
         cwd: "/repo",
         skillsBlock: "### Skills\n\n- skill-a",
@@ -193,11 +178,9 @@ describe("ChatRuntime", () => {
     );
     expect(composition.baseSystemPrompt).toContain("<datetime>2026-01-01T00:00:00.000Z</datetime>");
 
-    expect(composition.subagentPrompts.default).toContain('<risk-level level="read-only">');
     expect(composition.subagentPrompts.default).toContain("<inherited-instructions>");
     expect(composition.subagentPrompts.default).toContain("main system prompt");
     expect(composition.subagentPrompts.researcher).toContain("research subagent prompt");
-    expect(composition.subagentPrompts.researcher).toContain('<risk-level level="read-write">');
 
     const lastSetPersona = calls.setPersonaCalls.at(-1);
     expect(lastSetPersona).toBeDefined();
@@ -212,7 +195,6 @@ describe("ChatRuntime", () => {
     const runtime = new ChatRuntime({
       session,
       persona: createPersona(),
-      riskLevel: "read-only",
       promptContext: {
         cwd: "/repo/start",
         skillsBlock: "### Skills\n\n- initial",

--- a/test/chat_runtime.test.js
+++ b/test/chat_runtime.test.js
@@ -187,35 +187,4 @@ describe("ChatRuntime", () => {
     expect(lastSetPersona.systemPrompt).toBe(composition.baseSystemPrompt);
     expect(lastSetPersona.subagentPrompts).toEqual(composition.subagentPrompts);
   });
-
-  it("rebuilds only subagent prompts while preserving the main system prompt", () => {
-    const { session, calls } = createStubSession();
-
-    const runtime = new ChatRuntime({
-      session,
-      persona: createPersona(),
-      promptContext: {
-        cwd: "/repo/start",
-        skillsBlock: "### Skills\n\n- initial",
-      },
-      environment: createEnvironment(),
-    });
-
-    const mainBefore = runtime.promptComposition.baseSystemPrompt;
-    const subagentBefore = runtime.promptComposition.subagentPrompts.researcher;
-
-    runtime.updatePromptContext({ cwd: "/repo/next" });
-    runtime.rebuildSubagentPrompts();
-
-    const composition = runtime.promptComposition;
-    expect(composition.baseSystemPrompt).toBe(mainBefore);
-    expect(composition.baseSystemPrompt).toContain("<cwd>/repo/start</cwd>");
-    expect(composition.subagentPrompts.researcher).toContain("<cwd>/repo/next</cwd>");
-    expect(composition.subagentPrompts.researcher).not.toBe(subagentBefore);
-
-    const lastSetPersona = calls.setPersonaCalls.at(-1);
-    expect(lastSetPersona).toBeDefined();
-    expect(lastSetPersona.systemPrompt).toBe(mainBefore);
-    expect(lastSetPersona.subagentPrompts).toEqual(composition.subagentPrompts);
-  });
 });

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -36,12 +36,6 @@ describe("cli", () => {
     );
   });
 
-  it("requires exact risk level casing", () => {
-    expect(() => parseCliArgs(["--risk", "READ-ONLY"], [])).toThrow(
-      "invalid risk level 'READ-ONLY'",
-    );
-  });
-
   it("prints telegram help text when telegram command parsing fails", () => {
     const mainPath = resolve(process.cwd(), "dist/main.js");
     const result = spawnSync(process.execPath, [mainPath, "telegram"], {

--- a/test/client_tool_broker.test.js
+++ b/test/client_tool_broker.test.js
@@ -35,7 +35,6 @@ describe("ClientToolBroker", () => {
     const definition = broker.getToolDefinitions("session-1")[0];
     const result = await definition.dispatch(
       createToolCall({ choice: "a" }),
-      "read-only",
       new AbortController().signal,
       {},
     );
@@ -84,7 +83,6 @@ describe("ClientToolBroker", () => {
 
     const result = await definition.dispatch(
       createToolCall({ choice: "a" }),
-      "read-only",
       new AbortController().signal,
       {},
     );
@@ -117,7 +115,6 @@ describe("ClientToolBroker", () => {
 
       const dispatched = definition.dispatch(
         createToolCall({ choice: "a" }),
-        "read-only",
         new AbortController().signal,
         {},
       );

--- a/test/config_layers.test.js
+++ b/test/config_layers.test.js
@@ -90,7 +90,6 @@ describe("config paths", () => {
       writeFileSync(
         join(fx.home, ".config", "tau", "config.json"),
         JSON.stringify({
-          defaultRisk: "read-only",
           apiKeys: { openai: "global", anthropic: "anthropic-key", mistral: "mistral-key" },
           diffTool: {
             command: "./scripts/global-diff-tool",
@@ -135,7 +134,6 @@ describe("config paths", () => {
       writeFileSync(
         join(repo, ".tau", "config.json"),
         JSON.stringify({
-          defaultRisk: "read-write",
           apiKeys: { openai: "repo", google: "google-key" },
           diffTool: {
             command: "./scripts/repo-diff-tool",
@@ -187,7 +185,6 @@ describe("config paths", () => {
       });
 
       const config = loadConfig(nested, deps);
-      expect(config.defaultRisk).toBe("read-write");
       expect(config.defaultPersona).toBe("custom-persona");
       expect(config.apiKeys).toEqual({
         openai: "repo",
@@ -260,7 +257,6 @@ describe("config paths", () => {
       const config = loadConfig(fx.repo, deps);
       expect(config).toMatchObject({
         defaultPersona: "opus-4.8-chat",
-        defaultRisk: "read-only",
         autoCompact: {
           enabled: true,
           reserveTokens: 16384,
@@ -290,7 +286,6 @@ describe("config paths", () => {
       const result = loadConfigWithDiagnostics(deps, { levels, modelResolver });
       expect(result.config).toMatchObject({
         defaultPersona: "opus-4.8-chat",
-        defaultRisk: "read-only",
       });
       expect(result.errors.length).toBeGreaterThan(0);
     } finally {
@@ -306,7 +301,6 @@ describe("config paths", () => {
       writeFileSync(
         join(fx.repo, ".tau", "config.json"),
         JSON.stringify({
-          defaultRisk: "invalid",
           disableBuiltinPersonas: true,
           disableBuiltinThemes: "yes",
           defaultTheme: " midnight ",
@@ -322,13 +316,9 @@ describe("config paths", () => {
       const levels = resolveConfigLevels(deps, { cwd: fx.repo });
       const modelResolver = loadModelResolver({ deps, levels });
       const result = loadConfigWithDiagnostics(deps, { levels, modelResolver });
-      expect(result.config.defaultRisk).toBe("read-only");
       expect(result.config.disableBuiltinPersonas).toBe(true);
       expect(result.config.disableBuiltinThemes).toBeUndefined();
       expect(result.config.defaultTheme).toBe("midnight");
-      expect(result.errors).toContain(
-        `${join(fx.repo, ".tau", "config.json")}: 'defaultRisk' must be a valid risk level.`,
-      );
       expect(result.errors).toContain(
         `${join(fx.repo, ".tau", "config.json")}: 'disableBuiltinThemes' must be a boolean.`,
       );
@@ -420,7 +410,7 @@ describe("config paths", () => {
     }
   });
 
-  it("reports unknown top-level config keys", () => {
+  it("strips unknown top-level config keys", () => {
     const fx = setupFixture();
 
     try {
@@ -441,15 +431,14 @@ describe("config paths", () => {
       const modelResolver = loadModelResolver({ deps, levels });
       const result = loadConfigWithDiagnostics(deps, { levels, modelResolver });
 
-      expect(result.errors).toContain(
-        `${join(fx.repo, ".tau", "config.json")}: unknown key in config: async.`,
-      );
+      expect(result.config).not.toHaveProperty("async");
+      expect(result.errors).toEqual([]);
     } finally {
       fx.cleanup();
     }
   });
 
-  it("reports unknown autoCompact keys", () => {
+  it("strips unknown autoCompact keys", () => {
     const fx = setupFixture();
 
     try {
@@ -470,9 +459,12 @@ describe("config paths", () => {
       const modelResolver = loadModelResolver({ deps, levels });
       const result = loadConfigWithDiagnostics(deps, { levels, modelResolver });
 
-      expect(result.errors).toContain(
-        `${join(fx.repo, ".tau", "config.json")}: unknown key in autoCompact: bogus.`,
-      );
+      expect(result.config.autoCompact).toEqual({
+        enabled: true,
+        reserveTokens: 1000,
+        keepRecentTokens: 20000,
+      });
+      expect(result.errors).toEqual([]);
     } finally {
       fx.cleanup();
     }

--- a/test/core_runtime.test.js
+++ b/test/core_runtime.test.js
@@ -69,16 +69,11 @@ describe("command registry", () => {
       reload: async () => calls.push({ type: "reload" }),
       listen: () => calls.push({ type: "listen" }),
       speak: () => calls.push({ type: "speak" }),
-      risk: (level) => calls.push({ type: "risk", level }),
       persona: (id) => calls.push({ type: "persona", id }),
       prompt: (id) => calls.push({ type: "prompt", id }),
       theme: (id) => calls.push({ type: "theme", id }),
       unknown: (raw) => calls.push({ type: "unknown", raw }),
     };
-
-    const cmd = registry.parse("/risk:read-only");
-    expect(cmd).toEqual({ type: "risk", level: "read-only" });
-    await registry.dispatch(cmd, ctx);
 
     const rewind = registry.parse("/rewind");
     expect(rewind).toEqual({ type: "rewind" });
@@ -116,7 +111,6 @@ describe("command registry", () => {
     const unknown = registry.parse("/not-a-command");
     await registry.dispatch(unknown, ctx);
 
-    expect(calls).toContainEqual({ type: "risk", level: "read-only" });
     expect(calls).toContainEqual({ type: "rewind" });
     expect(calls).toContainEqual({ type: "copyText" });
     expect(calls).toContainEqual({ type: "compactSummaryOnly" });
@@ -128,7 +122,7 @@ describe("command registry", () => {
   });
 });
 
-describe("tool enablement by risk level", () => {
+describe("tool enablement", () => {
   it("exposes a stable tool list", () => {
     const backend = createLocalToolExecutionBackend();
     const registry = ToolCatalog.createRegistry(backend);
@@ -163,7 +157,6 @@ describe("core session rewind APIs", () => {
       persona: personas[0],
       systemPrompt: "system",
       subagentPrompts: {},
-      riskLevel: "read-only",
       toolRegistry,
     });
 
@@ -219,7 +212,6 @@ describe("core session rewind APIs", () => {
       persona: personas[0],
       systemPrompt: "system",
       subagentPrompts: {},
-      riskLevel: "read-only",
       toolRegistry,
     });
     const text = prependTauUserMetadata("visible summary", [
@@ -258,7 +250,6 @@ describe("core session rewind APIs", () => {
       persona: personas[0],
       systemPrompt: "system",
       subagentPrompts: {},
-      riskLevel: "read-only",
       toolRegistry,
     });
 
@@ -297,7 +288,6 @@ describe("core session rewind APIs", () => {
         persona,
         systemPrompt: "system",
         subagentPrompts: {},
-        riskLevel: "read-only",
         toolRegistry: new ToolRegistry([]),
         config: { nook: { domain: "nook.example.com" } },
       });
@@ -336,7 +326,6 @@ describe("core session rewind APIs", () => {
         persona,
         systemPrompt: "system",
         subagentPrompts: {},
-        riskLevel: "read-only",
         toolRegistry: new ToolRegistry([]),
       });
 
@@ -379,7 +368,6 @@ describe("core session rewind APIs", () => {
         persona,
         systemPrompt: "system",
         subagentPrompts: {},
-        riskLevel: "read-only",
         toolRegistry: new ToolRegistry([]),
         config: {
           autoCompact: {
@@ -441,7 +429,7 @@ describe("core session rewind APIs", () => {
             additionalProperties: false,
           },
         },
-        async dispatch(_toolCall, _riskLevel, _signal, context) {
+        async dispatch(_toolCall, _signal, context) {
           toolContextReasoning.push(context.persona.settings.reasoning);
           session.setReasoning("high");
           return {
@@ -472,7 +460,6 @@ describe("core session rewind APIs", () => {
       persona,
       systemPrompt: "system",
       subagentPrompts: {},
-      riskLevel: "read-only",
       toolRegistry,
     });
     const responses = [
@@ -535,7 +522,7 @@ describe("core session rewind APIs", () => {
               additionalProperties: false,
             },
           },
-          async dispatch(toolCall, _riskLevel, _signal, context) {
+          async dispatch(toolCall, _signal, context) {
             receivedOriginHistoryEntryId = context.originHistoryEntryId;
             return {
               kind: "single",
@@ -564,7 +551,6 @@ describe("core session rewind APIs", () => {
         persona,
         systemPrompt: "system",
         subagentPrompts: {},
-        riskLevel: "read-only",
         toolRegistry,
         config: {
           autoCompact: {
@@ -620,7 +606,6 @@ describe("core session model notices", () => {
       persona,
       systemPrompt: "system",
       subagentPrompts: {},
-      riskLevel: "read-only",
       toolRegistry,
       config: {
         modelSystemNotices: {
@@ -647,7 +632,6 @@ describe("core session model notices", () => {
       persona: openaiPersona,
       systemPrompt: "system",
       subagentPrompts: {},
-      riskLevel: "read-only",
       toolRegistry,
       config: {
         modelSystemNotices: {
@@ -672,7 +656,6 @@ describe("context builder", () => {
       datetime: "2025-01-01T00:00:00.000Z",
       cwd: "/repo",
       repoRoot: "/repo",
-      riskLevel: "read-only",
       platform: "darwin",
       nodeVersion: "v20.0.0",
     });
@@ -895,7 +878,7 @@ describe("runtime prompt bootstrap", () => {
 });
 
 describe("session prompt composer", () => {
-  it("composes main and subagent prompts with risk overrides", () => {
+  it("composes main and subagent prompts", () => {
     const persona = {
       id: "test-persona",
       label: "test persona",
@@ -909,7 +892,6 @@ describe("session prompt composer", () => {
         researcher: {
           systemPrompt: "research subagent prompt",
           description: "deep research helper",
-          riskLevel: "read-write",
           launchModels: ["openai/gpt-5.4:high"],
         },
       },
@@ -919,14 +901,12 @@ describe("session prompt composer", () => {
       persona,
       skillsBlock: "### Skills\n\n- skill-a",
       projectContextBlock: '### Project context\n\n<file path="/repo/AGENTS.md">ctx</file>',
-      riskLevel: "read-only",
       cwd: "/repo",
       datetime: "2026-01-01T00:00:00.000Z",
       platform: "darwin",
       nodeVersion: "v24.0.0",
     });
 
-    expect(result.environmentTag).toContain('<risk-level level="read-only">');
     expect(result.baseSystemPrompt).toContain("main system prompt");
     expect(result.baseSystemPrompt).toContain("### Skills");
     expect(result.baseSystemPrompt).toContain("### Project context");
@@ -938,7 +918,6 @@ describe("session prompt composer", () => {
       "By default, launch the subagent without a model override unless the user explicitly asks to use a specific model.",
     );
 
-    expect(result.subagentPrompts.default).toContain('<risk-level level="read-only">');
     expect(result.subagentPrompts.default).toContain("<inherited-instructions>");
     expect(result.subagentPrompts.default).toContain("main system prompt");
     expect(result.subagentPrompts.default).not.toContain("{{inherited_instructions}}");
@@ -946,7 +925,6 @@ describe("session prompt composer", () => {
       "You are a subagent supporting the main agent.",
     );
     expect(result.subagentPrompts.researcher).toContain("research subagent prompt");
-    expect(result.subagentPrompts.researcher).toContain('<risk-level level="read-write">');
   });
 
   it("includes repo root in the environment tag when inside a git repo", () => {
@@ -973,7 +951,6 @@ describe("session prompt composer", () => {
 
     const result = composeSessionPrompts({
       persona,
-      riskLevel: "read-only",
       cwd,
       datetime: "2026-01-01T00:00:00.000Z",
       platform: "darwin",
@@ -995,7 +972,6 @@ describe("session prompt composer", () => {
 
     const result = composeSessionPrompts({
       persona,
-      riskLevel: "read-only",
       cwd: "/repo",
       datetime: "2026-01-01T00:00:00.000Z",
       platform: "darwin",
@@ -1069,10 +1045,10 @@ describe("summary formatting", () => {
     const history = [userMessage("continue")];
 
     const summary = formatHistoryForCompaction(history, {
-      systemPrompt: "follow AGENTS.md and current risk level",
+      systemPrompt: "follow AGENTS.md and current instructions",
     });
 
-    expect(summary).toContain("[System prompt]:\nfollow AGENTS.md and current risk level");
+    expect(summary).toContain("[System prompt]:\nfollow AGENTS.md and current instructions");
     expect(summary).toContain("[User]:\ncontinue");
   });
 

--- a/test/core_runtime.test.js
+++ b/test/core_runtime.test.js
@@ -5,6 +5,7 @@ import { join, resolve } from "node:path";
 import { fauxAssistantMessage, fauxProvider, fauxToolCall } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
 import { createCommandRegistry } from "../dist/core/commands/index.js";
+import { safeParseCoreEventEnvelope } from "../dist/core/events/parser.js";
 import { resolveRuntimePromptBootstrap } from "../dist/core/index.js";
 import { personas } from "../dist/core/personas.js";
 import { resolveRuntimePromptBootstrapAsync } from "../dist/core/runtime/runtime_bootstrap.js";
@@ -43,11 +44,54 @@ import {
   getCompactionMetadataFromMessage,
   hasAutoCompactionContinuationMetadata,
   prependTauUserMetadata,
+  splitTauUserMetadata,
   stripTauUserDisplayText,
   stripTauUserMetadata,
   stripTauUserMetadataFromMessage,
   TAU_USER_METADATA_PREFIX,
 } from "../dist/core/utils/user_metadata.js";
+
+describe("core event parser", () => {
+  it("strips unknown envelope, event, and nested payload fields", () => {
+    expect(
+      safeParseCoreEventEnvelope({
+        version: 1,
+        envelopeExtra: true,
+        event: {
+          type: "compaction_end",
+          reason: "threshold",
+          outcome: "compacted",
+          eventExtra: true,
+          result: {
+            summaryHistoryEntryId: "summary-1",
+            continuationHistoryEntryId: "continuation-1",
+            compactionMessage: "compacted",
+            cutType: "turn-boundary",
+            retainedMessageCount: 2,
+            resultExtra: true,
+          },
+        },
+      }),
+    ).toEqual({
+      ok: true,
+      value: {
+        version: 1,
+        event: {
+          type: "compaction_end",
+          reason: "threshold",
+          outcome: "compacted",
+          result: {
+            summaryHistoryEntryId: "summary-1",
+            continuationHistoryEntryId: "continuation-1",
+            compactionMessage: "compacted",
+            cutType: "turn-boundary",
+            retainedMessageCount: 2,
+          },
+        },
+      },
+    });
+  });
+});
 
 describe("command registry", () => {
   it("parses and dispatches commands", async () => {
@@ -1202,12 +1246,39 @@ describe("compaction context message", () => {
     ).toThrow("invalid tau user metadata");
 
     const encoded = Buffer.from(
-      JSON.stringify([{ type: "compaction", version: 1, summary: "summary", extra: true }]),
+      JSON.stringify([{ type: "compaction", version: 2, summary: "summary" }]),
       "utf8",
     ).toString("base64url");
     expect(() =>
       stripTauUserMetadata(`${TAU_USER_METADATA_PREFIX}${encoded}\u001evisible`),
-    ).toThrow("invalid tau user metadata: unknown key: extra");
+    ).toThrow("invalid tau user metadata: unsupported compaction metadata version");
+  });
+
+  it("strips unknown tau user metadata fields", () => {
+    const encoded = Buffer.from(
+      JSON.stringify([
+        {
+          type: "compaction",
+          version: 1,
+          summary: "summary",
+          preservedUserMessages: [{ id: "user-1", text: "keep me", extra: true }],
+          extra: true,
+        },
+      ]),
+      "utf8",
+    ).toString("base64url");
+
+    expect(splitTauUserMetadata(`${TAU_USER_METADATA_PREFIX}${encoded}\u001evisible`)).toEqual({
+      metadata: [
+        {
+          type: "compaction",
+          version: 1,
+          summary: "summary",
+          preservedUserMessages: [{ id: "user-1", text: "keep me" }],
+        },
+      ],
+      visibleText: "visible",
+    });
   });
 
   it("skips hidden auto-continuation messages when preparing manual compaction", () => {

--- a/test/diff_tool_config.test.js
+++ b/test/diff_tool_config.test.js
@@ -136,7 +136,6 @@ describe("diffTool config", () => {
       writeFileSync(
         join(fx.repo, ".tau", "config.json"),
         JSON.stringify({
-          defaultRisk: "read-write",
           diffTool: { command: "", args: ["--ok"] },
           builtInDiffTool: { codeTheme: "not-a-theme" },
         }),
@@ -147,7 +146,6 @@ describe("diffTool config", () => {
       const modelResolver = loadModelResolver({ deps, levels });
       const result = loadConfigWithDiagnostics(deps, { levels, modelResolver });
 
-      expect(result.config.defaultRisk).toBe("read-write");
       expect(result.config.diffTool).toBeUndefined();
       expect(result.config.builtInDiffTool).toBeUndefined();
       expect(result.errors).toContain(

--- a/test/edit_tool.test.js
+++ b/test/edit_tool.test.js
@@ -66,31 +66,25 @@ describe("edit tool", () => {
       const backend = createLocalToolExecutionBackend();
       const editTool = createEditToolDefinition(backend);
 
-      await editTool.dispatch(
-        {
-          id: "tool-1",
-          name: TOOL_NAME_EDIT,
-          arguments: {
-            path: filePath,
-            oldText: originalLines[0],
-            newText: "const cost = `$${formatAdaptiveNumber(entry.costTotal, 2, 5)}`;",
-          },
+      await editTool.dispatch({
+        id: "tool-1",
+        name: TOOL_NAME_EDIT,
+        arguments: {
+          path: filePath,
+          oldText: originalLines[0],
+          newText: "const cost = `$${formatAdaptiveNumber(entry.costTotal, 2, 5)}`;",
         },
-        "read-write",
-      );
+      });
 
-      await editTool.dispatch(
-        {
-          id: "tool-2",
-          name: TOOL_NAME_EDIT,
-          arguments: {
-            path: filePath,
-            oldText: originalLines[1],
-            newText: 'const label = "$1";',
-          },
+      await editTool.dispatch({
+        id: "tool-2",
+        name: TOOL_NAME_EDIT,
+        arguments: {
+          path: filePath,
+          oldText: originalLines[1],
+          newText: 'const label = "$1";',
         },
-        "read-write",
-      );
+      });
 
       const updated = readFileSync(filePath, "utf-8");
       expect(updated).toBe(

--- a/test/file_session_store.test.js
+++ b/test/file_session_store.test.js
@@ -88,14 +88,14 @@ describe("FileSessionStore", () => {
     });
   });
 
-  it("rejects stored snapshots with legacy duplicate history", async () => {
+  it("rejects stored snapshots with invalid known fields", async () => {
     await withTempStore(async (store, directory) => {
       await mkdir(directory, { recursive: true });
       await writeFile(
         join(directory, "c2Vzc2lvbi0x.json"),
         JSON.stringify({
           ...createSnapshot("session-1", "entry"),
-          history: [{ role: "user", content: [{ type: "text", text: "legacy duplicate" }] }],
+          settings: "invalid",
         }),
         "utf8",
       );
@@ -111,7 +111,7 @@ describe("FileSessionStore", () => {
       await expect(
         store.commitSessionSnapshot({
           ...createSnapshot("session-1", "entry"),
-          history: [{ role: "user", content: [{ type: "text", text: "legacy duplicate" }] }],
+          settings: "invalid",
         }),
       ).rejects.toThrow("session snapshot is invalid");
 

--- a/test/helpers/session_protocol_fixtures.js
+++ b/test/helpers/session_protocol_fixtures.js
@@ -22,7 +22,6 @@ export function createProtocolBootstrap(overrides = {}) {
       skills: "*",
       source: "builtin",
     },
-    riskLevel: "read-only",
     prompt: {
       environmentTag: "<environment></environment>",
       baseSystemPrompt: "system prompt",
@@ -76,7 +75,6 @@ export function createProtocolSnapshot(overrides = {}) {
     costTotal: overrides.costTotal ?? 0,
     settings: overrides.settings ?? {
       personaId: bootstrap.persona?.id ?? "persona-1",
-      riskLevel: bootstrap.riskLevel ?? "read-only",
       ...(bootstrap.persona?.settings?.reasoning !== undefined
         ? { reasoning: bootstrap.persona.settings.reasoning }
         : {}),

--- a/test/in_process_session_transport.test.js
+++ b/test/in_process_session_transport.test.js
@@ -45,7 +45,6 @@ function createHostedSession(sessionId, sessions, options = {}) {
   let running = false;
   let releaseTurn;
   let pendingTurnResult = { aborted: false };
-  let riskLevel = bootstrap.riskLevel;
 
   const hostedSession = {
     get isTurnRunning() {
@@ -139,15 +138,11 @@ function createHostedSession(sessionId, sessions, options = {}) {
     async closeEphemeralContext() {
       return { closed: true };
     },
-    setRiskLevel(nextRiskLevel) {
-      riskLevel = nextRiskLevel;
-    },
     async snapshot() {
       return createProtocolSnapshot({
         sessionId,
         revision: historyEntries.length + 1,
         lifecycle: running ? "running" : "idle",
-        bootstrap: { ...bootstrap, riskLevel },
         historyEntries: historyEntries.map((entry) => ({
           id: entry.id,
           message: entry.message,

--- a/test/local_execution_environment.test.js
+++ b/test/local_execution_environment.test.js
@@ -84,7 +84,7 @@ describe("LocalExecutionEnvironment", () => {
       const repo = join(storedHome, "repo");
       await mkdir(join(storedHome, ".config", "tau"), { recursive: true });
       await mkdir(repo, { recursive: true });
-      await writeFile(join(storedHome, ".config", "tau", "config.json"), "utf8");
+      await writeFile(join(storedHome, ".config", "tau", "config.json"), "{}", "utf8");
       const resolver = new LocalExecutionEnvironmentResolver({
         home: "/host/home",
         readFile: () => {

--- a/test/local_execution_environment.test.js
+++ b/test/local_execution_environment.test.js
@@ -84,11 +84,7 @@ describe("LocalExecutionEnvironment", () => {
       const repo = join(storedHome, "repo");
       await mkdir(join(storedHome, ".config", "tau"), { recursive: true });
       await mkdir(repo, { recursive: true });
-      await writeFile(
-        join(storedHome, ".config", "tau", "config.json"),
-        JSON.stringify({ defaultRisk: "read-write" }),
-        "utf8",
-      );
+      await writeFile(join(storedHome, ".config", "tau", "config.json"), "utf8");
       const resolver = new LocalExecutionEnvironmentResolver({
         home: "/host/home",
         readFile: () => {
@@ -104,7 +100,6 @@ describe("LocalExecutionEnvironment", () => {
       });
       const runtime = await environment.resolveRuntimeConfig();
 
-      expect(runtime.config.defaultRisk).toBe("read-write");
       expect(runtime.bootstrap.levels[0].levelRoot).toBe(storedHome);
     } finally {
       await rm(storedHome, { recursive: true, force: true });

--- a/test/local_session_host.test.js
+++ b/test/local_session_host.test.js
@@ -48,7 +48,6 @@ function createHost(store, options = {}) {
   return new LocalSessionHost({
     store,
     persona: options.persona ?? personas[0],
-    riskLevel: options.riskLevel ?? "read-only",
     discoveredSkills: [],
     personas: options.personas ?? [personas[0]],
     prompts: [],
@@ -116,10 +115,9 @@ function expectedCatalog(persona = personas[0]) {
   };
 }
 
-function expectedSettings(persona = personas[0], riskLevel = "read-only") {
+function expectedSettings(persona = personas[0]) {
   return {
     personaId: persona.id,
-    riskLevel,
     ...(persona.settings.reasoning !== undefined ? { reasoning: persona.settings.reasoning } : {}),
     ...(persona.settings.serviceTier !== undefined
       ? { serviceTier: persona.settings.serviceTier }
@@ -150,7 +148,6 @@ function createStoredSnapshot(overrides = {}) {
     revision: overrides.revision ?? 1,
     lifecycle: overrides.lifecycle ?? "idle",
     costTotal: overrides.costTotal ?? 0,
-    settings: overrides.settings ?? expectedSettings(persona, overrides.riskLevel ?? "read-only"),
     bootstrap: overrides.bootstrap ?? {
       model: expectedModel(persona),
       prompt: {
@@ -159,6 +156,7 @@ function createStoredSnapshot(overrides = {}) {
       },
     },
     catalog: overrides.catalog ?? expectedCatalog(persona),
+    settings: overrides.settings ?? expectedSettings(persona),
     executionEnvironment: overrides.executionEnvironment ?? {
       kind: "local",
       cwd: "/repo",
@@ -957,24 +955,21 @@ describe("LocalSessionHost", () => {
     );
   });
 
-  it("applies session.create persona, risk, and reasoning overrides before startup", async () => {
+  it("applies session.create persona and reasoning overrides before startup", async () => {
     const store = new MemorySessionStore();
     const host = createHost(store, { personas: [personas[0], personas[1]] });
     const hostedSession = await host.createSession({
       executionEnvironment: { kind: "local", cwd: "/repo" },
       personaId: personas[1].id,
-      riskLevel: "read-write",
       reasoning: "high",
     });
 
     expect(hostedSession.runtime.persona.id).toBe(personas[1].id);
     expect(hostedSession.runtime.persona.settings.reasoning).toBe("high");
-    expect(hostedSession.runtime.currentRiskLevel).toBe("read-write");
     await expect(hostedSession.snapshot()).resolves.toEqual(
       expect.objectContaining({
         settings: {
           personaId: personas[1].id,
-          riskLevel: "read-write",
           reasoning: "high",
         },
         bootstrap: expect.objectContaining({
@@ -1008,7 +1003,6 @@ describe("LocalSessionHost", () => {
     const toolRegistry = ToolCatalog.createRegistry(createLocalToolExecutionBackend());
     const resolveRuntimeConfig = vi.fn(async () => ({
       bootstrap: {},
-      config: { defaultRisk: "read-only" },
       personas: [livePersona],
       prompts: [],
       skills: [
@@ -1080,7 +1074,6 @@ describe("LocalSessionHost", () => {
         });
         return {
           persona: resolvedPersona,
-          riskLevel: "read-write",
           discoveredSkills: [
             {
               name: "resolved-skill",
@@ -1090,7 +1083,6 @@ describe("LocalSessionHost", () => {
           ],
           personas: [resolvedPersona],
           prompts: [],
-          config: { defaultRisk: "read-write" },
         };
       },
     });
@@ -1100,7 +1092,6 @@ describe("LocalSessionHost", () => {
 
     expect(snapshot.settings).toEqual({
       personaId: "resolved-persona",
-      riskLevel: "read-write",
       reasoning: "high",
     });
     expect(snapshot.catalog.personas).toEqual([
@@ -1110,7 +1101,6 @@ describe("LocalSessionHost", () => {
       }),
     ]);
     expect(session.runtime.persona.id).toBe("resolved-persona");
-    expect(session.runtime.currentRiskLevel).toBe("read-write");
   });
 
   it("reloads hosted session content from the execution environment", async () => {
@@ -1123,7 +1113,6 @@ describe("LocalSessionHost", () => {
     const toolRegistry = ToolCatalog.createRegistry(createLocalToolExecutionBackend());
     const resolveRuntimeConfig = vi.fn(async () => ({
       bootstrap: {},
-      config: { defaultRisk: "read-only" },
       personas: [reloadedPersona],
       prompts: [{ id: "reload-prompt", template: "reload prompt" }],
       skills: [
@@ -1476,7 +1465,6 @@ describe("LocalSessionHost", () => {
         const runtimeConfig = await executionEnvironment.resolveRuntimeConfig();
         return {
           persona: runtimeConfig.personas[0],
-          riskLevel: runtimeConfig.config.defaultRisk ?? "read-only",
           discoveredSkills: runtimeConfig.skills,
           personas: runtimeConfig.personas,
           prompts: runtimeConfig.prompts,

--- a/test/nook.test.js
+++ b/test/nook.test.js
@@ -672,20 +672,9 @@ describe("nook tool", () => {
     arguments: { operation: "list_sites" },
   };
 
-  it("requires read-write risk for every operation", async () => {
-    const tool = createNookToolDefinition({});
-    const result = await tool.dispatch(toolCall, "read-only", new AbortController().signal, {
-      config: { nook: { domain: "nook.example.com" } },
-    });
-
-    expect(result.kind).toBe("single");
-    expect(result.toolResult.isError).toBe(true);
-    expect(result.toolResult.content[0].text).toContain("read-write");
-  });
-
   it("fails fast when nook is not configured", async () => {
     const tool = createNookToolDefinition({});
-    const result = await tool.dispatch(toolCall, "read-write", new AbortController().signal, {
+    const result = await tool.dispatch(toolCall, new AbortController().signal, {
       config: {},
     });
 
@@ -714,7 +703,6 @@ describe("nook tool", () => {
           directory: "/workspace/app",
         },
       },
-      "read-write",
       new AbortController().signal,
       { config: { nook: { domain: "nook.example.com" } } },
     );
@@ -734,7 +722,6 @@ describe("nook tool", () => {
         name: "nook",
         arguments: { operation: "put_kv", site: "demo", key: "settings" },
       },
-      "read-write",
       new AbortController().signal,
       { config: { nook: { domain: "nook.example.com" } } },
     );

--- a/test/rpc_server.test.js
+++ b/test/rpc_server.test.js
@@ -119,7 +119,6 @@ function createHarness(options = {}) {
     let releaseTurn;
     let pendingTurnResult = { aborted: false };
     let pendingTurn = null;
-    let riskLevel = bootstrap.riskLevel;
     let reasoning = bootstrap.persona.settings.reasoning;
 
     const emitDelta = (delta) => {
@@ -167,7 +166,6 @@ function createHarness(options = {}) {
           lifecycle: running ? "running" : "idle",
           bootstrap: {
             ...bootstrap,
-            riskLevel,
             persona: {
               ...bootstrap.persona,
               settings: { ...bootstrap.persona.settings, reasoning },
@@ -248,29 +246,6 @@ function createHarness(options = {}) {
         return createProtocolExecResult({
           command: runOptions.command,
         });
-      },
-      async setRiskLevel(nextRiskLevel) {
-        riskLevel = nextRiskLevel;
-        const snapshot = createProtocolSnapshot({
-          sessionId,
-          revision: historyEntries.length + 2,
-          lifecycle: running ? "running" : "idle",
-          bootstrap: {
-            ...bootstrap,
-            riskLevel,
-            persona: {
-              ...bootstrap.persona,
-              settings: { ...bootstrap.persona.settings, reasoning },
-            },
-          },
-          executionEnvironment: { kind: "local", cwd: "/repo", home: "/home/user" },
-          historyEntries: historyEntries.map((entry) => ({
-            id: entry.id,
-            message: entry.message,
-          })),
-        });
-        emitDelta(createResetDelta(sessionId, historyEntries.length + 1, snapshot));
-        return snapshot;
       },
       async setReasoning(nextReasoning) {
         reasoning = nextReasoning;
@@ -525,25 +500,6 @@ describe("rpc_server", () => {
     await submit;
 
     await harness.server.handleLine(
-      request("risk-created", "session.setRisk", {
-        sessionId: "session-2",
-        riskLevel: "read-write",
-      }),
-    );
-    const riskChanged = harness.lines.find(
-      (line) => line.type === "response" && line.id === "risk-created",
-    );
-    expect(riskChanged).toEqual(
-      expect.objectContaining({
-        ok: true,
-        result: expect.objectContaining({
-          sessionId: "session-2",
-          settings: expect.objectContaining({ riskLevel: "read-write" }),
-        }),
-      }),
-    );
-
-    await harness.server.handleLine(
       request("compact-created", "session.compact", {
         sessionId: "session-2",
         mode: "summary-and-last",
@@ -707,68 +663,6 @@ describe("rpc_server", () => {
         },
       }),
     );
-  });
-
-  it("broadcasts non-core session updates across handlers and supports detach", async () => {
-    const harness = createHarness();
-    const observerLines = [];
-    const observer = new RpcServer({
-      host: harness.host,
-      send: (line) => observerLines.push(JSON.parse(line)),
-    });
-
-    await observer.handleLine(request("attach", "session.observe", { sessionId: "session-1" }));
-    await harness.server.handleLine(
-      request("risk", "session.setRisk", {
-        sessionId: "session-1",
-        riskLevel: "read-write",
-      }),
-    );
-
-    await waitFor(() =>
-      observerLines.some(
-        (line) =>
-          line.type === "session.delta" &&
-          line.sessionId === "session-1" &&
-          line.delta?.type === "snapshot.reset" &&
-          line.reason === "configuration",
-      ),
-    );
-    const update = observerLines.find((line) => line.type === "session.delta");
-    expect(update).toEqual(
-      expect.objectContaining({
-        sessionId: "session-1",
-        toRevision: expect.any(Number),
-        reason: "configuration",
-        delta: expect.objectContaining({ type: "snapshot.reset" }),
-      }),
-    );
-
-    await observer.handleLine(request("detach", "session.unobserve", { sessionId: "session-1" }));
-    const detach = observerLines.find((line) => line.type === "response" && line.id === "detach");
-    expect(detach).toEqual(
-      expect.objectContaining({
-        ok: true,
-        result: { unobserved: true },
-      }),
-    );
-    const updateCountAfterDetach = observerLines.filter(
-      (line) => line.type === "session.delta",
-    ).length;
-
-    await harness.server.handleLine(
-      request("risk-again", "session.setRisk", {
-        sessionId: "session-1",
-        riskLevel: "read-only",
-      }),
-    );
-    await Promise.resolve();
-
-    expect(observerLines.filter((line) => line.type === "session.delta")).toHaveLength(
-      updateCountAfterDetach,
-    );
-
-    await observer.close();
   });
 
   it("buffers initial observed deltas until after the observe snapshot response", async () => {

--- a/test/rpc_server.test.js
+++ b/test/rpc_server.test.js
@@ -665,6 +665,66 @@ describe("rpc_server", () => {
     );
   });
 
+  it("broadcasts session updates across handlers and stops after detach", async () => {
+    const harness = createHarness();
+    const observerLines = [];
+    const observer = new RpcServer({
+      host: harness.host,
+      send: (line) => observerLines.push(JSON.parse(line)),
+    });
+
+    await observer.handleLine(request("attach", "session.observe", { sessionId: "session-1" }));
+    await harness.server.handleLine(
+      request("reasoning", "session.setReasoning", {
+        sessionId: "session-1",
+        reasoning: "high",
+      }),
+    );
+
+    await waitFor(() =>
+      observerLines.some(
+        (line) =>
+          line.type === "session.delta" &&
+          line.sessionId === "session-1" &&
+          line.delta?.type === "snapshot.patch" &&
+          line.reason === "configuration",
+      ),
+    );
+    expect(observerLines.find((line) => line.type === "session.delta")).toEqual(
+      expect.objectContaining({
+        sessionId: "session-1",
+        toRevision: expect.any(Number),
+        reason: "configuration",
+        delta: expect.objectContaining({ type: "snapshot.patch" }),
+      }),
+    );
+
+    await observer.handleLine(request("detach", "session.unobserve", { sessionId: "session-1" }));
+    expect(observerLines.find((line) => line.type === "response" && line.id === "detach")).toEqual(
+      expect.objectContaining({
+        ok: true,
+        result: { unobserved: true },
+      }),
+    );
+    const updateCountAfterDetach = observerLines.filter(
+      (line) => line.type === "session.delta",
+    ).length;
+
+    await harness.server.handleLine(
+      request("reasoning-again", "session.setReasoning", {
+        sessionId: "session-1",
+        reasoning: "low",
+      }),
+    );
+    await Promise.resolve();
+
+    expect(observerLines.filter((line) => line.type === "session.delta")).toHaveLength(
+      updateCountAfterDetach,
+    );
+
+    await observer.close();
+  });
+
   it("buffers initial observed deltas until after the observe snapshot response", async () => {
     let harness;
     harness = createHarness({

--- a/test/runtime_config_snapshot.test.js
+++ b/test/runtime_config_snapshot.test.js
@@ -21,7 +21,7 @@ describe("runtime config snapshot", () => {
       await mkdir(join(repo, ".tau", "personas"), { recursive: true });
       await writeFile(
         join(repo, ".tau", "config.json"),
-        JSON.stringify({ defaultPersona: "project-persona:high", defaultRisk: "read-write" }),
+        JSON.stringify({ defaultPersona: "project-persona:high" }),
         "utf8",
       );
       await writeFile(
@@ -45,7 +45,6 @@ describe("runtime config snapshot", () => {
       });
 
       expect(runtime.config.defaultPersona).toBe("project-persona:high");
-      expect(runtime.config.defaultRisk).toBe("read-write");
       expect(runtime.personas.find((persona) => persona.id === "project-persona")).toEqual(
         expect.objectContaining({
           label: "Project Persona",

--- a/test/sdk_client.test.js
+++ b/test/sdk_client.test.js
@@ -166,17 +166,11 @@ class FakeSessionProtocolTransport {
           return createObserveResult(params.sessionId);
         case "session.snapshot":
           return createSnapshot(params.sessionId);
-        case "session.setRisk":
-          return createProtocolSnapshot({
-            sessionId: params.sessionId,
-            bootstrap: { ...bootstrap, riskLevel: params.riskLevel },
-          });
         case "session.setReasoning":
           return {
             revision: 2,
             settings: {
               personaId: bootstrap.persona.id,
-              riskLevel: "read-only",
               reasoning: params.reasoning,
             },
           };
@@ -600,17 +594,6 @@ describe("sdk_client", () => {
       method: "session.record",
       params: { sessionId: "session-1", text: "review", historyEntryId: "review-1" },
     });
-
-    await expect(readySession.setRiskLevel("read-write")).resolves.toEqual(
-      expect.objectContaining({
-        settings: expect.objectContaining({ riskLevel: "read-write" }),
-      }),
-    );
-    expect(transport.requests.at(-1)).toEqual({
-      method: "session.setRisk",
-      params: { sessionId: "session-1", riskLevel: "read-write" },
-    });
-
     await expect(readySession.setReasoning("high")).resolves.toEqual(
       expect.objectContaining({
         settings: expect.objectContaining({ reasoning: "high" }),
@@ -1113,7 +1096,6 @@ describe("sdk_client", () => {
     const transport = new StdioSessionProtocolTransport(child);
     const clientPromise = createTauSdkClientFromTransport(transport, {
       persona: "gpt-5.5-coder",
-      riskLevel: "read-only",
       noAgentContextFiles: true,
       connectTimeoutMs: 500,
     });

--- a/test/sdk_client_integration.test.js
+++ b/test/sdk_client_integration.test.js
@@ -87,7 +87,7 @@ describe("sdk client integration", () => {
       await mkdir(join(repo, ".tau", "personas"), { recursive: true });
       await writeFile(
         join(repo, ".tau", "config.json"),
-        JSON.stringify({ defaultPersona: "rpc-project-persona:high", defaultRisk: "read-write" }),
+        JSON.stringify({ defaultPersona: "rpc-project-persona:high" }),
         "utf8",
       );
       await writeFile(
@@ -116,7 +116,6 @@ describe("sdk client integration", () => {
 
         expect(snapshot.settings).toEqual({
           personaId: "rpc-project-persona",
-          riskLevel: "read-write",
           reasoning: "high",
         });
         expect(snapshot.catalog.personas).toEqual(

--- a/test/sdk_pack_types.test.js
+++ b/test/sdk_pack_types.test.js
@@ -85,7 +85,7 @@ describe("sdk npm pack types", () => {
       writeFileSync(
         validFixturePath,
         [
-          'import type { SessionProtocolSnapshot, SessionProtocolTransport, TauSdkClient, TauSdkCreateSessionInput, TauSdkDelta, TauSdkInitializeParams, TauSdkRequestId, TauSdkSessionExecResult, TauSdkSessionSetReasoningResult, TauSdkSessionSetRiskResult, TauSdkReadyMessage, TauSdkTransportClientOptions, TauSdkUserTextProjection } from "@markusylisiurunen/tau/sdk";',
+          'import type { SessionProtocolSnapshot, SessionProtocolTransport, TauSdkClient, TauSdkCreateSessionInput, TauSdkDelta, TauSdkInitializeParams, TauSdkRequestId, TauSdkSessionExecResult, TauSdkSessionSetReasoningResult, TauSdkReadyMessage, TauSdkTransportClientOptions, TauSdkUserTextProjection } from "@markusylisiurunen/tau/sdk";',
           'import { StdioSessionProtocolTransport, applySessionProtocolDelta, createTauSdkClient, createTauSdkClientFromTransport, createTauSdkWebSocketClient, getTauUserDisplayText, getTauUserModelText, projectTauUserText } from "@markusylisiurunen/tau/sdk";',
           "",
           "const sdkDelta: TauSdkDelta = {",
@@ -115,7 +115,6 @@ describe("sdk npm pack types", () => {
           "const initializeParams: TauSdkInitializeParams = { client: { name: 'fixture', version: '1' } };",
           "const requestId: TauSdkRequestId = 'req-1';",
           "declare const execResult: TauSdkSessionExecResult;",
-          "declare const setRiskResult: TauSdkSessionSetRiskResult;",
           "declare const setReasoningResult: TauSdkSessionSetReasoningResult;",
           "declare const snapshot: SessionProtocolSnapshot;",
           "const patchedSnapshot = applySessionProtocolDelta(snapshot, sdkDelta);",
@@ -132,7 +131,6 @@ describe("sdk npm pack types", () => {
           "void initializeParams;",
           "void requestId;",
           "void execResult;",
-          "void setRiskResult;",
           "void setReasoningResult;",
           "void patchedSnapshot;",
           "void projectedUserText;",

--- a/test/session_chat_controller.test.js
+++ b/test/session_chat_controller.test.js
@@ -31,10 +31,9 @@ const altBootstrap = createProtocolBootstrap({
   },
 });
 
-function createSnapshot(historyEntries = [], riskLevel = "read-only") {
+function createSnapshot(historyEntries = []) {
   return createProtocolSnapshot({
     sessionId: "session-1",
-    bootstrap: { ...bootstrap, riskLevel },
     catalog: {
       personas: [bootstrap.persona, altBootstrap.persona],
       prompts: [{ id: "fix", label: "Fix", template: "fix the bug" }],
@@ -63,13 +62,11 @@ function historyEntriesFromSnapshot(snapshot) {
 }
 
 function updateSnapshot(snapshot, overrides = {}) {
-  const riskLevel = overrides.riskLevel ?? snapshot.settings.riskLevel;
   return createProtocolSnapshot({
     sessionId: snapshot.sessionId,
     revision: overrides.revision ?? snapshot.revision,
     lifecycle: overrides.lifecycle ?? snapshot.lifecycle,
     costTotal: overrides.costTotal ?? snapshot.costTotal,
-    bootstrap: { ...bootstrap, riskLevel },
     catalog: overrides.catalog ?? snapshot.catalog,
     executionEnvironment: snapshot.executionEnvironment,
     historyEntries: overrides.historyEntries ?? historyEntriesFromSnapshot(snapshot),
@@ -296,14 +293,6 @@ class FakeSession {
   }));
   cancelPendingMessages = vi.fn(async () => ({ cancelled: [] }));
   interrupt = vi.fn(async () => ({ interrupted: true, isTurnRunning: false }));
-  setRiskLevel = vi.fn(async (riskLevel) => {
-    this.snapshotValue = updateSnapshot(this.snapshotValue, {
-      revision: this.snapshotValue.revision + 1,
-      riskLevel,
-      settings: { ...this.snapshotValue.settings, riskLevel },
-    });
-    return this.snapshotValue;
-  });
   setReasoning = vi.fn(async (reasoning) => {
     this.snapshotValue = updateSnapshot(this.snapshotValue, {
       revision: this.snapshotValue.revision + 1,
@@ -1209,8 +1198,6 @@ describe("SessionChatController", () => {
 
     session.snapshotValue = updateSnapshot(session.snapshotValue, {
       revision: session.snapshotValue.revision + 1,
-      riskLevel: "read-write",
-      settings: { ...session.snapshotValue.settings, riskLevel: "read-write" },
       historyEntries: [
         {
           id: "other-user",
@@ -1235,7 +1222,6 @@ describe("SessionChatController", () => {
         }),
       ]),
     );
-    expect(view.status.footer.riskLevel).toBe("read-write");
   });
 
   it("ignores stale snapshot reset deltas", async () => {
@@ -1616,13 +1602,11 @@ describe("SessionChatController", () => {
 
     expect(controller.isStreaming).toBe(false);
     expect(controller.submittedTurnInProgress).toBe(true);
-    expect(controller.getInputHandlers().beforeSubmit?.("/risk:read-write")).toBe(false);
+    expect(session.submit).toHaveBeenCalledTimes(1);
 
-    controller.getInputHandlers().onSubmit("/risk:read-write");
+    controller.getInputHandlers().onSubmit("/help");
     await flush();
 
-    expect(session.setRiskLevel).not.toHaveBeenCalled();
-    expect(session.submit).toHaveBeenCalledTimes(1);
     expect(view.systems).toContainEqual(
       expect.objectContaining({
         kind: "warn",
@@ -2754,16 +2738,12 @@ describe("SessionChatController", () => {
     });
     controller.start();
 
-    controller.getInputHandlers().onSubmit("/risk:read-write");
-    await flush();
-
     controller.getInputHandlers().onSubmit("/compact:summary-and-last preserve decisions");
     await flush();
 
     controller.getInputHandlers().onSubmit("/prune:smart 0.5 keep errors");
     await flush();
 
-    expect(session.setRiskLevel).toHaveBeenCalledWith("read-write");
     expect(session.compact).toHaveBeenCalledWith("summary-and-last", {
       guidance: "preserve decisions",
     });
@@ -2772,7 +2752,6 @@ describe("SessionChatController", () => {
       guidance: "keep errors",
     });
     expect(session.submit).not.toHaveBeenCalled();
-    expect(view.status.footer.riskLevel).toBe("read-write");
     expect(view.messages).toContainEqual({
       id: "summary-entry",
       model: { type: "user", text: "compacted summary: preserve decisions" },
@@ -2781,12 +2760,6 @@ describe("SessionChatController", () => {
       expect.objectContaining({
         kind: "success",
         text: "session compacted. previous context and last assistant message have been included.",
-      }),
-    );
-    expect(view.systems).toContainEqual(
-      expect.objectContaining({
-        kind: "success",
-        text: "risk level set to read-write (all tools)",
       }),
     );
     expect(view.systems).toContainEqual(
@@ -2830,10 +2803,6 @@ describe("SessionChatController", () => {
     await flush();
 
     expect(view.status.footer.commandHint).toBe("compacting context...");
-    controller.getInputHandlers().onSubmit("/risk:read-write");
-    await flush();
-    expect(session.setRiskLevel).not.toHaveBeenCalled();
-
     pendingCompact.resolve();
     await flush();
 
@@ -2851,16 +2820,12 @@ describe("SessionChatController", () => {
     });
     controller.start();
 
-    controller.getInputHandlers().onSubmit("/risk:read-write trailing words");
-    await flush();
-
     controller.getInputHandlers().onSubmit("/reload ignored");
     await flush();
 
     controller.getInputHandlers().onSubmit("/help extra");
     await flush();
 
-    expect(session.setRiskLevel).toHaveBeenCalledWith("read-write");
     expect(session.reload).toHaveBeenCalledTimes(1);
     expect(session.submit).not.toHaveBeenCalled();
     expect(view.systems.some((message) => message.text.includes("commands:"))).toBe(true);
@@ -3234,7 +3199,6 @@ describe("SessionChatController", () => {
     expect(session.createEphemeralContext).toHaveBeenCalledWith({
       instructions: expect.stringContaining("src/main.ts"),
       tools: ["bash", "view_image"],
-      riskLevel: "read-only",
     });
     expect(session.submitEphemeralThread).toHaveBeenCalledWith({
       contextId: "ephemeral-1",
@@ -3604,7 +3568,7 @@ describe("SessionChatController", () => {
         },
       ]),
     );
-    const nextSession = new FakeSession(createSnapshot([], "read-write"));
+    const nextSession = new FakeSession(createSnapshot([]));
     nextSession.id = "session-2";
     nextSession.snapshotValue = {
       ...nextSession.snapshotValue,
@@ -3629,7 +3593,6 @@ describe("SessionChatController", () => {
     expect(createSession).toHaveBeenCalledWith({
       executionEnvironment: { kind: "local", cwd: "/session/repo" },
       personaId: "persona-1",
-      riskLevel: "read-only",
       reasoning: "none",
     });
     expect(session.unobserve).toHaveBeenCalledTimes(1);

--- a/test/session_protocol.test.js
+++ b/test/session_protocol.test.js
@@ -187,26 +187,6 @@ describe("session_protocol", () => {
       },
     });
 
-    const setRisk = parseSessionProtocolRequestLine(
-      JSON.stringify({
-        version: SESSION_PROTOCOL_VERSION,
-        type: "request",
-        id: "req-risk",
-        method: "session.setRisk",
-        params: { sessionId: "session-1", riskLevel: "read-write" },
-      }),
-    );
-    expect(setRisk).toEqual({
-      ok: true,
-      request: {
-        version: SESSION_PROTOCOL_VERSION,
-        type: "request",
-        id: "req-risk",
-        method: "session.setRisk",
-        params: { sessionId: "session-1", riskLevel: "read-write" },
-      },
-    });
-
     const setReasoning = parseSessionProtocolRequestLine(
       JSON.stringify({
         version: SESSION_PROTOCOL_VERSION,
@@ -297,7 +277,6 @@ describe("session_protocol", () => {
           sessionId: "session-1",
           instructions: "review this",
           tools: ["bash", "view_image"],
-          riskLevel: "read-only",
         },
       }),
     );
@@ -312,7 +291,6 @@ describe("session_protocol", () => {
           sessionId: "session-1",
           instructions: "review this",
           tools: ["bash", "view_image"],
-          riskLevel: "read-only",
         },
       },
     });
@@ -495,12 +473,14 @@ describe("session_protocol", () => {
       }),
     );
     expect(requestWithUnsupportedFields).toEqual({
-      ok: false,
-      id: "req-unsupported",
-      error: expect.objectContaining({
-        code: SESSION_PROTOCOL_ERROR_CODES.invalidRequest,
-        message: "request contains unsupported top-level fields",
-      }),
+      ok: true,
+      request: {
+        version: SESSION_PROTOCOL_VERSION,
+        type: "request",
+        id: "req-unsupported",
+        method: "session.submit",
+        params: { sessionId: "session-1", text: "hello" },
+      },
     });
 
     const requestWithoutParams = parseSessionProtocolRequestLine(
@@ -621,14 +601,14 @@ describe("session_protocol", () => {
       }),
     );
     expect(responseWithUnsupportedFields).toEqual({
-      ok: false,
-      reason: "invalid_payload",
-      messageType: "response",
-      id: "req-10",
-      error: expect.objectContaining({
-        code: SESSION_PROTOCOL_ERROR_CODES.invalidRequest,
-        message: "successful response must only include result payload",
-      }),
+      ok: true,
+      message: {
+        version: SESSION_PROTOCOL_VERSION,
+        type: "response",
+        id: "req-10",
+        ok: true,
+        result: { shutdown: true },
+      },
     });
 
     const oldEventEnvelope = parseSessionProtocolOutgoingLine(
@@ -721,7 +701,6 @@ describe("session_protocol", () => {
       validateSessionProtocolParams("session.create", {
         executionEnvironment: { kind: "local", cwd: "/repo" },
         personaId: "coder",
-        riskLevel: "read-write",
         reasoning: "high",
       }),
     ).toEqual({
@@ -729,7 +708,6 @@ describe("session_protocol", () => {
       value: {
         executionEnvironment: { kind: "local", cwd: "/repo" },
         personaId: "coder",
-        riskLevel: "read-write",
         reasoning: "high",
       },
     });
@@ -889,7 +867,6 @@ describe("session_protocol", () => {
         sessionId: "session-1",
         instructions: "review this",
         tools: ["bash", "view_image"],
-        riskLevel: "read-only",
       }),
     ).toEqual({
       ok: true,
@@ -897,7 +874,6 @@ describe("session_protocol", () => {
         sessionId: "session-1",
         instructions: "review this",
         tools: ["bash", "view_image"],
-        riskLevel: "read-only",
       },
     });
     expect(
@@ -975,17 +951,20 @@ describe("session_protocol", () => {
     });
 
     expect(
-      createSessionProtocolRequest("req-bad", "session.submit", {
+      createSessionProtocolRequest("req-extra", "session.submit", {
         sessionId: "session-1",
         text: "hello",
         mode: "submit",
       }),
     ).toEqual({
-      ok: false,
-      error: expect.objectContaining({
-        code: SESSION_PROTOCOL_ERROR_CODES.invalidParams,
-        message: "session.submit params only support sessionId, text, and optional historyEntryId",
-      }),
+      ok: true,
+      value: {
+        version: SESSION_PROTOCOL_VERSION,
+        type: "request",
+        id: "req-extra",
+        method: "session.submit",
+        params: { sessionId: "session-1", text: "hello" },
+      },
     });
 
     expect(
@@ -1055,11 +1034,8 @@ describe("session_protocol", () => {
         turn: { aborted: false },
       }),
     ).toEqual({
-      ok: false,
-      error: expect.objectContaining({
-        code: SESSION_PROTOCOL_ERROR_CODES.invalidRequest,
-        message: expect.stringContaining("Unrecognized key"),
-      }),
+      ok: true,
+      value: { turn: { aborted: false } },
     });
 
     expect(
@@ -1080,13 +1056,13 @@ describe("session_protocol", () => {
     expect(
       validateSessionProtocolResult("session.setReasoning", {
         revision: 2,
-        settings: { personaId: "default", riskLevel: "read-only", reasoning: "max" },
+        settings: { personaId: "default", reasoning: "high" },
       }),
     ).toEqual({
       ok: true,
       value: {
         revision: 2,
-        settings: { personaId: "default", riskLevel: "read-only", reasoning: "max" },
+        settings: { personaId: "default", reasoning: "high" },
       },
     });
 
@@ -1387,11 +1363,8 @@ describe("session_protocol", () => {
         status: "running",
       }),
     ).toEqual({
-      ok: false,
-      error: expect.objectContaining({
-        code: SESSION_PROTOCOL_ERROR_CODES.invalidRequest,
-        message: expect.stringContaining("Unrecognized key"),
-      }),
+      ok: true,
+      value: createProtocolSnapshot(),
     });
 
     expect(
@@ -1400,33 +1373,26 @@ describe("session_protocol", () => {
         runtimeConfig: {},
       }),
     ).toEqual({
-      ok: false,
-      error: expect.objectContaining({
-        code: SESSION_PROTOCOL_ERROR_CODES.invalidRequest,
-        message: expect.stringContaining("Unrecognized key"),
-      }),
+      ok: true,
+      value: createProtocolSnapshot(),
     });
 
-    expect(
-      validateSessionProtocolResult(
-        "session.snapshot",
-        createProtocolSnapshot({
-          bootstrap: {
-            ...bootstrap,
-            model: {
-              ...bootstrap.persona.model,
-              headers: { authorization: "Bearer secret", "x-custom": "secret" },
-            },
+    const snapshotWithUnknownModelFields = validateSessionProtocolResult(
+      "session.snapshot",
+      createProtocolSnapshot({
+        bootstrap: {
+          ...bootstrap,
+          model: {
+            ...bootstrap.persona.model,
+            headers: { authorization: "Bearer secret", "x-custom": "secret" },
           },
-        }),
-      ),
-    ).toEqual({
-      ok: false,
-      error: expect.objectContaining({
-        code: SESSION_PROTOCOL_ERROR_CODES.invalidRequest,
-        message: expect.stringContaining("session.snapshot result is invalid"),
+        },
       }),
-    });
+    );
+    expect(snapshotWithUnknownModelFields.ok).toBe(true);
+    if (snapshotWithUnknownModelFields.ok) {
+      expect(snapshotWithUnknownModelFields.value.bootstrap.model).not.toHaveProperty("headers");
+    }
 
     expect(
       validateSessionProtocolResult("session.snapshot", {
@@ -1446,11 +1412,8 @@ describe("session_protocol", () => {
         history: [{ role: "alien", content: [] }],
       }),
     ).toEqual({
-      ok: false,
-      error: expect.objectContaining({
-        code: SESSION_PROTOCOL_ERROR_CODES.invalidRequest,
-        message: expect.stringContaining("session.snapshot result is invalid"),
-      }),
+      ok: true,
+      value: createProtocolSnapshot(),
     });
 
     expect(
@@ -1518,11 +1481,8 @@ describe("session_protocol", () => {
         },
       }),
     ).toEqual({
-      ok: false,
-      error: expect.objectContaining({
-        code: SESSION_PROTOCOL_ERROR_CODES.invalidRequest,
-        message: expect.stringContaining("session.snapshot result is invalid"),
-      }),
+      ok: true,
+      value: createProtocolSnapshot(),
     });
   });
 
@@ -1610,7 +1570,7 @@ describe("session_protocol", () => {
         changes: [
           {
             type: "settings.set",
-            settings: { personaId: "default", riskLevel: "read-only", reasoning: "high" },
+            settings: { personaId: "default", reasoning: "high" },
           },
         ],
       },
@@ -1619,14 +1579,12 @@ describe("session_protocol", () => {
       createProtocolSnapshot({
         sessionId: "session-1",
         revision: 2,
-        settings: { personaId: "default", riskLevel: "read-only", reasoning: "medium" },
       }),
       settingsDelta,
     );
     expect(settingsPatchedSnapshot.revision).toBe(3);
     expect(settingsPatchedSnapshot.settings).toEqual({
       personaId: "default",
-      riskLevel: "read-only",
       reasoning: "high",
     });
 

--- a/test/session_runner.test.js
+++ b/test/session_runner.test.js
@@ -317,7 +317,6 @@ describe("session runner tool dispatch context", () => {
       toolCalls: [toolCall],
       toolRegistry,
       enabledTools: toolRegistry.schemas,
-      riskLevel: "read-only",
       signal,
       dispatchContext,
     })) {
@@ -461,7 +460,6 @@ describe("session runner tool dispatch context", () => {
       toolCalls: [slowCall, fastCall],
       toolRegistry,
       enabledTools: toolRegistry.schemas,
-      riskLevel: "read-only",
       signal,
       dispatchContext,
     })[Symbol.asyncIterator]();
@@ -522,7 +520,7 @@ describe("session runner tool dispatch context", () => {
           additionalProperties: false,
         },
       },
-      async dispatch(call, _riskLevel, dispatchSignal, context) {
+      async dispatch(call, dispatchSignal, context) {
         receivedSignal = dispatchSignal;
         receivedContext = context;
         return {
@@ -554,7 +552,6 @@ describe("session runner tool dispatch context", () => {
       toolCalls: [toolCall],
       toolRegistry,
       enabledTools: toolRegistry.schemas,
-      riskLevel: "read-only",
       signal,
       dispatchContext,
     })) {

--- a/test/session_store.test.js
+++ b/test/session_store.test.js
@@ -104,7 +104,7 @@ describe("MemorySessionStore", () => {
     await expect(
       store.commitSessionSnapshot({
         ...createSnapshot("session-1", "entry"),
-        history: [{ role: "user", content: [{ type: "text", text: "legacy duplicate" }] }],
+        settings: "invalid",
       }),
     ).rejects.toThrow("session snapshot is invalid");
 

--- a/test/slash_autocomplete.test.js
+++ b/test/slash_autocomplete.test.js
@@ -15,7 +15,6 @@ function createProvider(options = {}) {
       (options.files ?? []).filter((path) => path.includes(query)).slice(0, limit),
     () => options.skills ?? [],
     () => options.agents ?? [],
-    () => ["read-only", "read-write"],
   );
 }
 

--- a/test/spawn_agent_tool.test.js
+++ b/test/spawn_agent_tool.test.js
@@ -79,7 +79,6 @@ function createContext(overrides = {}) {
         },
       },
     },
-    riskLevel: "read-only",
     subagentPrompts: {
       default: "default prompt",
       researcher: "research prompt",
@@ -120,7 +119,6 @@ describe("spawn_agent tool", () => {
           model: "openai/gpt-5.5:high",
         },
       },
-      "read-only",
       undefined,
       context,
     );
@@ -175,7 +173,6 @@ describe("spawn_agent tool", () => {
           model: "openai/gpt-5.5:high",
         },
       },
-      "read-only",
       undefined,
       context,
     );
@@ -221,7 +218,6 @@ describe("spawn_agent tool", () => {
           model: "openai/gpt-5.5:high",
         },
       },
-      "read-only",
       undefined,
       context,
     );
@@ -247,7 +243,6 @@ describe("spawn_agent tool", () => {
           model: "openai/gpt-5.5:low",
         },
       },
-      "read-only",
       undefined,
       context,
     );
@@ -274,7 +269,6 @@ describe("spawn_agent tool", () => {
           prompt: "collect findings",
         },
       },
-      "read-only",
       undefined,
       context,
     );
@@ -306,7 +300,6 @@ describe("spawn_agent tool", () => {
           model: "openai/gpt-5.5:high",
         },
       },
-      "read-only",
       undefined,
       context,
     );
@@ -336,7 +329,6 @@ describe("spawn_agent tool", () => {
           model: "",
         },
       },
-      "read-only",
       undefined,
       context,
     );
@@ -363,7 +355,6 @@ describe("spawn_agent tool", () => {
           workingDirectory: "",
         },
       },
-      "read-only",
       undefined,
       context,
     );
@@ -392,7 +383,6 @@ describe("spawn_agent tool", () => {
           workingDirectory: "/tmp",
         },
       },
-      "read-only",
       undefined,
       context,
     );
@@ -421,7 +411,6 @@ describe("spawn_agent tool", () => {
           workingDirectory: "..",
         },
       },
-      "read-only",
       undefined,
       context,
     );
@@ -472,7 +461,6 @@ describe("spawn_agent tool", () => {
             workingDirectory: "..",
           },
         },
-        "read-only",
         undefined,
         context,
       );
@@ -525,7 +513,6 @@ describe("spawn_agent tool", () => {
             workingDirectory: "..",
           },
         },
-        "read-only",
         undefined,
         context,
       );
@@ -565,7 +552,6 @@ describe("spawn_agent tool", () => {
             workingDirectory: ".",
           },
         },
-        "read-only",
         undefined,
         context,
       );
@@ -628,7 +614,6 @@ describe("spawn_agent tool", () => {
             workingDirectory: ".",
           },
         },
-        "read-only",
         undefined,
         context,
       );

--- a/test/subagent_engine.test.js
+++ b/test/subagent_engine.test.js
@@ -94,7 +94,6 @@ describe("subagent engine model notices", () => {
         systemPrompt: "subagent system",
         model: persona.model,
         tools: [],
-        riskLevel: "read-only",
         workingDirectory: "/repo/current",
       },
       prompt: "collect findings",
@@ -132,7 +131,6 @@ describe("subagent engine model notices", () => {
       name: "bash",
       arguments: {
         command: "pwd",
-        safetyLevel: "read",
       },
     };
 
@@ -163,7 +161,6 @@ describe("subagent engine model notices", () => {
         systemPrompt: "subagent system",
         model: persona.model,
         tools: ["bash"],
-        riskLevel: "read-only",
         workingDirectory: "/repo/subdir",
       },
       prompt: "collect findings",

--- a/test/telegram_adapter.test.js
+++ b/test/telegram_adapter.test.js
@@ -112,7 +112,6 @@ function createStatusSnapshot(overrides = {}) {
     settings: {
       personaId: "default",
       reasoning: "medium",
-      riskLevel: "read-write",
     },
     bootstrap: {
       model: {

--- a/test/telegram_cli.test.js
+++ b/test/telegram_cli.test.js
@@ -38,7 +38,6 @@ describe("telegram cli", () => {
           workspaceRoot: "project-workspaces",
           workingDirectory: "packages/core",
           persona: "gpt-5.5-coder:high",
-          riskLevel: "read-only",
         },
       },
     });
@@ -61,7 +60,6 @@ describe("telegram cli", () => {
           workspaceRoot: join(dir, "project-workspaces"),
           workingDirectory: "packages/core",
           persona: "gpt-5.5-coder:high",
-          riskLevel: "read-only",
         },
       },
     });

--- a/test/ui_components.test.js
+++ b/test/ui_components.test.js
@@ -44,7 +44,6 @@ function createSlashProvider(options = {}) {
     () => options.files ?? [],
     () => options.skills ?? [],
     () => options.agents ?? [],
-    () => options.riskLevels ?? ["read-only", "read-write"],
   );
 }
 
@@ -293,17 +292,15 @@ test("PendingMessagesComponent distinguishes steering and queued previews", () =
   );
 });
 
-test("FooterComponent renders risk label with styling", () => {
+test("FooterComponent renders session status", () => {
   const theme = createTagTheme();
   const ui = { requestRender() {} };
   const footer = new FooterComponent(theme, ui);
   footer.setStatus({
     contextUsage: "ctx 10/100",
     sessionCost: "$0.01",
-    riskLevel: "read-only",
   });
   const line = renderLines(footer, 120)[0];
-  expect(line).toContain("<riskReadOnlyText>read-only</riskReadOnlyText>");
   expect(line).toContain("<textDim>ctx 10/100 · $0.01</textDim>");
 });
 
@@ -314,7 +311,6 @@ test("FooterComponent compacts cwd before truncating and keeps ellipsis styled",
   footer.setStatus({
     contextUsage: "ctx",
     sessionCost: "$0.01",
-    riskLevel: "read-only",
   });
 
   const compactLine = renderLines(footer, 50)[0];
@@ -323,7 +319,6 @@ test("FooterComponent compacts cwd before truncating and keeps ellipsis styled",
   footer.setStatus({
     contextUsage: "this is a very long context usage string",
     sessionCost: "$0.01",
-    riskLevel: "read-only",
   });
 
   const truncatedLine = renderLines(footer, 40)[0];

--- a/test/view_image_tool.test.js
+++ b/test/view_image_tool.test.js
@@ -78,14 +78,11 @@ describe("view_image tool", () => {
 
       const backend = createLocalToolExecutionBackend();
       const tool = createViewImageToolDefinition(backend);
-      const result = await tool.dispatch(
-        {
-          id: "tool-1",
-          name: TOOL_NAME_VIEW_IMAGE,
-          arguments: { path: filePath },
-        },
-        "read-only",
-      );
+      const result = await tool.dispatch({
+        id: "tool-1",
+        name: TOOL_NAME_VIEW_IMAGE,
+        arguments: { path: filePath },
+      });
 
       expect(result.kind).toBe("single");
       if (result.kind !== "single") {
@@ -120,14 +117,11 @@ describe("view_image tool", () => {
 
       const backend = createLocalToolExecutionBackend();
       const tool = createViewImageToolDefinition(backend);
-      const result = await tool.dispatch(
-        {
-          id: "tool-2",
-          name: TOOL_NAME_VIEW_IMAGE,
-          arguments: { path: filePath },
-        },
-        "read-only",
-      );
+      const result = await tool.dispatch({
+        id: "tool-2",
+        name: TOOL_NAME_VIEW_IMAGE,
+        arguments: { path: filePath },
+      });
 
       expect(result.kind).toBe("single");
       if (result.kind !== "single") {
@@ -159,14 +153,11 @@ describe("view_image tool", () => {
 
       const backend = createLocalToolExecutionBackend();
       const tool = createViewImageToolDefinition(backend);
-      const result = await tool.dispatch(
-        {
-          id: "tool-3",
-          name: TOOL_NAME_VIEW_IMAGE,
-          arguments: { path: filePath },
-        },
-        "read-only",
-      );
+      const result = await tool.dispatch({
+        id: "tool-3",
+        name: TOOL_NAME_VIEW_IMAGE,
+        arguments: { path: filePath },
+      });
 
       expect(result.kind).toBe("single");
       if (result.kind !== "single") {
@@ -205,14 +196,11 @@ describe("view_image tool", () => {
 
       const backend = createLocalToolExecutionBackend();
       const tool = createViewImageToolDefinition(backend);
-      const result = await tool.dispatch(
-        {
-          id: "tool-4",
-          name: TOOL_NAME_VIEW_IMAGE,
-          arguments: { path: filePath },
-        },
-        "read-only",
-      );
+      const result = await tool.dispatch({
+        id: "tool-4",
+        name: TOOL_NAME_VIEW_IMAGE,
+        arguments: { path: filePath },
+      });
 
       expect(result.kind).toBe("single");
       if (result.kind !== "single") {


### PR DESCRIPTION
## why

Tau's risk levels duplicate tool availability with a second runtime authorization layer that flows through configuration, prompts, sessions, protocol contracts, SDK APIs, subagents, and the TUI. Removing that concept makes enabled tools behave consistently and leaves persona and subagent tool lists as the single access boundary.

Strict unknown-field rejection also made persisted snapshots, protocol payloads, and user-authored configuration unnecessarily brittle across versions.

## what

Remove risk levels and bash safety classification from the complete Tau stack, including runtime tool dispatch, session state, protocol and SDK contracts, CLI and TUI controls, subagent configuration, Telegram integration, themes, prompts, tests, and documentation.

Versioned protocol data and configuration schemas now accept and strip unknown object fields while continuing to validate known fields, required values, discriminators, and method names. Immediate tool-call argument schemas remain strict.

fixes #283
