### PR TITLE
unify tool dispatch

### DIFF
--- a/src/core/session/runner.ts
+++ b/src/core/session/runner.ts
@@ -14,13 +14,7 @@ import type {
   RunnerAssistantPartialEvent,
   RunnerToolResultEvent,
 } from "../events/types.js";
-import type {
-  ToolDefinition,
-  ToolDispatchContext,
-  ToolDispatchResult,
-  ToolDispatchResultWithPhases,
-  ToolRegistry,
-} from "../tools/registry.js";
+import type { ToolDefinition, ToolDispatchContext, ToolRegistry } from "../tools/registry.js";
 import { createToolError } from "../utils/messages.js";
 import type { ModelRuntime } from "../utils/model_stream.js";
 import type { TauStreamOptions } from "../utils/streaming_settings.js";
@@ -323,88 +317,6 @@ export class SequentialToolCallRunner implements AsyncIterable<ToolRunnerEvent> 
   }
 }
 
-type PhasedToolRaceResult =
-  | { type: "run"; result: ToolDispatchResult }
-  | { type: "run_error"; error: unknown }
-  | { type: "ui"; result: IteratorResult<CoreToolUiEvent["uiEvent"]> }
-  | { type: "ui_error"; error: unknown };
-
-async function* runPhasedToolResult(
-  result: ToolDispatchResultWithPhases,
-): AsyncGenerator<ToolRunnerEvent, ToolDispatchResult, void> {
-  if (!result.uiEvents) {
-    return await result.run;
-  }
-
-  const iterator = result.uiEvents[Symbol.asyncIterator]();
-  let runSettled = false;
-  let uiSettled = false;
-  let finalResult: ToolDispatchResult | undefined;
-  let runPromise: Promise<PhasedToolRaceResult> | undefined = result.run.then(
-    (value) => ({ type: "run", result: value }),
-    (error: unknown) => ({ type: "run_error", error }),
-  );
-  let uiPromise: Promise<PhasedToolRaceResult> | undefined = iterator.next().then(
-    (value) => ({ type: "ui", result: value }),
-    (error: unknown) => ({ type: "ui_error", error }),
-  );
-
-  while (!runSettled) {
-    const pending = [runPromise, uiPromise].filter(
-      (promise): promise is Promise<PhasedToolRaceResult> => Boolean(promise),
-    );
-    const next = await Promise.race(pending);
-
-    switch (next.type) {
-      case "run":
-        runSettled = true;
-        finalResult = next.result;
-        break;
-      case "run_error":
-        runSettled = true;
-        await iterator.return?.();
-        throw next.error;
-      case "ui":
-        if (next.result.done) {
-          uiSettled = true;
-          uiPromise = undefined;
-        } else {
-          yield { type: "tool_ui", uiEvent: next.result.value };
-          uiPromise = iterator.next().then(
-            (value) => ({ type: "ui", result: value }),
-            (error: unknown) => ({ type: "ui_error", error }),
-          );
-        }
-        break;
-      case "ui_error":
-        uiSettled = true;
-        uiPromise = undefined;
-        yield {
-          type: "notice",
-          severity: "warn",
-          text: `tool UI update stream failed: ${next.error instanceof Error ? next.error.message : String(next.error)}`,
-        };
-        break;
-    }
-
-    if (uiSettled) {
-      uiPromise = undefined;
-    }
-    if (runSettled) {
-      runPromise = undefined;
-    }
-  }
-
-  if (!uiSettled) {
-    await iterator.return?.();
-  }
-
-  if (!finalResult) {
-    throw new Error("phased tool completed without a result");
-  }
-  return finalResult;
-}
-
 export async function* runToolCalls(
   options: RunToolCallsOptions,
 ): AsyncGenerator<ToolRunnerEvent, void, void> {
@@ -471,13 +383,11 @@ export async function* runToolCalls(
 
     const { index, toolCall, def } = entry;
     try {
-      const dispatched = await def.dispatch(toolCall, signal, dispatchContext);
-      if (dispatched.kind === "phased" && dispatched.startedUiEvent) {
-        yield { type: "tool_ui", uiEvent: dispatched.startedUiEvent };
+      const dispatch = await def.dispatch(toolCall, signal, dispatchContext);
+      if (dispatch.startedUiEvent) {
+        yield { type: "tool_ui", uiEvent: dispatch.startedUiEvent };
       }
-      const result =
-        dispatched.kind === "phased" ? yield* runPhasedToolResult(dispatched) : dispatched;
-      const { toolResult, uiEvent } = result;
+      const { toolResult, uiEvent } = await dispatch.run;
       resultsByIndex.set(index, toolResult);
       if (uiEvent) {
         yield { type: "tool_ui", uiEvent };

--- a/src/core/tools/bash.ts
+++ b/src/core/tools/bash.ts
@@ -16,13 +16,14 @@ import {
 import type { ToolExecutionBackend } from "./execution_backend.js";
 import type {
   ToolDefinition,
+  ToolDispatch,
   ToolDispatchContext,
   ToolDispatchResult,
-  ToolDispatchResultWithPhases,
   ToolUiEvent,
   ToolUiLine,
   ToolUiText,
 } from "./registry.js";
+import { createToolDispatch } from "./registry.js";
 import { TOOL_NAME_BASH } from "./tool_names.js";
 
 const BASH_MODEL_DEFAULT_MAX_TOKENS = 8192;
@@ -386,7 +387,7 @@ export function createBashToolDefinition(backend: ToolExecutionBackend): ToolDef
       toolCall: ToolCall,
       signal: AbortSignal,
       context: ToolDispatchContext,
-    ): Promise<ToolDispatchResult | ToolDispatchResultWithPhases> {
+    ): Promise<ToolDispatch> {
       const parsedArgs = parseBashArgs(toolCall.arguments);
       const commandForDisplay = parsedArgs.ok
         ? parsedArgs.data.commandForDisplay
@@ -402,11 +403,11 @@ export function createBashToolDefinition(backend: ToolExecutionBackend): ToolDef
           headerTarget,
           reason,
         };
-        return { kind: "single", toolResult, uiEvent };
+        return { toolResult, uiEvent };
       };
 
       if (!parsedArgs.ok) {
-        return blocked(`Invalid arguments: ${parsedArgs.error}`);
+        return createToolDispatch(() => blocked(`Invalid arguments: ${parsedArgs.error}`));
       }
 
       const { command, workingDirectory, timeout, maxOutputTokens, hasMaxOutputTokens } =
@@ -417,9 +418,7 @@ export function createBashToolDefinition(backend: ToolExecutionBackend): ToolDef
         workingDirectory,
       });
 
-      // All acceptance checks passed; return two-phase result
       return {
-        kind: "phased",
         startedUiEvent: {
           type: "bash_started",
           toolCallId: toolCall.id,
@@ -472,7 +471,7 @@ export function createBashToolDefinition(backend: ToolExecutionBackend): ToolDef
               uiText,
               durationMs,
             };
-            return { kind: "single", toolResult, uiEvent };
+            return { toolResult, uiEvent };
           } catch (e) {
             const msg = `Bash tool execution failed: ${e instanceof Error ? e.message : String(e)}`;
             const toolResult = createToolError(toolCall, msg);
@@ -483,7 +482,7 @@ export function createBashToolDefinition(backend: ToolExecutionBackend): ToolDef
               reason: msg,
               toolCallId: toolCall.id,
             };
-            return { kind: "single", toolResult, uiEvent };
+            return { toolResult, uiEvent };
           }
         })(),
       };

--- a/src/core/tools/edit.ts
+++ b/src/core/tools/edit.ts
@@ -7,11 +7,13 @@ import { formatZodError } from "../utils/zod.js";
 import type { ToolExecutionBackend } from "./execution_backend.js";
 import type {
   ToolDefinition,
+  ToolDispatch,
   ToolDispatchResult,
   ToolUiEvent,
   ToolUiLine,
   ToolUiText,
 } from "./registry.js";
+import { createToolDispatch } from "./registry.js";
 import { TOOL_NAME_EDIT } from "./tool_names.js";
 
 const EDIT_DESCRIPTION = [
@@ -121,109 +123,115 @@ function buildEditUiText(args: {
 export function createEditToolDefinition(backend: ToolExecutionBackend): ToolDefinition {
   return {
     schema: EDIT_TOOL,
-    async dispatch(toolCall: ToolCall): Promise<ToolDispatchResult> {
-      const parsedArgs = parseEditArgs(toolCall.arguments);
-      const path = parsedArgs.ok ? parsedArgs.data.path : "";
-      const headerTarget = path || "(invalid arguments)";
+    async dispatch(toolCall: ToolCall): Promise<ToolDispatch> {
+      return createToolDispatch(async () => {
+        const parsedArgs = parseEditArgs(toolCall.arguments);
+        const path = parsedArgs.ok ? parsedArgs.data.path : "";
+        const headerTarget = path || "(invalid arguments)";
 
-      const blocked = (reason: string): ToolDispatchResult => {
-        const toolResult = createToolError(toolCall, reason);
-        const uiEvent: ToolUiEvent = {
-          type: "edit_blocked",
-          toolCallId: toolCall.id,
-          path: path || "(invalid path)",
-          headerTarget,
-          reason,
+        const blocked = (reason: string): ToolDispatchResult => {
+          const toolResult = createToolError(toolCall, reason);
+          const uiEvent: ToolUiEvent = {
+            type: "edit_blocked",
+            toolCallId: toolCall.id,
+            path: path || "(invalid path)",
+            headerTarget,
+            reason,
+          };
+          return { toolResult, uiEvent };
         };
-        return { kind: "single", toolResult, uiEvent };
-      };
 
-      if (!parsedArgs.ok) {
-        return blocked(`Invalid arguments: ${parsedArgs.error}`);
-      }
-
-      const { oldText, newText } = parsedArgs.data;
-
-      let content: string;
-      try {
-        const result = await backend.readFile(path);
-        content = result.content;
-      } catch (e) {
-        const errorMessage = e instanceof Error ? e.message : String(e);
-        if ((e as NodeJS.ErrnoException).code === "ENOENT") {
-          return blocked(`File not found at '${path}'. Verify the path is correct.`);
+        if (!parsedArgs.ok) {
+          return blocked(`Invalid arguments: ${parsedArgs.error}`);
         }
-        return blocked(`Could not read file: ${errorMessage}`);
-      }
 
-      const matchCount = countOccurrences(content, oldText);
+        const { oldText, newText } = parsedArgs.data;
 
-      if (matchCount === 0) {
-        // Provide helpful context for debugging
-        const trimmedOld = oldText.trim();
-        const trimmedCount = trimmedOld !== oldText ? countOccurrences(content, trimmedOld) : 0;
-
-        let hint = "";
-        if (trimmedCount > 0) {
-          hint =
-            " Hint: Found matches when ignoring leading/trailing whitespace. Check that your oldText exactly matches the file content, including whitespace.";
-        } else if (oldText.includes("\n")) {
-          hint =
-            " Hint: Your search contains newlines. Ensure line endings match the file (LF vs CRLF) and indentation is exact.";
-        } else {
-          // Check for partial matches
-          const words = oldText.split(/\s+/).filter((w) => w.length > 3);
-          const partialMatches = words.filter((w) => content.includes(w));
-          if (partialMatches.length > 0 && partialMatches.length < words.length) {
-            hint = ` Hint: Some words from oldText were found ('${partialMatches.slice(0, 3).join("', '")}'), but the exact string was not. Check for typos or extra whitespace.`;
+        let content: string;
+        try {
+          const result = await backend.readFile(path);
+          content = result.content;
+        } catch (e) {
+          const errorMessage = e instanceof Error ? e.message : String(e);
+          if ((e as NodeJS.ErrnoException).code === "ENOENT") {
+            return blocked(`File not found at '${path}'. Verify the path is correct.`);
           }
+          return blocked(`Could not read file: ${errorMessage}`);
         }
 
-        return blocked(
-          `No exact match for oldText was found in the file.${hint} Read the file first to see its current content.`,
-        );
-      }
+        const matchCount = countOccurrences(content, oldText);
 
-      if (matchCount > 1) {
-        const firstMatchContext = findMatchContext(content, oldText);
-        return blocked(
-          `Found ${matchCount} matches for oldText, but exactly 1 is required. Make oldText more specific to match only one location.\n\nFirst match context:\n${firstMatchContext}`,
-        );
-      }
+        if (matchCount === 0) {
+          // Provide helpful context for debugging
+          const trimmedOld = oldText.trim();
+          const trimmedCount = trimmedOld !== oldText ? countOccurrences(content, trimmedOld) : 0;
 
-      // Exactly one match -> perform the replacement
-      const newContent = content.replace(oldText, () => newText);
+          let hint = "";
+          if (trimmedCount > 0) {
+            hint =
+              " Hint: Found matches when ignoring leading/trailing whitespace. Check that your oldText exactly matches the file content, including whitespace.";
+          } else if (oldText.includes("\n")) {
+            hint =
+              " Hint: Your search contains newlines. Ensure line endings match the file (LF vs CRLF) and indentation is exact.";
+          } else {
+            // Check for partial matches
+            const words = oldText.split(/\s+/).filter((w) => w.length > 3);
+            const partialMatches = words.filter((w) => content.includes(w));
+            if (partialMatches.length > 0 && partialMatches.length < words.length) {
+              hint = ` Hint: Some words from oldText were found ('${partialMatches.slice(0, 3).join("', '")}'), but the exact string was not. Check for typos or extra whitespace.`;
+            }
+          }
 
-      try {
-        await backend.writeFile(path, newContent);
+          return blocked(
+            `No exact match for oldText was found in the file.${hint} Read the file first to see its current content.`,
+          );
+        }
 
-        const { lines: diffLines, added, removed } = buildLineDiff(oldText, newText);
-        const sizeDiff = newText.length - oldText.length;
-        const sizeDiffStr =
-          sizeDiff === 0 ? "Same size" : sizeDiff > 0 ? `+${sizeDiff} chars` : `${sizeDiff} chars`;
-        const summaryLine = `Successfully edited ${path}: ${oldText.length} → ${newText.length} chars (${sizeDiffStr})`;
-        const statusLine = `+${added}, -${removed} · ${oldText.length} → ${newText.length} chars (${sizeDiffStr})`;
+        if (matchCount > 1) {
+          const firstMatchContext = findMatchContext(content, oldText);
+          return blocked(
+            `Found ${matchCount} matches for oldText, but exactly 1 is required. Make oldText more specific to match only one location.\n\nFirst match context:\n${firstMatchContext}`,
+          );
+        }
 
-        const resultText = formatEditToolResultText({ summaryLine });
+        // Exactly one match -> perform the replacement
+        const newContent = content.replace(oldText, () => newText);
 
-        const toolResult = createToolSuccess(toolCall, resultText);
-        const uiText = buildEditUiText({ summaryLine, statusLine, diffLines });
-        const uiEvent: ToolUiEvent = {
-          type: "edit_success",
-          toolCallId: toolCall.id,
-          path,
-          headerTarget,
-          oldLength: oldText.length,
-          newLength: newText.length,
-          oldText,
-          newText,
-          uiText,
-        };
-        return { kind: "single", toolResult, uiEvent };
-      } catch (e) {
-        const errorMessage = e instanceof Error ? e.message : String(e);
-        return blocked(`Could not write file: ${errorMessage}`);
-      }
+        try {
+          await backend.writeFile(path, newContent);
+
+          const { lines: diffLines, added, removed } = buildLineDiff(oldText, newText);
+          const sizeDiff = newText.length - oldText.length;
+          const sizeDiffStr =
+            sizeDiff === 0
+              ? "Same size"
+              : sizeDiff > 0
+                ? `+${sizeDiff} chars`
+                : `${sizeDiff} chars`;
+          const summaryLine = `Successfully edited ${path}: ${oldText.length} → ${newText.length} chars (${sizeDiffStr})`;
+          const statusLine = `+${added}, -${removed} · ${oldText.length} → ${newText.length} chars (${sizeDiffStr})`;
+
+          const resultText = formatEditToolResultText({ summaryLine });
+
+          const toolResult = createToolSuccess(toolCall, resultText);
+          const uiText = buildEditUiText({ summaryLine, statusLine, diffLines });
+          const uiEvent: ToolUiEvent = {
+            type: "edit_success",
+            toolCallId: toolCall.id,
+            path,
+            headerTarget,
+            oldLength: oldText.length,
+            newLength: newText.length,
+            oldText,
+            newText,
+            uiText,
+          };
+          return { toolResult, uiEvent };
+        } catch (e) {
+          const errorMessage = e instanceof Error ? e.message : String(e);
+          return blocked(`Could not write file: ${errorMessage}`);
+        }
+      });
     },
   };
 }

--- a/src/core/tools/emit_output.ts
+++ b/src/core/tools/emit_output.ts
@@ -4,8 +4,10 @@ import { z } from "zod";
 import { createToolError, createToolSuccess } from "../utils/messages.js";
 import { formatZodError } from "../utils/zod.js";
 import {
+  createToolDispatch,
   isSubagentToolDispatchContext,
   type ToolDefinition,
+  type ToolDispatch,
   type ToolDispatchContext,
   type ToolDispatchResult,
 } from "./registry.js";
@@ -53,30 +55,32 @@ export function createEmitOutputToolDefinition(): ToolDefinition {
       toolCall: ToolCall,
       _signal: AbortSignal,
       context: ToolDispatchContext,
-    ): Promise<ToolDispatchResult> {
-      const parsedArgs = parseEmitOutputArgs(toolCall.arguments);
+    ): Promise<ToolDispatch> {
+      return createToolDispatch(async () => {
+        const parsedArgs = parseEmitOutputArgs(toolCall.arguments);
 
-      const blocked = (reason: string): ToolDispatchResult => {
-        const toolResult = createToolError(toolCall, reason);
-        return { kind: "single", toolResult };
-      };
+        const blocked = (reason: string): ToolDispatchResult => {
+          const toolResult = createToolError(toolCall, reason);
+          return { toolResult };
+        };
 
-      if (!parsedArgs.ok) {
-        return blocked(`Invalid arguments: ${parsedArgs.error}`);
-      }
+        if (!parsedArgs.ok) {
+          return blocked(`Invalid arguments: ${parsedArgs.error}`);
+        }
 
-      const { text } = parsedArgs.data;
+        const { text } = parsedArgs.data;
 
-      if (!isSubagentToolDispatchContext(context)) {
-        return blocked("The emit_output tool is only available to subagents.");
-      }
+        if (!isSubagentToolDispatchContext(context)) {
+          return blocked("The emit_output tool is only available to subagents.");
+        }
 
-      const { subagentContext } = context;
+        const { subagentContext } = context;
 
-      subagentContext.controlPlane.recordEmitOutput(subagentContext.id, text);
+        subagentContext.controlPlane.recordEmitOutput(subagentContext.id, text);
 
-      const toolResult = createToolSuccess(toolCall, "Emitted.");
-      return { kind: "single", toolResult };
+        const toolResult = createToolSuccess(toolCall, "Emitted.");
+        return { toolResult };
+      });
     },
   };
 }

--- a/src/core/tools/grep.ts
+++ b/src/core/tools/grep.ts
@@ -8,12 +8,13 @@ import { formatZodError } from "../utils/zod.js";
 import type { ToolExecutionBackend } from "./execution_backend.js";
 import type {
   ToolDefinition,
+  ToolDispatch,
   ToolDispatchResult,
-  ToolDispatchResultWithPhases,
   ToolUiEvent,
   ToolUiLine,
   ToolUiText,
 } from "./registry.js";
+import { createToolDispatch } from "./registry.js";
 import { TOOL_NAME_GREP } from "./tool_names.js";
 
 export const GREP_TOOL_MAX_TOKENS = 8192;
@@ -229,10 +230,7 @@ function buildGrepUiText(args: {
 export function createGrepToolDefinition(backend: ToolExecutionBackend): ToolDefinition {
   return {
     schema: GREP_TOOL,
-    async dispatch(
-      toolCall: ToolCall,
-      signal?: AbortSignal,
-    ): Promise<ToolDispatchResult | ToolDispatchResultWithPhases> {
+    async dispatch(toolCall: ToolCall, signal?: AbortSignal): Promise<ToolDispatch> {
       const parsedArgs = parseGrepArgs(toolCall.arguments);
       const pattern = parsedArgs.ok ? parsedArgs.data.pattern : "";
       const headerTarget = pattern || "(invalid arguments)";
@@ -246,11 +244,11 @@ export function createGrepToolDefinition(backend: ToolExecutionBackend): ToolDef
           headerTarget,
           reason,
         };
-        return { kind: "single", toolResult, uiEvent };
+        return { toolResult, uiEvent };
       };
 
       if (!parsedArgs.ok) {
-        return blocked(`invalid arguments: ${parsedArgs.error}`);
+        return createToolDispatch(() => blocked(`invalid arguments: ${parsedArgs.error}`));
       }
 
       const parsed = parsedArgs.data;
@@ -265,11 +263,10 @@ export function createGrepToolDefinition(backend: ToolExecutionBackend): ToolDef
         });
       } catch (e) {
         const errorMessage = e instanceof Error ? e.message : String(e);
-        return blocked(`grep failed: ${errorMessage}`);
+        return createToolDispatch(() => blocked(`grep failed: ${errorMessage}`));
       }
 
       return {
-        kind: "phased",
         startedUiEvent: {
           type: "grep_started",
           toolCallId: toolCall.id,
@@ -324,7 +321,7 @@ export function createGrepToolDefinition(backend: ToolExecutionBackend): ToolDef
             uiText,
           };
 
-          return { kind: "single", toolResult, uiEvent };
+          return { toolResult, uiEvent };
         })(),
       };
     },

--- a/src/core/tools/list.ts
+++ b/src/core/tools/list.ts
@@ -8,11 +8,13 @@ import { formatZodError } from "../utils/zod.js";
 import type { ToolExecutionBackend } from "./execution_backend.js";
 import type {
   ToolDefinition,
+  ToolDispatch,
   ToolDispatchResult,
   ToolUiEvent,
   ToolUiLine,
   ToolUiText,
 } from "./registry.js";
+import { createToolDispatch } from "./registry.js";
 import { TOOL_NAME_LIST } from "./tool_names.js";
 
 export const LIST_MAX_ENTRIES = 4096;
@@ -99,73 +101,75 @@ function buildListUiText(args: {
 export function createListToolDefinition(backend: ToolExecutionBackend): ToolDefinition {
   return {
     schema: LIST_TOOL,
-    async dispatch(toolCall: ToolCall): Promise<ToolDispatchResult> {
-      const parsedArgs = parseListArgs(toolCall.arguments);
-      const path = parsedArgs.ok ? parsedArgs.data.path : "";
-      const headerTarget = path || "(invalid arguments)";
+    async dispatch(toolCall: ToolCall): Promise<ToolDispatch> {
+      return createToolDispatch(async () => {
+        const parsedArgs = parseListArgs(toolCall.arguments);
+        const path = parsedArgs.ok ? parsedArgs.data.path : "";
+        const headerTarget = path || "(invalid arguments)";
 
-      const blocked = (reason: string): ToolDispatchResult => {
-        const toolResult = createToolError(toolCall, reason);
-        const uiEvent: ToolUiEvent = {
-          type: "list_blocked",
-          toolCallId: toolCall.id,
-          path: path || "(invalid path)",
-          headerTarget,
-          reason,
-        };
-        return { kind: "single", toolResult, uiEvent };
-      };
-
-      if (!parsedArgs.ok) {
-        return blocked(`invalid arguments: ${parsedArgs.error}`);
-      }
-
-      const { offset, limit } = parsedArgs.data;
-      const effectiveLimit = Math.min(Math.max(1, limit), LIST_MAX_ENTRIES);
-
-      try {
-        const { path: resolvedPath, entries: dirents } = await backend.listDir(path);
-
-        const entries = dirents
-          .map((d) => ({
-            name: d.name,
-            suffix: d.isDirectory ? "/" : d.isSymlink ? "@" : "",
-          }))
-          .sort((a, b) => a.name.localeCompare(b.name))
-          .map((e) => `${e.name}${e.suffix}`);
-
-        const total = entries.length;
-        const windowed = entries.slice(offset, offset + effectiveLimit);
-
-        const toolText = formatListToolResultText(windowed);
-        const uiText = buildListUiText({
-          offset,
-          limit: effectiveLimit,
-          total,
-          returned: windowed.length,
-          entries: windowed,
-          fullText: toolText,
-        });
-
-        const toolResult: ToolResultMessage = createToolResult(toolCall, toolText, false);
-        const uiEvent: ToolUiEvent = {
-          type: "list_success",
-          toolCallId: toolCall.id,
-          path: resolvedPath,
-          headerTarget: resolvedPath,
-          offset,
-          limit: effectiveLimit,
-          total,
-          returned: windowed.length,
-          entries: windowed,
-          uiText,
+        const blocked = (reason: string): ToolDispatchResult => {
+          const toolResult = createToolError(toolCall, reason);
+          const uiEvent: ToolUiEvent = {
+            type: "list_blocked",
+            toolCallId: toolCall.id,
+            path: path || "(invalid path)",
+            headerTarget,
+            reason,
+          };
+          return { toolResult, uiEvent };
         };
 
-        return { kind: "single", toolResult, uiEvent };
-      } catch (e) {
-        const errorMessage = e instanceof Error ? e.message : String(e);
-        return blocked(`list failed: ${errorMessage}`);
-      }
+        if (!parsedArgs.ok) {
+          return blocked(`invalid arguments: ${parsedArgs.error}`);
+        }
+
+        const { offset, limit } = parsedArgs.data;
+        const effectiveLimit = Math.min(Math.max(1, limit), LIST_MAX_ENTRIES);
+
+        try {
+          const { path: resolvedPath, entries: dirents } = await backend.listDir(path);
+
+          const entries = dirents
+            .map((d) => ({
+              name: d.name,
+              suffix: d.isDirectory ? "/" : d.isSymlink ? "@" : "",
+            }))
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .map((e) => `${e.name}${e.suffix}`);
+
+          const total = entries.length;
+          const windowed = entries.slice(offset, offset + effectiveLimit);
+
+          const toolText = formatListToolResultText(windowed);
+          const uiText = buildListUiText({
+            offset,
+            limit: effectiveLimit,
+            total,
+            returned: windowed.length,
+            entries: windowed,
+            fullText: toolText,
+          });
+
+          const toolResult: ToolResultMessage = createToolResult(toolCall, toolText, false);
+          const uiEvent: ToolUiEvent = {
+            type: "list_success",
+            toolCallId: toolCall.id,
+            path: resolvedPath,
+            headerTarget: resolvedPath,
+            offset,
+            limit: effectiveLimit,
+            total,
+            returned: windowed.length,
+            entries: windowed,
+            uiText,
+          };
+
+          return { toolResult, uiEvent };
+        } catch (e) {
+          const errorMessage = e instanceof Error ? e.message : String(e);
+          return blocked(`list failed: ${errorMessage}`);
+        }
+      });
     },
   };
 }

--- a/src/core/tools/nook.ts
+++ b/src/core/tools/nook.ts
@@ -12,12 +12,13 @@ import { formatZodError } from "../utils/zod.js";
 import type { ToolExecutionBackend } from "./execution_backend.js";
 import type {
   ToolDefinition,
+  ToolDispatch,
   ToolDispatchContext,
-  ToolDispatchResult,
   ToolUiEvent,
   ToolUiLine,
   ToolUiText,
 } from "./registry.js";
+import { createToolDispatch } from "./registry.js";
 import { TOOL_NAME_NOOK } from "./tool_names.js";
 
 const NOOK_DESCRIPTION = [
@@ -181,136 +182,135 @@ export function createNookToolDefinition(backend: ToolExecutionBackend): ToolDef
       toolCall: ToolCall,
       _signal: AbortSignal,
       context: ToolDispatchContext,
-    ): Promise<ToolDispatchResult> {
-      const parsed = nookArgsSchema.safeParse(toolCall.arguments);
-      if (!parsed.success) {
-        const message = `Invalid arguments: ${formatZodError(parsed.error)}`;
-        return {
-          kind: "single",
-          toolResult: createToolError(toolCall, message),
-          uiEvent: buildUiEvent(toolCall, "error", message),
-        };
-      }
-
-      try {
-        const args = parsed.data;
-        const client = createNookClientFromConfig({ config: context.config });
-        let result: unknown;
-
-        switch (args.operation) {
-          case "read_skill":
-            result = await client.readSkill();
-            break;
-          case "list_sites":
-            result = { sites: await client.listSites() };
-            break;
-          case "delete_site":
-            result = await client.deleteSite(requireArg(args, "site"));
-            break;
-          case "copy_site": {
-            const site = requireArg(args, "site");
-            const directory = requireArg(args, "directory");
-            const destination = await backend.listDir(directory);
-            if (destination.entries.length > 0) {
-              throw new Error(`site copy destination is not empty: ${directory}`);
-            }
-            const manifest = await client.getSiteManifest(site);
-            const files = await client.downloadSiteFiles(site, manifest);
-            for (const file of files) {
-              await backend.writeFileBinary(joinBackendPath(directory, file.path), file.content);
-            }
-            result = {
-              site,
-              directory,
-              deploymentId: manifest.deploymentId,
-              fileCount: files.length,
-              byteCount: files.reduce((total, file) => total + file.sizeBytes, 0),
-            };
-            break;
-          }
-          case "list_templates":
-            result = { templates: await client.listTemplates() };
-            break;
-          case "copy_template": {
-            const template = requireArg(args, "template");
-            const directory = requireArg(args, "directory");
-            const destination = await backend.listDir(directory);
-            if (destination.entries.length > 0) {
-              throw new Error(`template copy destination is not empty: ${directory}`);
-            }
-            const manifest = await client.getTemplateManifest(template);
-            const files = await client.downloadTemplateFiles(template, manifest);
-            for (const file of files) {
-              await backend.writeFileBinary(joinBackendPath(directory, file.path), file.content);
-            }
-            result = {
-              template,
-              directory,
-              fileCount: files.length,
-              byteCount: files.reduce((total, file) => total + file.sizeBytes, 0),
-            };
-            break;
-          }
-          case "save_template": {
-            const files = await buildNookTemplateManifestFromBackend(
-              backend,
-              requireArg(args, "directory"),
-            );
-            result = await client.saveTemplate({
-              name: requireArg(args, "template"),
-              files,
-            });
-            break;
-          }
-          case "delete_template":
-            result = await client.deleteTemplate(requireArg(args, "template"));
-            break;
-          case "deploy_site": {
-            const directory = requireArg(args, "directory");
-            const files = await buildNookDeployManifestFromBackend(backend, directory);
-            result = await client.deploySite({
-              site: requireArg(args, "site"),
-              files,
-              visibility: args.public ? "public" : "private",
-            });
-            break;
-          }
-          case "get_kv":
-            result = {
-              site: requireArg(args, "site"),
-              key: requireArg(args, "key"),
-              value: await client.getKv(requireArg(args, "site"), requireArg(args, "key")),
-            };
-            break;
-          case "put_kv":
-            result = await client.putKv(
-              requireArg(args, "site"),
-              requireArg(args, "key"),
-              requireValue(args),
-            );
-            break;
-          case "delete_kv":
-            result = await client.deleteKv(requireArg(args, "site"), requireArg(args, "key"));
-            break;
-          case "list_kv":
-            result = await client.listKv(requireArg(args, "site"), args.prefix);
-            break;
+    ): Promise<ToolDispatch> {
+      return createToolDispatch(async () => {
+        const parsed = nookArgsSchema.safeParse(toolCall.arguments);
+        if (!parsed.success) {
+          const message = `Invalid arguments: ${formatZodError(parsed.error)}`;
+          return {
+            toolResult: createToolError(toolCall, message),
+            uiEvent: buildUiEvent(toolCall, "error", message),
+          };
         }
 
-        const text = typeof result === "string" ? result : stringifyResult(result);
-        return {
-          kind: "single",
-          toolResult: createToolSuccess(toolCall, text),
-          uiEvent: buildUiEvent(toolCall, "success", text),
-        };
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        return {
-          kind: "single",
-          toolResult: createToolError(toolCall, message),
-          uiEvent: buildUiEvent(toolCall, "error", message),
-        };
-      }
+        try {
+          const args = parsed.data;
+          const client = createNookClientFromConfig({ config: context.config });
+          let result: unknown;
+
+          switch (args.operation) {
+            case "read_skill":
+              result = await client.readSkill();
+              break;
+            case "list_sites":
+              result = { sites: await client.listSites() };
+              break;
+            case "delete_site":
+              result = await client.deleteSite(requireArg(args, "site"));
+              break;
+            case "copy_site": {
+              const site = requireArg(args, "site");
+              const directory = requireArg(args, "directory");
+              const destination = await backend.listDir(directory);
+              if (destination.entries.length > 0) {
+                throw new Error(`site copy destination is not empty: ${directory}`);
+              }
+              const manifest = await client.getSiteManifest(site);
+              const files = await client.downloadSiteFiles(site, manifest);
+              for (const file of files) {
+                await backend.writeFileBinary(joinBackendPath(directory, file.path), file.content);
+              }
+              result = {
+                site,
+                directory,
+                deploymentId: manifest.deploymentId,
+                fileCount: files.length,
+                byteCount: files.reduce((total, file) => total + file.sizeBytes, 0),
+              };
+              break;
+            }
+            case "list_templates":
+              result = { templates: await client.listTemplates() };
+              break;
+            case "copy_template": {
+              const template = requireArg(args, "template");
+              const directory = requireArg(args, "directory");
+              const destination = await backend.listDir(directory);
+              if (destination.entries.length > 0) {
+                throw new Error(`template copy destination is not empty: ${directory}`);
+              }
+              const manifest = await client.getTemplateManifest(template);
+              const files = await client.downloadTemplateFiles(template, manifest);
+              for (const file of files) {
+                await backend.writeFileBinary(joinBackendPath(directory, file.path), file.content);
+              }
+              result = {
+                template,
+                directory,
+                fileCount: files.length,
+                byteCount: files.reduce((total, file) => total + file.sizeBytes, 0),
+              };
+              break;
+            }
+            case "save_template": {
+              const files = await buildNookTemplateManifestFromBackend(
+                backend,
+                requireArg(args, "directory"),
+              );
+              result = await client.saveTemplate({
+                name: requireArg(args, "template"),
+                files,
+              });
+              break;
+            }
+            case "delete_template":
+              result = await client.deleteTemplate(requireArg(args, "template"));
+              break;
+            case "deploy_site": {
+              const directory = requireArg(args, "directory");
+              const files = await buildNookDeployManifestFromBackend(backend, directory);
+              result = await client.deploySite({
+                site: requireArg(args, "site"),
+                files,
+                visibility: args.public ? "public" : "private",
+              });
+              break;
+            }
+            case "get_kv":
+              result = {
+                site: requireArg(args, "site"),
+                key: requireArg(args, "key"),
+                value: await client.getKv(requireArg(args, "site"), requireArg(args, "key")),
+              };
+              break;
+            case "put_kv":
+              result = await client.putKv(
+                requireArg(args, "site"),
+                requireArg(args, "key"),
+                requireValue(args),
+              );
+              break;
+            case "delete_kv":
+              result = await client.deleteKv(requireArg(args, "site"), requireArg(args, "key"));
+              break;
+            case "list_kv":
+              result = await client.listKv(requireArg(args, "site"), args.prefix);
+              break;
+          }
+
+          const text = typeof result === "string" ? result : stringifyResult(result);
+          return {
+            toolResult: createToolSuccess(toolCall, text),
+            uiEvent: buildUiEvent(toolCall, "success", text),
+          };
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          return {
+            toolResult: createToolError(toolCall, message),
+            uiEvent: buildUiEvent(toolCall, "error", message),
+          };
+        }
+      });
     },
   };
 }

--- a/src/core/tools/read.ts
+++ b/src/core/tools/read.ts
@@ -13,11 +13,13 @@ import { formatZodError } from "../utils/zod.js";
 import type { ToolExecutionBackend } from "./execution_backend.js";
 import type {
   ToolDefinition,
+  ToolDispatch,
   ToolDispatchResult,
   ToolUiEvent,
   ToolUiLine,
   ToolUiText,
 } from "./registry.js";
+import { createToolDispatch } from "./registry.js";
 import { TOOL_NAME_READ } from "./tool_names.js";
 
 export const READ_TOOL_MAX_TOKENS = 8192;
@@ -134,101 +136,103 @@ function buildReadUiText(args: {
 export function createReadToolDefinition(backend: ToolExecutionBackend): ToolDefinition {
   return {
     schema: READ_TOOL,
-    async dispatch(toolCall: ToolCall): Promise<ToolDispatchResult> {
-      const parsedArgs = parseReadArgs(toolCall.arguments);
-      const path = parsedArgs.ok ? parsedArgs.data.path : "";
-      const headerTarget = path || "(invalid arguments)";
+    async dispatch(toolCall: ToolCall): Promise<ToolDispatch> {
+      return createToolDispatch(async () => {
+        const parsedArgs = parseReadArgs(toolCall.arguments);
+        const path = parsedArgs.ok ? parsedArgs.data.path : "";
+        const headerTarget = path || "(invalid arguments)";
 
-      const blocked = (reason: string): ToolDispatchResult => {
-        const toolResult = createToolError(toolCall, reason);
-        const uiEvent: ToolUiEvent = {
-          type: "read_blocked",
-          toolCallId: toolCall.id,
-          path: path || "(invalid path)",
-          headerTarget,
-          reason,
+        const blocked = (reason: string): ToolDispatchResult => {
+          const toolResult = createToolError(toolCall, reason);
+          const uiEvent: ToolUiEvent = {
+            type: "read_blocked",
+            toolCallId: toolCall.id,
+            path: path || "(invalid path)",
+            headerTarget,
+            reason,
+          };
+          return { toolResult, uiEvent };
         };
-        return { kind: "single", toolResult, uiEvent };
-      };
 
-      if (!parsedArgs.ok) {
-        return blocked(`invalid arguments: ${parsedArgs.error}`);
-      }
-
-      const { startLine, endLine } = parsedArgs.data;
-
-      if (startLine !== undefined && endLine !== undefined && endLine < startLine) {
-        return blocked("endLine must be >= startLine.");
-      }
-
-      try {
-        const { path: resolvedPath, content: rawContent } = await backend.readFile(path);
-
-        const allLines = rawContent.split("\n");
-        const totalLines = allLines.length;
-        const start = startLine ?? 1;
-        const endRequested = endLine ?? totalLines;
-        const endEffective = Math.min(endRequested, totalLines);
-        const endDisplay = endLine === undefined ? undefined : endEffective;
-
-        if (start > totalLines) {
-          return blocked(`startLine (${start}) exceeds total lines (${totalLines}).`);
+        if (!parsedArgs.ok) {
+          return blocked(`invalid arguments: ${parsedArgs.error}`);
         }
 
-        const startIndex = Math.max(0, start - 1);
-        const endIndex = Math.max(startIndex, endEffective);
+        const { startLine, endLine } = parsedArgs.data;
 
-        const selected = allLines.slice(startIndex, endIndex).join("\n");
-        const selectedLines = Math.max(0, endIndex - startIndex);
-        const selectedBytes = Buffer.byteLength(selected, "utf-8");
-        const captureTruncated = selectedBytes > READ_MAX_CAPTURE_BYTES;
-        const captured = captureTruncated
-          ? truncateToBytesFromStart(selected, READ_MAX_CAPTURE_BYTES)
-          : selected;
+        if (startLine !== undefined && endLine !== undefined && endLine < startLine) {
+          return blocked("endLine must be >= startLine.");
+        }
 
-        const modelTruncation = truncateForTokens(captured, {
-          maxTokens: READ_TOOL_MAX_TOKENS,
-          strategy: "head",
-        });
+        try {
+          const { path: resolvedPath, content: rawContent } = await backend.readFile(path);
 
-        const toolText = formatReadToolResultText({
-          content: modelTruncation.content,
-          truncation: modelTruncation,
-          captureTruncated,
-          totalLines: selectedLines,
-        });
+          const allLines = rawContent.split("\n");
+          const totalLines = allLines.length;
+          const start = startLine ?? 1;
+          const endRequested = endLine ?? totalLines;
+          const endEffective = Math.min(endRequested, totalLines);
+          const endDisplay = endLine === undefined ? undefined : endEffective;
 
-        const uiText = buildReadUiText({
-          modelTruncation,
-          startLine: start,
-          endLine: endDisplay,
-          fullText: toolText,
-          totalLines: selectedLines,
-          captureTruncated,
-        });
+          if (start > totalLines) {
+            return blocked(`startLine (${start}) exceeds total lines (${totalLines}).`);
+          }
 
-        const toolResult: ToolResultMessage = createToolResult(toolCall, toolText, false);
-        const uiEvent: ToolUiEvent = {
-          type: "read_success",
-          toolCallId: toolCall.id,
-          path: resolvedPath,
-          headerTarget: resolvedPath,
-          startLine: start,
-          endLine: endDisplay,
-          content: modelTruncation.content,
-          modelTruncation: {
-            truncated: modelTruncation.truncated,
-            totalLines: modelTruncation.totalLines,
-            outputLines: modelTruncation.outputLines,
-          },
-          uiText,
-        };
+          const startIndex = Math.max(0, start - 1);
+          const endIndex = Math.max(startIndex, endEffective);
 
-        return { kind: "single", toolResult, uiEvent };
-      } catch (e) {
-        const errorMessage = e instanceof Error ? e.message : String(e);
-        return blocked(`read failed: ${errorMessage}`);
-      }
+          const selected = allLines.slice(startIndex, endIndex).join("\n");
+          const selectedLines = Math.max(0, endIndex - startIndex);
+          const selectedBytes = Buffer.byteLength(selected, "utf-8");
+          const captureTruncated = selectedBytes > READ_MAX_CAPTURE_BYTES;
+          const captured = captureTruncated
+            ? truncateToBytesFromStart(selected, READ_MAX_CAPTURE_BYTES)
+            : selected;
+
+          const modelTruncation = truncateForTokens(captured, {
+            maxTokens: READ_TOOL_MAX_TOKENS,
+            strategy: "head",
+          });
+
+          const toolText = formatReadToolResultText({
+            content: modelTruncation.content,
+            truncation: modelTruncation,
+            captureTruncated,
+            totalLines: selectedLines,
+          });
+
+          const uiText = buildReadUiText({
+            modelTruncation,
+            startLine: start,
+            endLine: endDisplay,
+            fullText: toolText,
+            totalLines: selectedLines,
+            captureTruncated,
+          });
+
+          const toolResult: ToolResultMessage = createToolResult(toolCall, toolText, false);
+          const uiEvent: ToolUiEvent = {
+            type: "read_success",
+            toolCallId: toolCall.id,
+            path: resolvedPath,
+            headerTarget: resolvedPath,
+            startLine: start,
+            endLine: endDisplay,
+            content: modelTruncation.content,
+            modelTruncation: {
+              truncated: modelTruncation.truncated,
+              totalLines: modelTruncation.totalLines,
+              outputLines: modelTruncation.outputLines,
+            },
+            uiText,
+          };
+
+          return { toolResult, uiEvent };
+        } catch (e) {
+          const errorMessage = e instanceof Error ? e.message : String(e);
+          return blocked(`read failed: ${errorMessage}`);
+        }
+      });
     },
   };
 }

--- a/src/core/tools/registry.ts
+++ b/src/core/tools/registry.ts
@@ -262,17 +262,24 @@ export type ToolUiText = {
 };
 
 export type ToolDispatchResult = {
-  kind: "single";
   toolResult: ToolResultMessage;
   uiEvent?: ToolUiEvent;
 };
 
-export type ToolDispatchResultWithPhases = {
-  kind: "phased";
+export type ToolDispatch = {
   startedUiEvent?: ToolUiEvent;
-  uiEvents?: AsyncIterable<ToolUiEvent>;
   run: Promise<ToolDispatchResult>;
 };
+
+export function createToolDispatch(
+  run: ToolDispatchResult | (() => ToolDispatchResult | Promise<ToolDispatchResult>),
+  startedUiEvent?: ToolUiEvent,
+): ToolDispatch {
+  return {
+    startedUiEvent,
+    run: typeof run === "function" ? Promise.resolve().then(run) : Promise.resolve(run),
+  };
+}
 
 export type SubagentDispatchContext = {
   id: string;
@@ -338,7 +345,7 @@ export interface ToolDefinition {
     toolCall: ToolCall,
     signal: AbortSignal,
     context: ToolDispatchContext,
-  ): Promise<ToolDispatchResult | ToolDispatchResultWithPhases>;
+  ): Promise<ToolDispatch>;
 }
 
 export class ToolRegistry {

--- a/src/core/tools/send_input_to_agent.ts
+++ b/src/core/tools/send_input_to_agent.ts
@@ -6,11 +6,12 @@ import { createToolError, createToolResult } from "../utils/messages.js";
 import { parseToolArgs } from "../utils/zod.js";
 import type { ToolExecutionBackend } from "./execution_backend.js";
 import {
+  createToolDispatch,
   isMainToolDispatchContext,
   type ToolDefinition,
+  type ToolDispatch,
   type ToolDispatchContext,
   type ToolDispatchResult,
-  type ToolDispatchResultWithPhases,
   type ToolUiEvent,
 } from "./registry.js";
 import { buildSubagentUiText } from "./subagent_ui.js";
@@ -64,7 +65,7 @@ export function createSendInputToAgentToolDefinition(
       toolCall: ToolCall,
       signal: AbortSignal,
       context: ToolDispatchContext,
-    ): Promise<ToolDispatchResult | ToolDispatchResultWithPhases> {
+    ): Promise<ToolDispatch> {
       let id = "";
       let prompt = "";
       let headerTarget = "(invalid arguments)";
@@ -83,28 +84,30 @@ export function createSendInputToAgentToolDefinition(
           headerTarget: details?.title ?? headerTarget,
           reason,
         };
-        return { kind: "single", toolResult, uiEvent } satisfies ToolDispatchResult;
+        return { toolResult, uiEvent } satisfies ToolDispatchResult;
       };
 
       const parsedArgs = parseToolArgs(sendInputArgsSchema, toolCall.arguments);
       if (!parsedArgs.ok) {
-        return blocked(`Invalid arguments: ${parsedArgs.error}`);
+        return createToolDispatch(() => blocked(`Invalid arguments: ${parsedArgs.error}`));
       }
 
       ({ id, prompt } = parsedArgs.data);
       headerTarget = id;
 
       if (!isMainToolDispatchContext(context)) {
-        return blocked("The send_input_to_agent tool is only available in the main session.", {
-          id,
-        });
+        return createToolDispatch(() =>
+          blocked("The send_input_to_agent tool is only available in the main session.", {
+            id,
+          }),
+        );
       }
 
       const controlPlane = context.subagentControlPlane;
 
       const snapshot = controlPlane.getSnapshot(id);
       if (!snapshot) {
-        return blocked(`Unknown subagent ID: ${id}`, { id, title: id });
+        return createToolDispatch(() => blocked(`Unknown subagent ID: ${id}`, { id, title: id }));
       }
 
       const config = context.config;
@@ -112,7 +115,6 @@ export function createSendInputToAgentToolDefinition(
       const target = resolveSnapshotTarget(snapshot);
 
       return {
-        kind: "phased",
         startedUiEvent: {
           type: "send_input_to_agent_started",
           toolCallId: toolCall.id,
@@ -142,7 +144,7 @@ export function createSendInputToAgentToolDefinition(
               message: reason,
               uiText,
             };
-            return { kind: "single", toolResult, uiEvent };
+            return { toolResult, uiEvent };
           }
 
           const sendResult = controlPlane.sendInput({
@@ -166,7 +168,7 @@ export function createSendInputToAgentToolDefinition(
               headerTarget: target.title,
               reason: sendResult.reason,
             };
-            return { kind: "single", toolResult, uiEvent };
+            return { toolResult, uiEvent };
           }
 
           const resultText = formatSendInputToolResult(sendResult);
@@ -187,7 +189,7 @@ export function createSendInputToAgentToolDefinition(
             status: "success",
             uiText,
           };
-          return { kind: "single", toolResult, uiEvent };
+          return { toolResult, uiEvent };
         })(),
       };
     },

--- a/src/core/tools/spawn_agent.ts
+++ b/src/core/tools/spawn_agent.ts
@@ -10,11 +10,12 @@ import { createToolError, createToolResult } from "../utils/messages.js";
 import { parseToolArgs } from "../utils/zod.js";
 import type { ToolExecutionBackend } from "./execution_backend.js";
 import {
+  createToolDispatch,
   isMainToolDispatchContext,
   type ToolDefinition,
+  type ToolDispatch,
   type ToolDispatchContext,
   type ToolDispatchResult,
-  type ToolDispatchResultWithPhases,
   type ToolUiEvent,
 } from "./registry.js";
 import { buildSubagentUiText } from "./subagent_ui.js";
@@ -108,7 +109,7 @@ export function createSpawnAgentToolDefinition(backend: ToolExecutionBackend): T
       toolCall: ToolCall,
       signal: AbortSignal,
       context: ToolDispatchContext,
-    ): Promise<ToolDispatchResult | ToolDispatchResultWithPhases> {
+    ): Promise<ToolDispatch> {
       let name = "";
       let title = "";
       let headerTarget = "(invalid arguments)";
@@ -123,12 +124,12 @@ export function createSpawnAgentToolDefinition(backend: ToolExecutionBackend): T
           headerTarget: details?.title ?? headerTarget,
           reason,
         };
-        return { kind: "single", toolResult, uiEvent } satisfies ToolDispatchResult;
+        return { toolResult, uiEvent } satisfies ToolDispatchResult;
       };
 
       const parsedArgs = parseToolArgs(spawnArgsSchema, toolCall.arguments);
       if (!parsedArgs.ok) {
-        return blocked(`Invalid arguments: ${parsedArgs.error}`);
+        return createToolDispatch(() => blocked(`Invalid arguments: ${parsedArgs.error}`));
       }
 
       const { prompt, model, workingDirectory } = parsedArgs.data;
@@ -137,10 +138,12 @@ export function createSpawnAgentToolDefinition(backend: ToolExecutionBackend): T
       headerTarget = title;
 
       if (!isMainToolDispatchContext(context)) {
-        return blocked("The spawn_agent tool is only available in the main session.", {
-          name,
-          title,
-        });
+        return createToolDispatch(() =>
+          blocked("The spawn_agent tool is only available in the main session.", {
+            name,
+            title,
+          }),
+        );
       }
 
       const { persona, cwd: baseCwd, subagentPrompts } = context;
@@ -152,7 +155,9 @@ export function createSpawnAgentToolDefinition(backend: ToolExecutionBackend): T
       let effectiveSubagentPrompts = subagentPrompts;
       if (workingDirectory) {
         if (!context.resolveSubagentRuntime) {
-          return blocked("Working-directory context resolution is unavailable.", { name, title });
+          return createToolDispatch(() =>
+            blocked("Working-directory context resolution is unavailable.", { name, title }),
+          );
         }
         try {
           const runtime = await context.resolveSubagentRuntime({ cwd, persona });
@@ -161,64 +166,78 @@ export function createSpawnAgentToolDefinition(backend: ToolExecutionBackend): T
           modelResolver = runtime.modelResolver;
           effectiveSubagentPrompts = runtime.subagentPrompts;
         } catch (error) {
-          return blocked(
-            `Failed to build the subagent prompt for workingDirectory '${cwd}': ${(error as Error).message}`,
-            {
-              name,
-              title,
-            },
+          return createToolDispatch(() =>
+            blocked(
+              `Failed to build the subagent prompt for workingDirectory '${cwd}': ${(error as Error).message}`,
+              {
+                name,
+                title,
+              },
+            ),
           );
         }
       }
       if (!effectivePersona.subagents || Object.keys(effectivePersona.subagents).length === 0) {
-        return blocked("The spawn_agent tool is not enabled for the resolved persona.", {
-          name,
-          title,
-        });
+        return createToolDispatch(() =>
+          blocked("The spawn_agent tool is not enabled for the resolved persona.", {
+            name,
+            title,
+          }),
+        );
       }
       const personaConfig = effectivePersona.subagents[name];
       if (!personaConfig) {
-        return blocked(`Subagent '${name}' is not enabled for the resolved persona.`, {
-          name,
-          title,
-        });
+        return createToolDispatch(() =>
+          blocked(`Subagent '${name}' is not enabled for the resolved persona.`, {
+            name,
+            title,
+          }),
+        );
       }
       const systemPrompt = effectiveSubagentPrompts[name];
       if (!systemPrompt) {
-        return blocked(`Subagent '${name}' is missing its system prompt.`, {
-          name,
-          title,
-        });
+        return createToolDispatch(() =>
+          blocked(`Subagent '${name}' is missing its system prompt.`, {
+            name,
+            title,
+          }),
+        );
       }
 
       let launchModelOverride: SubagentLaunchModel | undefined;
       if (model) {
         const parsedLaunchModel = parseSubagentLaunchModel(model, { resolveModel: modelResolver });
         if (parsedLaunchModel.error || !parsedLaunchModel.launchModel) {
-          return blocked(`Invalid model parameter: ${parsedLaunchModel.error}.`, {
-            name,
-            title,
-          });
+          return createToolDispatch(() =>
+            blocked(`Invalid model parameter: ${parsedLaunchModel.error}.`, {
+              name,
+              title,
+            }),
+          );
         }
 
         const launchModels = personaConfig.launchModels ?? [];
         if (launchModels.length === 0) {
-          return blocked(
-            `Subagent '${name}' does not allow launch model overrides. Allowed values: ${formatAllowedLaunchModels(launchModels)}.`,
-            {
-              name,
-              title,
-            },
+          return createToolDispatch(() =>
+            blocked(
+              `Subagent '${name}' does not allow launch model overrides. Allowed values: ${formatAllowedLaunchModels(launchModels)}.`,
+              {
+                name,
+                title,
+              },
+            ),
           );
         }
 
         if (!launchModels.includes(parsedLaunchModel.launchModel.normalized)) {
-          return blocked(
-            `Model '${parsedLaunchModel.launchModel.normalized}' is not allowed for subagent '${name}'. Allowed values: ${formatAllowedLaunchModels(launchModels)}.`,
-            {
-              name,
-              title,
-            },
+          return createToolDispatch(
+            blocked(
+              `Model '${parsedLaunchModel.launchModel.normalized}' is not allowed for subagent '${name}'. Allowed values: ${formatAllowedLaunchModels(launchModels)}.`,
+              {
+                name,
+                title,
+              },
+            ),
           );
         }
 
@@ -247,7 +266,6 @@ export function createSpawnAgentToolDefinition(backend: ToolExecutionBackend): T
       const statusPrefixParts = [name, modelLabel, statusWorkingDirectory].filter(Boolean);
 
       return {
-        kind: "phased",
         startedUiEvent: {
           type: "spawn_agent_started",
           toolCallId: toolCall.id,
@@ -275,7 +293,7 @@ export function createSpawnAgentToolDefinition(backend: ToolExecutionBackend): T
               message: reason,
               uiText,
             };
-            return { kind: "single", toolResult, uiEvent };
+            return { toolResult, uiEvent };
           }
 
           const spawnResult = controlPlane.spawn({
@@ -301,7 +319,7 @@ export function createSpawnAgentToolDefinition(backend: ToolExecutionBackend): T
               headerTarget,
               reason: spawnResult.reason,
             };
-            return { kind: "single", toolResult, uiEvent };
+            return { toolResult, uiEvent };
           }
 
           const resultText = formatSpawnToolResult({
@@ -329,7 +347,7 @@ export function createSpawnAgentToolDefinition(backend: ToolExecutionBackend): T
             agentId: spawnResult.id,
             uiText,
           };
-          return { kind: "single", toolResult, uiEvent };
+          return { toolResult, uiEvent };
         })(),
       };
     },

--- a/src/core/tools/terminate_agent.ts
+++ b/src/core/tools/terminate_agent.ts
@@ -5,11 +5,12 @@ import type { SubagentResult } from "../subagents/control_plane.js";
 import { createToolError, createToolResult } from "../utils/messages.js";
 import { parseToolArgs } from "../utils/zod.js";
 import {
+  createToolDispatch,
   isMainToolDispatchContext,
   type ToolDefinition,
+  type ToolDispatch,
   type ToolDispatchContext,
   type ToolDispatchResult,
-  type ToolDispatchResultWithPhases,
   type ToolUiEvent,
 } from "./registry.js";
 import { buildSubagentUiText, formatSubagentStatusLine } from "./subagent_ui.js";
@@ -80,7 +81,7 @@ export function createTerminateAgentToolDefinition(): ToolDefinition {
       toolCall: ToolCall,
       signal: AbortSignal,
       context: ToolDispatchContext,
-    ): Promise<ToolDispatchResult | ToolDispatchResultWithPhases> {
+    ): Promise<ToolDispatch> {
       let id = "";
       let headerTarget = "(invalid arguments)";
 
@@ -93,25 +94,26 @@ export function createTerminateAgentToolDefinition(): ToolDefinition {
           headerTarget,
           reason,
         };
-        return { kind: "single", toolResult, uiEvent };
+        return { toolResult, uiEvent };
       };
 
       const parsedArgs = parseToolArgs(terminateArgsSchema, toolCall.arguments);
       if (!parsedArgs.ok) {
-        return blocked(`Invalid arguments: ${parsedArgs.error}`);
+        return createToolDispatch(() => blocked(`Invalid arguments: ${parsedArgs.error}`));
       }
 
       ({ id } = parsedArgs.data);
       headerTarget = id;
 
       if (!isMainToolDispatchContext(context)) {
-        return blocked("The terminate_agent tool is only available in the main session.");
+        return createToolDispatch(() =>
+          blocked("The terminate_agent tool is only available in the main session."),
+        );
       }
 
       const controlPlane = context.subagentControlPlane;
 
       return {
-        kind: "phased",
         startedUiEvent: {
           type: "terminate_agent_started",
           toolCallId: toolCall.id,
@@ -139,7 +141,7 @@ export function createTerminateAgentToolDefinition(): ToolDefinition {
                 uiText,
               };
               const toolResult = createToolError(toolCall, message);
-              return { kind: "single", toolResult, uiEvent };
+              return { toolResult, uiEvent };
             }
 
             const resultText = formatTerminateResult(result);
@@ -168,7 +170,7 @@ export function createTerminateAgentToolDefinition(): ToolDefinition {
               uiText,
             };
             const toolResult = createToolResult(toolCall, resultText, !succeeded);
-            return { kind: "single", toolResult, uiEvent };
+            return { toolResult, uiEvent };
           } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
             const reason = message.trim() || "The terminate_agent request failed.";
@@ -188,7 +190,7 @@ export function createTerminateAgentToolDefinition(): ToolDefinition {
               uiText,
             };
             const toolResult = createToolError(toolCall, reason);
-            return { kind: "single", toolResult, uiEvent };
+            return { toolResult, uiEvent };
           }
         })(),
       };

--- a/src/core/tools/view_image.ts
+++ b/src/core/tools/view_image.ts
@@ -7,7 +7,14 @@ import { createToolError } from "../utils/messages.js";
 import { formatBytes } from "../utils/truncate.js";
 import { formatZodError } from "../utils/zod.js";
 import type { ToolExecutionBackend } from "./execution_backend.js";
-import type { ToolDefinition, ToolDispatchResult, ToolUiEvent, ToolUiText } from "./registry.js";
+import type {
+  ToolDefinition,
+  ToolDispatch,
+  ToolDispatchResult,
+  ToolUiEvent,
+  ToolUiText,
+} from "./registry.js";
+import { createToolDispatch } from "./registry.js";
 import { TOOL_NAME_VIEW_IMAGE } from "./tool_names.js";
 
 const VIEW_IMAGE_DESCRIPTION = [
@@ -227,74 +234,76 @@ function buildViewImageUiText(args: { mimeType: string; fullText: string }): Too
 export function createViewImageToolDefinition(backend: ToolExecutionBackend): ToolDefinition {
   return {
     schema: VIEW_IMAGE_TOOL,
-    async dispatch(toolCall: ToolCall): Promise<ToolDispatchResult> {
-      const parsedArgs = parseViewImageArgs(toolCall.arguments);
-      const path = parsedArgs.ok ? parsedArgs.data.path : "";
-      const headerTarget = path || "(invalid arguments)";
+    async dispatch(toolCall: ToolCall): Promise<ToolDispatch> {
+      return createToolDispatch(async () => {
+        const parsedArgs = parseViewImageArgs(toolCall.arguments);
+        const path = parsedArgs.ok ? parsedArgs.data.path : "";
+        const headerTarget = path || "(invalid arguments)";
 
-      const blocked = (reason: string): ToolDispatchResult => {
-        const toolResult = createToolError(toolCall, reason);
-        const uiEvent: ToolUiEvent = {
-          type: "view_image_blocked",
-          toolCallId: toolCall.id,
-          path: path || "(invalid path)",
-          headerTarget,
-          reason,
+        const blocked = (reason: string): ToolDispatchResult => {
+          const toolResult = createToolError(toolCall, reason);
+          const uiEvent: ToolUiEvent = {
+            type: "view_image_blocked",
+            toolCallId: toolCall.id,
+            path: path || "(invalid path)",
+            headerTarget,
+            reason,
+          };
+          return { toolResult, uiEvent };
         };
-        return { kind: "single", toolResult, uiEvent };
-      };
 
-      if (!parsedArgs.ok) {
-        return blocked(`Invalid arguments: ${parsedArgs.error}`);
-      }
-
-      try {
-        const { path: resolvedPath, content } = await backend.readFileBinary(path, {
-          maxBytes: VIEW_IMAGE_READ_MAX_BYTES,
-        });
-
-        const detected = await fileTypeFromBuffer(content);
-        const mimeType = detected?.mime;
-        if (!isSupportedImageType(mimeType)) {
-          return blocked(
-            `Unsupported image format. Supported formats: ${SUPPORTED_IMAGE_TYPES.join(", ")}.`,
-          );
+        if (!parsedArgs.ok) {
+          return blocked(`Invalid arguments: ${parsedArgs.error}`);
         }
 
-        const encodedImage = await prepareImageForModel(content, mimeType);
-        const data = encodedImage.content.toString("base64");
-        const resultText = `Viewed ${resolvedPath} (${encodedImage.mimeType})`;
-        const toolResult: ToolResultMessage = {
-          role: "toolResult",
-          toolCallId: toolCall.id,
-          toolName: toolCall.name,
-          content: [
-            { type: "text", text: resultText },
-            { type: "image", data, mimeType: encodedImage.mimeType },
-          ],
-          isError: false,
-          timestamp: Date.now(),
-        };
+        try {
+          const { path: resolvedPath, content } = await backend.readFileBinary(path, {
+            maxBytes: VIEW_IMAGE_READ_MAX_BYTES,
+          });
 
-        const uiText = buildViewImageUiText({
-          mimeType: encodedImage.mimeType,
-          fullText: resultText,
-        });
-        const uiEvent: ToolUiEvent = {
-          type: "view_image_success",
-          toolCallId: toolCall.id,
-          path: resolvedPath,
-          headerTarget: resolvedPath,
-          mimeType: encodedImage.mimeType,
-          bytes: encodedImage.content.byteLength,
-          uiText,
-        };
+          const detected = await fileTypeFromBuffer(content);
+          const mimeType = detected?.mime;
+          if (!isSupportedImageType(mimeType)) {
+            return blocked(
+              `Unsupported image format. Supported formats: ${SUPPORTED_IMAGE_TYPES.join(", ")}.`,
+            );
+          }
 
-        return { kind: "single", toolResult, uiEvent };
-      } catch (e) {
-        const errorMessage = e instanceof Error ? e.message : String(e);
-        return blocked(`Tool view_image failed: ${errorMessage}`);
-      }
+          const encodedImage = await prepareImageForModel(content, mimeType);
+          const data = encodedImage.content.toString("base64");
+          const resultText = `Viewed ${resolvedPath} (${encodedImage.mimeType})`;
+          const toolResult: ToolResultMessage = {
+            role: "toolResult",
+            toolCallId: toolCall.id,
+            toolName: toolCall.name,
+            content: [
+              { type: "text", text: resultText },
+              { type: "image", data, mimeType: encodedImage.mimeType },
+            ],
+            isError: false,
+            timestamp: Date.now(),
+          };
+
+          const uiText = buildViewImageUiText({
+            mimeType: encodedImage.mimeType,
+            fullText: resultText,
+          });
+          const uiEvent: ToolUiEvent = {
+            type: "view_image_success",
+            toolCallId: toolCall.id,
+            path: resolvedPath,
+            headerTarget: resolvedPath,
+            mimeType: encodedImage.mimeType,
+            bytes: encodedImage.content.byteLength,
+            uiText,
+          };
+
+          return { toolResult, uiEvent };
+        } catch (e) {
+          const errorMessage = e instanceof Error ? e.message : String(e);
+          return blocked(`Tool view_image failed: ${errorMessage}`);
+        }
+      });
     },
   };
 }

--- a/src/core/tools/wait_for_agents.ts
+++ b/src/core/tools/wait_for_agents.ts
@@ -6,11 +6,12 @@ import { createToolError, createToolResult } from "../utils/messages.js";
 import { truncateForTokens } from "../utils/truncate.js";
 import { parseToolArgs } from "../utils/zod.js";
 import {
+  createToolDispatch,
   isMainToolDispatchContext,
   type ToolDefinition,
+  type ToolDispatch,
   type ToolDispatchContext,
   type ToolDispatchResult,
-  type ToolDispatchResultWithPhases,
   type ToolUiEvent,
 } from "./registry.js";
 import { buildSubagentUiText, formatSubagentStatusLine } from "./subagent_ui.js";
@@ -133,7 +134,7 @@ export function createWaitForAgentsToolDefinition(): ToolDefinition {
       toolCall: ToolCall,
       signal: AbortSignal,
       context: ToolDispatchContext,
-    ): Promise<ToolDispatchResult | ToolDispatchResultWithPhases> {
+    ): Promise<ToolDispatch> {
       let ids: string[] = [];
       const formatHeaderTarget = (entries: string[]): string => {
         const cleaned = entries.map((id) => id.trim()).filter(Boolean);
@@ -150,12 +151,12 @@ export function createWaitForAgentsToolDefinition(): ToolDefinition {
           headerTarget,
           reason,
         };
-        return { kind: "single", toolResult, uiEvent };
+        return { toolResult, uiEvent };
       };
 
       const parsedArgs = parseToolArgs(waitArgsSchema, toolCall.arguments);
       if (!parsedArgs.ok) {
-        return blocked(`Invalid arguments: ${parsedArgs.error}`);
+        return createToolDispatch(() => blocked(`Invalid arguments: ${parsedArgs.error}`));
       }
 
       ({ ids } = parsedArgs.data);
@@ -172,13 +173,14 @@ export function createWaitForAgentsToolDefinition(): ToolDefinition {
       const dedupedTarget = formatHeaderTarget(deduped);
 
       if (!isMainToolDispatchContext(context)) {
-        return blocked("The wait_for_agents tool is only available in the main session.");
+        return createToolDispatch(() =>
+          blocked("The wait_for_agents tool is only available in the main session."),
+        );
       }
 
       const controlPlane = context.subagentControlPlane;
 
       return {
-        kind: "phased",
         startedUiEvent: {
           type: "wait_for_agents_started",
           toolCallId: toolCall.id,
@@ -214,7 +216,7 @@ export function createWaitForAgentsToolDefinition(): ToolDefinition {
               uiText,
             };
             const toolResult = createToolResult(toolCall, resultText, hasFailures);
-            return { kind: "single", toolResult, uiEvent };
+            return { toolResult, uiEvent };
           } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
             const reason = message.trim() || "The wait_for_agents request failed.";
@@ -233,7 +235,7 @@ export function createWaitForAgentsToolDefinition(): ToolDefinition {
               uiText,
             };
             const toolResult = createToolError(toolCall, reason);
-            return { kind: "single", toolResult, uiEvent };
+            return { toolResult, uiEvent };
           }
         })(),
       };

--- a/src/core/tools/web_fetch.ts
+++ b/src/core/tools/web_fetch.ts
@@ -11,12 +11,8 @@ import {
 } from "../utils/parallel_api.js";
 import { TRUNCATION_MARKER, type TruncationResult, truncateForTokens } from "../utils/truncate.js";
 import { formatZodError } from "../utils/zod.js";
-import type {
-  ToolDefinition,
-  ToolDispatchResult,
-  ToolDispatchResultWithPhases,
-  ToolUiEvent,
-} from "./registry.js";
+import type { ToolDefinition, ToolDispatch, ToolDispatchResult, ToolUiEvent } from "./registry.js";
+import { createToolDispatch } from "./registry.js";
 import { TOOL_NAME_WEB_FETCH } from "./tool_names.js";
 
 const WEB_FETCH_DESCRIPTION = [
@@ -203,10 +199,7 @@ function formatExtractResults(response: ExtractResponse): TruncationResult {
 export function createWebFetchToolDefinition(config: Config): ToolDefinition {
   return {
     schema: WEB_FETCH_TOOL,
-    async dispatch(
-      toolCall: ToolCall,
-      signal?: AbortSignal,
-    ): Promise<ToolDispatchResult | ToolDispatchResultWithPhases> {
+    async dispatch(toolCall: ToolCall, signal?: AbortSignal): Promise<ToolDispatch> {
       const parsedArgs = parseArgs(toolCall.arguments);
       const url = parsedArgs.ok ? parsedArgs.data.url : "";
       const headerTarget = url || "(invalid arguments)";
@@ -221,22 +214,21 @@ export function createWebFetchToolDefinition(config: Config): ToolDefinition {
           status: "error",
           message: reason,
         };
-        return { kind: "single", toolResult, uiEvent };
+        return { toolResult, uiEvent };
       };
 
       if (!parsedArgs.ok) {
-        return blocked(`Invalid arguments: ${parsedArgs.error}`);
+        return createToolDispatch(() => blocked(`Invalid arguments: ${parsedArgs.error}`));
       }
 
       const args = parsedArgs.data;
 
       const apiKey = getParallelApiKey(config);
       if (!apiKey) {
-        return blocked("Missing Parallel API key.");
+        return createToolDispatch(() => blocked("Missing Parallel API key."));
       }
 
       return {
-        kind: "phased",
         startedUiEvent: {
           type: "web_fetch_started",
           toolCallId: toolCall.id,
@@ -305,7 +297,7 @@ export function createWebFetchToolDefinition(config: Config): ToolDefinition {
               costUsd: estimateParallelExtractCostUsd(1),
               message: resultText.truncated ? TRUNCATION_MARKER : undefined,
             };
-            return { kind: "single", toolResult, uiEvent };
+            return { toolResult, uiEvent };
           } catch (e) {
             const msg = e instanceof Error ? e.message : String(e);
             const reason = msg.trim() ? msg : "Request failed.";
@@ -318,7 +310,7 @@ export function createWebFetchToolDefinition(config: Config): ToolDefinition {
               status: "error",
               message: reason,
             };
-            return { kind: "single", toolResult, uiEvent };
+            return { toolResult, uiEvent };
           }
         })(),
       };

--- a/src/core/tools/web_search.ts
+++ b/src/core/tools/web_search.ts
@@ -11,12 +11,8 @@ import {
 } from "../utils/parallel_api.js";
 import { TRUNCATION_MARKER, type TruncationResult, truncateForTokens } from "../utils/truncate.js";
 import { formatZodError } from "../utils/zod.js";
-import type {
-  ToolDefinition,
-  ToolDispatchResult,
-  ToolDispatchResultWithPhases,
-  ToolUiEvent,
-} from "./registry.js";
+import type { ToolDefinition, ToolDispatch, ToolDispatchResult, ToolUiEvent } from "./registry.js";
+import { createToolDispatch } from "./registry.js";
 import { TOOL_NAME_WEB_SEARCH } from "./tool_names.js";
 
 const WEB_SEARCH_DESCRIPTION = [
@@ -175,10 +171,7 @@ function formatSearchResults(response: ParallelSearchResponse): TruncationResult
 export function createWebSearchToolDefinition(config: Config): ToolDefinition {
   return {
     schema: WEB_SEARCH_TOOL,
-    async dispatch(
-      toolCall: ToolCall,
-      signal?: AbortSignal,
-    ): Promise<ToolDispatchResult | ToolDispatchResultWithPhases> {
+    async dispatch(toolCall: ToolCall, signal?: AbortSignal): Promise<ToolDispatch> {
       const parsedArgs = parseArgs(toolCall.arguments);
       const objective = parsedArgs.ok ? parsedArgs.data.objective : "";
       const headerTarget = objective || "(invalid arguments)";
@@ -193,22 +186,21 @@ export function createWebSearchToolDefinition(config: Config): ToolDefinition {
           status: "error",
           message: reason,
         };
-        return { kind: "single", toolResult, uiEvent };
+        return { toolResult, uiEvent };
       };
 
       if (!parsedArgs.ok) {
-        return blocked(`Invalid arguments: ${parsedArgs.error}`);
+        return createToolDispatch(() => blocked(`Invalid arguments: ${parsedArgs.error}`));
       }
 
       const args = parsedArgs.data;
 
       const apiKey = getParallelApiKey(config);
       if (!apiKey) {
-        return blocked("Missing Parallel API key.");
+        return createToolDispatch(() => blocked("Missing Parallel API key."));
       }
 
       return {
-        kind: "phased",
         startedUiEvent: {
           type: "web_search_started",
           toolCallId: toolCall.id,
@@ -282,7 +274,7 @@ export function createWebSearchToolDefinition(config: Config): ToolDefinition {
               costUsd: estimateParallelSearchCostUsd(args.maxResults, response.results.length),
               message: resultText.truncated ? TRUNCATION_MARKER : undefined,
             };
-            return { kind: "single", toolResult, uiEvent };
+            return { toolResult, uiEvent };
           } catch (e) {
             const msg = e instanceof Error ? e.message : String(e);
             const reason = msg.trim() ? msg : "Request failed.";
@@ -295,7 +287,7 @@ export function createWebSearchToolDefinition(config: Config): ToolDefinition {
               status: "error",
               message: reason,
             };
-            return { kind: "single", toolResult, uiEvent };
+            return { toolResult, uiEvent };
           }
         })(),
       };

--- a/src/core/tools/write.ts
+++ b/src/core/tools/write.ts
@@ -13,11 +13,13 @@ import { formatZodError } from "../utils/zod.js";
 import type { ToolExecutionBackend } from "./execution_backend.js";
 import type {
   ToolDefinition,
+  ToolDispatch,
   ToolDispatchResult,
   ToolUiEvent,
   ToolUiLine,
   ToolUiText,
 } from "./registry.js";
+import { createToolDispatch } from "./registry.js";
 import { TOOL_NAME_WRITE } from "./tool_names.js";
 
 const WRITE_DESCRIPTION = [
@@ -94,50 +96,52 @@ function buildWriteUiText(args: {
 export function createWriteToolDefinition(backend: ToolExecutionBackend): ToolDefinition {
   return {
     schema: WRITE_TOOL,
-    async dispatch(toolCall: ToolCall): Promise<ToolDispatchResult> {
-      const parsedArgs = parseWriteArgs(toolCall.arguments);
-      const path = parsedArgs.ok ? parsedArgs.data.path : "";
-      const headerTarget = path || "(invalid arguments)";
+    async dispatch(toolCall: ToolCall): Promise<ToolDispatch> {
+      return createToolDispatch(async () => {
+        const parsedArgs = parseWriteArgs(toolCall.arguments);
+        const path = parsedArgs.ok ? parsedArgs.data.path : "";
+        const headerTarget = path || "(invalid arguments)";
 
-      const blocked = (reason: string): ToolDispatchResult => {
-        const toolResult = createToolError(toolCall, reason);
-        const uiEvent: ToolUiEvent = {
-          type: "write_blocked",
-          toolCallId: toolCall.id,
-          path: path || "(invalid path)",
-          headerTarget,
-          reason,
+        const blocked = (reason: string): ToolDispatchResult => {
+          const toolResult = createToolError(toolCall, reason);
+          const uiEvent: ToolUiEvent = {
+            type: "write_blocked",
+            toolCallId: toolCall.id,
+            path: path || "(invalid path)",
+            headerTarget,
+            reason,
+          };
+          return { toolResult, uiEvent };
         };
-        return { kind: "single", toolResult, uiEvent };
-      };
 
-      if (!parsedArgs.ok) {
-        return blocked(`Invalid arguments: ${parsedArgs.error}`);
-      }
+        if (!parsedArgs.ok) {
+          return blocked(`Invalid arguments: ${parsedArgs.error}`);
+        }
 
-      const { content } = parsedArgs.data;
+        const { content } = parsedArgs.data;
 
-      try {
-        const { bytes, lines } = await backend.writeFile(path, content);
-        const resultText = `Successfully wrote ${formatBytes(bytes)} (${lines} lines) to ${path}`;
+        try {
+          const { bytes, lines } = await backend.writeFile(path, content);
+          const resultText = `Successfully wrote ${formatBytes(bytes)} (${lines} lines) to ${path}`;
 
-        const toolResult = createToolSuccess(toolCall, resultText);
-        const uiText = buildWriteUiText({ bytes, lines, content, fullText: resultText });
-        const uiEvent: ToolUiEvent = {
-          type: "write_success",
-          toolCallId: toolCall.id,
-          path,
-          headerTarget,
-          bytes,
-          lines,
-          content,
-          uiText,
-        };
-        return { kind: "single", toolResult, uiEvent };
-      } catch (e) {
-        const errorMessage = e instanceof Error ? e.message : String(e);
-        return blocked(`Write failed: ${errorMessage}`);
-      }
+          const toolResult = createToolSuccess(toolCall, resultText);
+          const uiText = buildWriteUiText({ bytes, lines, content, fullText: resultText });
+          const uiEvent: ToolUiEvent = {
+            type: "write_success",
+            toolCallId: toolCall.id,
+            path,
+            headerTarget,
+            bytes,
+            lines,
+            content,
+            uiText,
+          };
+          return { toolResult, uiEvent };
+        } catch (e) {
+          const errorMessage = e instanceof Error ? e.message : String(e);
+          return blocked(`Write failed: ${errorMessage}`);
+        }
+      });
     },
   };
 }

--- a/src/host/client_tool_broker.ts
+++ b/src/host/client_tool_broker.ts
@@ -2,11 +2,12 @@ import { randomUUID } from "node:crypto";
 import type { Tool, ToolCall, ToolResultMessage } from "@earendil-works/pi-ai";
 import type {
   ToolDefinition,
+  ToolDispatch,
   ToolDispatchContext,
-  ToolDispatchResult,
   ToolUiEvent,
   ToolUiText,
 } from "../core/tools/registry.js";
+import { createToolDispatch } from "../core/tools/registry.js";
 import { createToolError, createToolResult } from "../core/utils/messages.js";
 import { formatTokenEstimate } from "../core/utils/token.js";
 import { buildHeadTailPreviewLines } from "../core/utils/tool_preview.js";
@@ -364,9 +365,11 @@ function createClientToolDefinition(
       toolCall: ToolCall,
       signal: AbortSignal,
       _context: ToolDispatchContext,
-    ): Promise<ToolDispatchResult> {
-      const toolResult = await broker.dispatch({ sessionId, clientId, tool, toolCall, signal });
-      return { kind: "single", toolResult, uiEvent: createClientToolFinishedUiEvent(toolResult) };
+    ): Promise<ToolDispatch> {
+      return createToolDispatch(async () => {
+        const toolResult = await broker.dispatch({ sessionId, clientId, tool, toolCall, signal });
+        return { toolResult, uiEvent: createClientToolFinishedUiEvent(toolResult) };
+      });
     },
   };
 }

--- a/test/bash_output.test.js
+++ b/test/bash_output.test.js
@@ -25,10 +25,16 @@ const backend = {
   },
 };
 
+async function runTool(tool, ...args) {
+  const dispatch = await tool.dispatch(...args);
+  return dispatch.run;
+}
+
 describe("bash output policy", () => {
   it("rejects unknown execution arguments", async () => {
     const tool = createBashToolDefinition(backend);
-    const result = await tool.dispatch(
+    const result = await runTool(
+      tool,
       {
         id: "bash-1",
         name: "bash",
@@ -38,7 +44,6 @@ describe("bash output policy", () => {
       { scope: "main" },
     );
 
-    expect(result.kind).toBe("single");
     expect(result.toolResult.isError).toBe(true);
   });
 

--- a/test/client_tool_broker.test.js
+++ b/test/client_tool_broker.test.js
@@ -10,6 +10,11 @@ function createToolCall(args = {}) {
   };
 }
 
+async function runTool(tool, ...args) {
+  const dispatch = await tool.dispatch(...args);
+  return dispatch.run;
+}
+
 describe("ClientToolBroker", () => {
   it("returns full client tool results with a truncated final UI event", async () => {
     const broker = new ClientToolBroker();
@@ -33,13 +38,13 @@ describe("ClientToolBroker", () => {
     registration.attachSession("session-1");
 
     const definition = broker.getToolDefinitions("session-1")[0];
-    const result = await definition.dispatch(
+    const result = await runTool(
+      definition,
       createToolCall({ choice: "a" }),
       new AbortController().signal,
       {},
     );
 
-    expect(result.kind).toBe("single");
     expect(result.toolResult.content[0].text).toBe(content);
     expect(result.uiEvent).toMatchObject({
       type: "client_tool_finished",
@@ -81,13 +86,13 @@ describe("ClientToolBroker", () => {
     const definition = broker.getToolDefinitions("session-1")[0];
     registration.detachSession("session-1");
 
-    const result = await definition.dispatch(
+    const result = await runTool(
+      definition,
       createToolCall({ choice: "a" }),
       new AbortController().signal,
       {},
     );
 
-    expect(result.kind).toBe("single");
     expect(result.toolResult.isError).toBe(true);
     expect(result.toolResult.content[0].text).toBe(
       "Client tool 'local_picker' is unavailable because its owning client detached.",
@@ -113,15 +118,14 @@ describe("ClientToolBroker", () => {
       registration.attachSession("session-1");
       const definition = broker.getToolDefinitions("session-1")[0];
 
-      const dispatched = definition.dispatch(
+      const dispatch = await definition.dispatch(
         createToolCall({ choice: "a" }),
         new AbortController().signal,
         {},
       );
       await vi.advanceTimersByTimeAsync(5000);
-      const result = await dispatched;
+      const result = await dispatch.run;
 
-      expect(result.kind).toBe("single");
       expect(result.toolResult.isError).toBe(true);
       expect(result.toolResult.content[0].text).toBe(
         "Client tool 'local_picker' is unavailable because its owning client did not acknowledge the tool call within 5000ms.",

--- a/test/core_runtime.test.js
+++ b/test/core_runtime.test.js
@@ -539,30 +539,32 @@ describe("core session rewind APIs", () => {
         markFirstStarted();
         await firstRun;
         return {
-          kind: "single",
-          toolResult: {
-            role: "toolResult",
-            toolCallId: toolCall.id,
-            toolName: toolCall.name,
-            content: [{ type: "text", text: "first done" }],
-            isError: false,
-            timestamp: 2,
-          },
+          run: Promise.resolve({
+            toolResult: {
+              role: "toolResult",
+              toolCallId: toolCall.id,
+              toolName: toolCall.name,
+              content: [{ type: "text", text: "first done" }],
+              isError: false,
+              timestamp: 2,
+            },
+          }),
         };
       }),
       createDefinition("second_tool", async (toolCall) => {
         secondHasStarted = true;
         markSecondStarted();
         return {
-          kind: "single",
-          toolResult: {
-            role: "toolResult",
-            toolCallId: toolCall.id,
-            toolName: toolCall.name,
-            content: [{ type: "text", text: "second done" }],
-            isError: false,
-            timestamp: 3,
-          },
+          run: Promise.resolve({
+            toolResult: {
+              role: "toolResult",
+              toolCallId: toolCall.id,
+              toolName: toolCall.name,
+              content: [{ type: "text", text: "second done" }],
+              isError: false,
+              timestamp: 3,
+            },
+          }),
         };
       }),
     ]);
@@ -664,15 +666,16 @@ describe("core session rewind APIs", () => {
         dispatch: async (call) => {
           executions += 1;
           return {
-            kind: "single",
-            toolResult: {
-              role: "toolResult",
-              toolCallId: call.id,
-              toolName: call.name,
-              content: [{ type: "text", text: "created result.txt" }],
-              isError: false,
-              timestamp: 2,
-            },
+            run: Promise.resolve({
+              toolResult: {
+                role: "toolResult",
+                toolCallId: call.id,
+                toolName: call.name,
+                content: [{ type: "text", text: "created result.txt" }],
+                isError: false,
+                timestamp: 2,
+              },
+            }),
           };
         },
       },
@@ -796,15 +799,16 @@ describe("core session rewind APIs", () => {
         dispatch: async (call) => {
           executions += 1;
           return {
-            kind: "single",
-            toolResult: {
-              role: "toolResult",
-              toolCallId: call.id,
-              toolName: call.name,
-              content: [{ type: "text", text: `completed ${call.id}` }],
-              isError: false,
-              timestamp: executions,
-            },
+            run: Promise.resolve({
+              toolResult: {
+                role: "toolResult",
+                toolCallId: call.id,
+                toolName: call.name,
+                content: [{ type: "text", text: `completed ${call.id}` }],
+                isError: false,
+                timestamp: executions,
+              },
+            }),
           };
         },
       },
@@ -892,15 +896,16 @@ describe("core session rewind APIs", () => {
             );
           }
           return {
-            kind: "single",
-            toolResult: {
-              role: "toolResult",
-              toolCallId: call.id,
-              toolName: call.name,
-              content: [{ type: "text", text: "cancelled after starting" }],
-              isError: true,
-              timestamp: 2,
-            },
+            run: Promise.resolve({
+              toolResult: {
+                role: "toolResult",
+                toolCallId: call.id,
+                toolName: call.name,
+                content: [{ type: "text", text: "cancelled after starting" }],
+                isError: true,
+                timestamp: 2,
+              },
+            }),
           };
         },
       },
@@ -997,15 +1002,16 @@ describe("core session rewind APIs", () => {
           await new Promise((resolve) => signal.addEventListener("abort", resolve, { once: true }));
           toolAborted = true;
           return {
-            kind: "single",
-            toolResult: {
-              role: "toolResult",
-              toolCallId: call.id,
-              toolName: call.name,
-              content: [{ type: "text", text: "cancelled" }],
-              isError: true,
-              timestamp: 2,
-            },
+            run: Promise.resolve({
+              toolResult: {
+                role: "toolResult",
+                toolCallId: call.id,
+                toolName: call.name,
+                content: [{ type: "text", text: "cancelled" }],
+                isError: true,
+                timestamp: 2,
+              },
+            }),
           };
         },
       },
@@ -1062,15 +1068,16 @@ describe("core session rewind APIs", () => {
           toolContextReasoning.push(context.persona.settings.reasoning);
           session.setReasoning("high");
           return {
-            kind: "single",
-            toolResult: {
-              role: "toolResult",
-              toolCallId: "fake-call",
-              toolName: "fake_tool",
-              content: [{ type: "text", text: "ok" }],
-              isError: false,
-              timestamp: 2,
-            },
+            run: Promise.resolve({
+              toolResult: {
+                role: "toolResult",
+                toolCallId: "fake-call",
+                toolName: "fake_tool",
+                content: [{ type: "text", text: "ok" }],
+                isError: false,
+                timestamp: 2,
+              },
+            }),
           };
         },
       },
@@ -1161,15 +1168,16 @@ describe("core session rewind APIs", () => {
           async dispatch(toolCall, _signal, context) {
             receivedOriginHistoryEntryId = context.originHistoryEntryId;
             return {
-              kind: "single",
-              toolResult: {
-                role: "toolResult",
-                toolCallId: toolCall.id,
-                toolName: toolCall.name,
-                content: [{ type: "text", text: "ok" }],
-                isError: false,
-                timestamp: 2,
-              },
+              run: Promise.resolve({
+                toolResult: {
+                  role: "toolResult",
+                  toolCallId: toolCall.id,
+                  toolName: toolCall.name,
+                  content: [{ type: "text", text: "ok" }],
+                  isError: false,
+                  timestamp: 2,
+                },
+              }),
             };
           },
         },

--- a/test/edit_tool.test.js
+++ b/test/edit_tool.test.js
@@ -14,6 +14,11 @@ function setupFixture() {
   };
 }
 
+async function runTool(tool, ...args) {
+  const dispatch = await tool.dispatch(...args);
+  return dispatch.run;
+}
+
 describe("edit tool", () => {
   it("resolves backend file operations relative to the configured cwd", async () => {
     const fx = setupFixture();
@@ -66,7 +71,7 @@ describe("edit tool", () => {
       const backend = createLocalToolExecutionBackend();
       const editTool = createEditToolDefinition(backend);
 
-      await editTool.dispatch({
+      await runTool(editTool, {
         id: "tool-1",
         name: TOOL_NAME_EDIT,
         arguments: {
@@ -76,7 +81,7 @@ describe("edit tool", () => {
         },
       });
 
-      await editTool.dispatch({
+      await runTool(editTool, {
         id: "tool-2",
         name: TOOL_NAME_EDIT,
         arguments: {

--- a/test/nook.test.js
+++ b/test/nook.test.js
@@ -72,6 +72,11 @@ async function startTemplateSave(registry, name = "starter") {
   return { response, body: await response.json() };
 }
 
+async function runTool(tool, ...args) {
+  const dispatch = await tool.dispatch(...args);
+  return dispatch.run;
+}
+
 describe("nook validation", () => {
   it("accepts path-safe slugs and rejects reserved or malformed slugs", () => {
     expect(validateNookSiteSlug("demo-app").ok).toBe(true);
@@ -674,11 +679,10 @@ describe("nook tool", () => {
 
   it("fails fast when nook is not configured", async () => {
     const tool = createNookToolDefinition({});
-    const result = await tool.dispatch(toolCall, new AbortController().signal, {
+    const result = await runTool(tool, toolCall, new AbortController().signal, {
       config: {},
     });
 
-    expect(result.kind).toBe("single");
     expect(result.toolResult.isError).toBe(true);
     expect(result.toolResult.content[0].text).toContain("not configured");
   });
@@ -692,7 +696,8 @@ describe("nook tool", () => {
     };
     const fetchMock = vi.spyOn(globalThis, "fetch");
     const tool = createNookToolDefinition(backend);
-    const result = await tool.dispatch(
+    const result = await runTool(
+      tool,
       {
         type: "toolCall",
         id: "call_1",
@@ -707,7 +712,6 @@ describe("nook tool", () => {
       { config: { nook: { domain: "nook.example.com" } } },
     );
 
-    expect(result.kind).toBe("single");
     expect(result.toolResult.isError).toBe(true);
     expect(result.toolResult.content[0].text).toContain("not empty");
     expect(fetchMock).not.toHaveBeenCalled();
@@ -715,7 +719,8 @@ describe("nook tool", () => {
 
   it("requires a value for put_kv", async () => {
     const tool = createNookToolDefinition({});
-    const result = await tool.dispatch(
+    const result = await runTool(
+      tool,
       {
         type: "toolCall",
         id: "call_1",
@@ -726,7 +731,6 @@ describe("nook tool", () => {
       { config: { nook: { domain: "nook.example.com" } } },
     );
 
-    expect(result.kind).toBe("single");
     expect(result.toolResult.isError).toBe(true);
     expect(result.toolResult.content[0].text).toContain("requires value");
   });

--- a/test/session_runner.test.js
+++ b/test/session_runner.test.js
@@ -394,121 +394,6 @@ describe("session runner tool dispatch context", () => {
     }
   });
 
-  it("emits phased intermediate tool UI events before the final tool result", async () => {
-    const signal = new AbortController().signal;
-    const toolCall = {
-      id: "tool-call-1",
-      type: "toolCall",
-      name: "fake_tool",
-      arguments: {},
-    };
-
-    async function* uiEvents() {
-      yield {
-        type: "bash_execution",
-        toolCallId: "tool-call-1",
-        command: "echo progress",
-        headerTarget: "echo progress",
-        exitCode: 0,
-        truncationInfo: {
-          output: "progress",
-          model: {
-            content: "progress",
-            truncated: false,
-            totalBytes: 8,
-            totalLines: 1,
-            outputBytes: 8,
-            outputLines: 1,
-          },
-          captureTruncated: false,
-        },
-        uiText: {
-          previewLines: [{ text: "progress" }],
-          fullLines: [{ text: "progress" }],
-        },
-      };
-    }
-
-    const definition = {
-      schema: {
-        name: "fake_tool",
-        description: "test",
-        parameters: {
-          type: "object",
-          properties: {},
-          additionalProperties: false,
-        },
-      },
-      async dispatch(call) {
-        return {
-          kind: "phased",
-          startedUiEvent: {
-            type: "bash_started",
-            toolCallId: call.id,
-            command: "echo start",
-            headerTarget: "echo start",
-          },
-          uiEvents: uiEvents(),
-          run: new Promise((resolve) => {
-            setTimeout(() => {
-              resolve({
-                kind: "single",
-                toolResult: createToolResult(call, "ok"),
-                uiEvent: {
-                  type: "bash_blocked",
-                  toolCallId: call.id,
-                  command: "echo done",
-                  headerTarget: "echo done",
-                  reason: "done",
-                },
-              });
-            }, 0);
-          }),
-        };
-      },
-    };
-
-    const toolRegistry = new ToolRegistry([definition]);
-    const dispatchContext = {
-      scope: "subagent",
-      config: {},
-      toolRegistry,
-      authPath: "/tmp/auth.json",
-      originHistoryEntryId: "history-1",
-      cwd: "/repo/subagent",
-      subagentContext: {
-        id: "subagent-1",
-        name: "default",
-        title: "default",
-        originHistoryEntryId: "history-1",
-        controlPlane: { recordEmitOutput: () => {} },
-      },
-    };
-
-    const events = [];
-    for await (const event of runToolCalls({
-      toolCalls: [toolCall],
-      toolRegistry,
-      enabledTools: toolRegistry.schemas,
-      signal,
-      dispatchContext,
-    })) {
-      events.push(event);
-    }
-
-    expect(events.map((event) => event.type)).toEqual([
-      "tool_ui",
-      "tool_ui",
-      "tool_ui",
-      "tool_ui",
-      "tool_result",
-    ]);
-    expect(events[0].uiEvent.type).toBe("tool_call_queued");
-    expect(events[1].uiEvent.type).toBe("bash_started");
-    expect(events[2].uiEvent.type).toBe("bash_execution");
-    expect(events[3].uiEvent.type).toBe("bash_blocked");
-  });
-
   it("emits queued UI events for all valid calls before executing the first tool", async () => {
     const signal = new AbortController().signal;
     const slowCall = {
@@ -542,7 +427,6 @@ describe("session runner tool dispatch context", () => {
       },
       async dispatch(call) {
         return {
-          kind: "phased",
           startedUiEvent: {
             type: "bash_started",
             toolCallId: call.id,
@@ -550,7 +434,6 @@ describe("session runner tool dispatch context", () => {
             headerTarget: "sleep 30",
           },
           run: slowRun.then(() => ({
-            kind: "single",
             toolResult: createToolResult(call, "slow ok"),
             uiEvent: {
               type: "bash_execution",
@@ -593,21 +476,22 @@ describe("session runner tool dispatch context", () => {
       async dispatch(call) {
         fastDispatched = true;
         return {
-          kind: "single",
-          toolResult: createToolResult(call, "fast ok"),
-          uiEvent: {
-            type: "write_success",
-            toolCallId: call.id,
-            path: "fast.txt",
-            headerTarget: "fast.txt",
-            bytes: 2,
-            lines: 1,
-            content: "ok",
-            uiText: {
-              previewLines: [{ text: "ok" }],
-              fullLines: [{ text: "ok" }],
+          run: Promise.resolve({
+            toolResult: createToolResult(call, "fast ok"),
+            uiEvent: {
+              type: "write_success",
+              toolCallId: call.id,
+              path: "fast.txt",
+              headerTarget: "fast.txt",
+              bytes: 2,
+              lines: 1,
+              content: "ok",
+              uiText: {
+                previewLines: [{ text: "ok" }],
+                fullLines: [{ text: "ok" }],
+              },
             },
-          },
+          }),
         };
       },
     };
@@ -671,6 +555,77 @@ describe("session runner tool dispatch context", () => {
     ).toEqual(["bash_execution", "write_success", "tool_result", "tool_result"]);
   });
 
+  it("converts rejected tool runs into tool error results", async () => {
+    const signal = new AbortController().signal;
+    const toolCall = {
+      id: "tool-call-1",
+      type: "toolCall",
+      name: "fake_tool",
+      arguments: {},
+    };
+    const definition = {
+      schema: {
+        name: "fake_tool",
+        description: "test",
+        parameters: {
+          type: "object",
+          properties: {},
+          additionalProperties: false,
+        },
+      },
+      async dispatch() {
+        return { run: Promise.reject(new Error("run failed")) };
+      },
+    };
+    const toolRegistry = new ToolRegistry([definition]);
+    const dispatchContext = {
+      scope: "subagent",
+      config: {},
+      toolRegistry,
+      authPath: "/tmp/auth.json",
+      originHistoryEntryId: "history-1",
+      cwd: "/repo/subagent",
+      subagentContext: {
+        id: "subagent-1",
+        name: "default",
+        title: "default",
+        originHistoryEntryId: "history-1",
+        controlPlane: { recordEmitOutput: () => {} },
+      },
+    };
+
+    const events = [];
+    for await (const event of runToolCalls({
+      toolCalls: [toolCall],
+      toolRegistry,
+      enabledTools: toolRegistry.schemas,
+      signal,
+      dispatchContext,
+    })) {
+      events.push(event);
+    }
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: "tool_ui",
+        uiEvent: expect.objectContaining({ type: "tool_call_queued" }),
+      }),
+      {
+        type: "notice",
+        severity: "error",
+        text: "Tool 'fake_tool' (tool-call-1) execution failed: run failed",
+      },
+      {
+        type: "tool_result",
+        message: expect.objectContaining({
+          toolCallId: "tool-call-1",
+          toolName: "fake_tool",
+          isError: true,
+        }),
+      },
+    ]);
+  });
+
   it("passes dispatchContext to tool definitions", async () => {
     const signal = new AbortController().signal;
     const toolCall = {
@@ -697,8 +652,7 @@ describe("session runner tool dispatch context", () => {
         receivedSignal = dispatchSignal;
         receivedContext = context;
         return {
-          kind: "single",
-          toolResult: createToolResult(call, "ok"),
+          run: Promise.resolve({ toolResult: createToolResult(call, "ok") }),
         };
       },
     };

--- a/test/spawn_agent_tool.test.js
+++ b/test/spawn_agent_tool.test.js
@@ -101,6 +101,11 @@ function createContext(overrides = {}) {
   return { context, anthropic, openai, spawned };
 }
 
+async function runTool(tool, ...args) {
+  const dispatch = await tool.dispatch(...args);
+  return dispatch.run;
+}
+
 describe("spawn_agent tool", () => {
   it("accepts an allowed launch model override", async () => {
     const backend = createLocalToolExecutionBackend();
@@ -122,9 +127,7 @@ describe("spawn_agent tool", () => {
       context,
     );
 
-    expect(dispatched.kind).toBe("phased");
     const result = await dispatched.run;
-    expect(result.kind).toBe("single");
     expect(result.toolResult.isError).toBe(false);
     expect(result.uiEvent.type).toBe("spawn_agent_finished");
     expect(result.uiEvent.uiText.statusLine).toContain("openai/gpt-5.5:high");
@@ -176,9 +179,7 @@ describe("spawn_agent tool", () => {
       context,
     );
 
-    expect(dispatched.kind).toBe("phased");
     const result = await dispatched.run;
-    expect(result.kind).toBe("single");
     expect(result.toolResult.isError).toBe(false);
     expect(result.uiEvent.type).toBe("spawn_agent_finished");
     expect(result.uiEvent.uiText.statusLine).toContain("openai/gpt-5.5:high");
@@ -206,7 +207,8 @@ describe("spawn_agent tool", () => {
       },
     });
 
-    const result = await tool.dispatch(
+    const result = await runTool(
+      tool,
       {
         id: "call-2",
         name: TOOL_NAME_SPAWN_AGENT,
@@ -221,7 +223,6 @@ describe("spawn_agent tool", () => {
       context,
     );
 
-    expect(result.kind).toBe("single");
     expect(result.toolResult.isError).toBe(true);
     expect(getText(result.toolResult)).toContain("does not allow launch model overrides");
   });
@@ -231,7 +232,8 @@ describe("spawn_agent tool", () => {
     const tool = createSpawnAgentToolDefinition(backend);
     const { context, spawned } = createContext();
 
-    const result = await tool.dispatch(
+    const result = await runTool(
+      tool,
       {
         id: "call-3",
         name: TOOL_NAME_SPAWN_AGENT,
@@ -246,7 +248,6 @@ describe("spawn_agent tool", () => {
       context,
     );
 
-    expect(result.kind).toBe("single");
     expect(result.toolResult.isError).toBe(true);
     expect(getText(result.toolResult)).toContain("is not allowed for subagent");
     expect(getText(result.toolResult)).toContain("openai/gpt-5.5:high");
@@ -272,9 +273,7 @@ describe("spawn_agent tool", () => {
       context,
     );
 
-    expect(dispatched.kind).toBe("phased");
     const result = await dispatched.run;
-    expect(result.kind).toBe("single");
     expect(result.toolResult.isError).toBe(false);
     expect(spawned).toHaveLength(1);
     expect(spawned[0].model.provider).toBe(anthropic.provider);
@@ -303,7 +302,6 @@ describe("spawn_agent tool", () => {
       context,
     );
 
-    expect(dispatched.kind).toBe("phased");
     await dispatched.run;
     expect(spawned).toHaveLength(1);
     expect(spawned[0].model.provider).toBe(openai.provider);
@@ -317,7 +315,8 @@ describe("spawn_agent tool", () => {
     const tool = createSpawnAgentToolDefinition(backend);
     const { context, spawned } = createContext();
 
-    const result = await tool.dispatch(
+    const result = await runTool(
+      tool,
       {
         id: "call-6",
         name: TOOL_NAME_SPAWN_AGENT,
@@ -332,7 +331,6 @@ describe("spawn_agent tool", () => {
       context,
     );
 
-    expect(result.kind).toBe("single");
     expect(result.toolResult.isError).toBe(true);
     expect(getText(result.toolResult)).toContain("Invalid arguments: model:");
     expect(spawned).toHaveLength(0);
@@ -343,7 +341,8 @@ describe("spawn_agent tool", () => {
     const tool = createSpawnAgentToolDefinition(backend);
     const { context, spawned } = createContext();
 
-    const result = await tool.dispatch(
+    const result = await runTool(
+      tool,
       {
         id: "call-7",
         name: TOOL_NAME_SPAWN_AGENT,
@@ -358,7 +357,6 @@ describe("spawn_agent tool", () => {
       context,
     );
 
-    expect(result.kind).toBe("single");
     expect(result.toolResult.isError).toBe(true);
     expect(getText(result.toolResult)).toContain("Invalid arguments: workingDirectory:");
     expect(spawned).toHaveLength(0);
@@ -386,7 +384,6 @@ describe("spawn_agent tool", () => {
       context,
     );
 
-    expect(dispatched.kind).toBe("phased");
     await dispatched.run;
     expect(spawned).toHaveLength(1);
     expect(spawned[0].workingDirectory).toBe("/tmp");
@@ -414,7 +411,6 @@ describe("spawn_agent tool", () => {
       context,
     );
 
-    expect(dispatched.kind).toBe("phased");
     await dispatched.run;
     expect(spawned).toHaveLength(1);
     expect(spawned[0].workingDirectory).toBe("/repo");
@@ -464,7 +460,6 @@ describe("spawn_agent tool", () => {
       context,
     );
 
-    expect(dispatched.kind).toBe("phased");
     await dispatched.run;
     expect(resolveSubagentRuntime).toHaveBeenCalledWith({
       cwd: "/repo",
@@ -485,7 +480,8 @@ describe("spawn_agent tool", () => {
       },
     });
 
-    const result = await createSpawnAgentToolDefinition(createLocalToolExecutionBackend()).dispatch(
+    const result = await runTool(
+      createSpawnAgentToolDefinition(createLocalToolExecutionBackend()),
       {
         id: "call-10",
         name: TOOL_NAME_SPAWN_AGENT,
@@ -500,7 +496,6 @@ describe("spawn_agent tool", () => {
       context,
     );
 
-    expect(result.kind).toBe("single");
     expect(result.toolResult.isError).toBe(true);
     expect(getText(result.toolResult)).toContain("Failed to build the subagent prompt");
     expect(getText(result.toolResult)).toContain("target skill configuration is invalid");

--- a/test/view_image_tool.test.js
+++ b/test/view_image_tool.test.js
@@ -68,6 +68,11 @@ function getImageBlock(content) {
   return block;
 }
 
+async function runTool(tool, ...args) {
+  const dispatch = await tool.dispatch(...args);
+  return dispatch.run;
+}
+
 describe("view_image tool", () => {
   it("downscales images to fit inside a 2000x2000 square", async () => {
     const fx = setupFixture();
@@ -78,16 +83,11 @@ describe("view_image tool", () => {
 
       const backend = createLocalToolExecutionBackend();
       const tool = createViewImageToolDefinition(backend);
-      const result = await tool.dispatch({
+      const result = await runTool(tool, {
         id: "tool-1",
         name: TOOL_NAME_VIEW_IMAGE,
         arguments: { path: filePath },
       });
-
-      expect(result.kind).toBe("single");
-      if (result.kind !== "single") {
-        throw new Error("expected single dispatch result");
-      }
 
       expect(result.uiEvent.type).toBe("view_image_success");
       if (result.uiEvent.type !== "view_image_success") {
@@ -117,16 +117,11 @@ describe("view_image tool", () => {
 
       const backend = createLocalToolExecutionBackend();
       const tool = createViewImageToolDefinition(backend);
-      const result = await tool.dispatch({
+      const result = await runTool(tool, {
         id: "tool-2",
         name: TOOL_NAME_VIEW_IMAGE,
         arguments: { path: filePath },
       });
-
-      expect(result.kind).toBe("single");
-      if (result.kind !== "single") {
-        throw new Error("expected single dispatch result");
-      }
 
       expect(result.uiEvent.type).toBe("view_image_success");
       if (result.uiEvent.type !== "view_image_success") {
@@ -153,16 +148,11 @@ describe("view_image tool", () => {
 
       const backend = createLocalToolExecutionBackend();
       const tool = createViewImageToolDefinition(backend);
-      const result = await tool.dispatch({
+      const result = await runTool(tool, {
         id: "tool-3",
         name: TOOL_NAME_VIEW_IMAGE,
         arguments: { path: filePath },
       });
-
-      expect(result.kind).toBe("single");
-      if (result.kind !== "single") {
-        throw new Error("expected single dispatch result");
-      }
 
       expect(result.uiEvent.type).toBe("view_image_success");
       if (result.uiEvent.type !== "view_image_success") {
@@ -196,16 +186,11 @@ describe("view_image tool", () => {
 
       const backend = createLocalToolExecutionBackend();
       const tool = createViewImageToolDefinition(backend);
-      const result = await tool.dispatch({
+      const result = await runTool(tool, {
         id: "tool-4",
         name: TOOL_NAME_VIEW_IMAGE,
         arguments: { path: filePath },
       });
-
-      expect(result.kind).toBe("single");
-      if (result.kind !== "single") {
-        throw new Error("expected single dispatch result");
-      }
 
       expect(result.uiEvent.type).toBe("view_image_blocked");
       expect(getTextBlock(result.toolResult.content)).toContain("Unsupported image format");


### PR DESCRIPTION
## why

Tool execution had separate single and phased result shapes even though both represented the same lifecycle. The phased path also retained an unused asynchronous UI progress stream and runner-side promise/iterator racing after the only production consumer moved out of the host tool system.

## what

All tools now return one dispatch handle with an optional started UI event and one promise for the final model and UI result. The runner follows the same queued, optional started, final sequence for every tool, and single-stage tools, client-provided tools, and test definitions use the same contract.

The obsolete progress-event iterable, phased/single discriminants, nested result shape, and associated race machinery have been removed. Regression coverage now verifies started-event ordering, sequential execution, rejected-run error conversion, and the updated direct tool contract.

fixes #293
