### PR TITLE
show streamed tool calls while queued

### DIFF
--- a/src/core/session/runner.ts
+++ b/src/core/session/runner.ts
@@ -245,6 +245,67 @@ export type RunToolCallsOptions = {
 
 export type SequentialToolCallRunnerOptions = Omit<RunToolCallsOptions, "toolCalls" | "signal">;
 
+type ToolCallPreparationOptions = Pick<
+  RunToolCallsOptions,
+  "toolRegistry" | "extraToolDefinitions" | "enabledTools" | "toolErrorMessages"
+>;
+
+type PreparedToolCall =
+  | {
+      type: "ready";
+      toolCall: ToolCall;
+      definition: ToolDefinition;
+    }
+  | {
+      type: "rejected";
+      message: string;
+      result: ToolResultMessage;
+    };
+
+function prepareToolCall(
+  toolCall: ToolCall,
+  options: ToolCallPreparationOptions,
+): PreparedToolCall {
+  if (!options.enabledTools.some((tool) => tool.name === toolCall.name)) {
+    const message =
+      options.toolErrorMessages?.notEnabled?.(toolCall) ??
+      `Tool '${toolCall.name}' is not enabled for this session.`;
+    return {
+      type: "rejected",
+      message,
+      result: createToolError(toolCall, message),
+    };
+  }
+
+  const definition =
+    options.toolRegistry.get(toolCall.name) ??
+    options.extraToolDefinitions?.find((candidate) => candidate.schema.name === toolCall.name);
+  if (!definition) {
+    const message =
+      options.toolErrorMessages?.unsupported?.(toolCall) ??
+      `Tool '${toolCall.name}' is not supported by tau.`;
+    return {
+      type: "rejected",
+      message,
+      result: createToolError(toolCall, message),
+    };
+  }
+
+  return { type: "ready", toolCall, definition };
+}
+
+function createToolQueuedEvent(toolCall: ToolCall): CoreToolUiEvent {
+  return {
+    type: "tool_ui",
+    uiEvent: {
+      type: "tool_call_queued",
+      toolCallId: toolCall.id,
+      toolName: toolCall.name,
+      headerTarget: toolCall.name,
+    },
+  };
+}
+
 export class SequentialToolCallRunner implements AsyncIterable<ToolRunnerEvent> {
   private readonly events: ToolRunnerEvent[] = [];
   private readonly waiters: Array<{
@@ -262,23 +323,24 @@ export class SequentialToolCallRunner implements AsyncIterable<ToolRunnerEvent> 
     private readonly signal: AbortSignal,
   ) {}
 
-  enqueue(toolCall: ToolCall): void {
+  enqueue(toolCall: ToolCall): CoreToolUiEvent | undefined {
     if (this.finished) {
       throw new Error("cannot enqueue a tool call after finishing the runner");
     }
 
+    const prepared = prepareToolCall(toolCall, this.options);
     this.execution = this.execution.then(async () => {
-      for await (const event of runToolCalls({
-        ...this.options,
-        toolCalls: [toolCall],
-        signal: this.signal,
-      })) {
-        const waiter = this.waiters.shift();
-        if (waiter) {
-          waiter.resolve({ done: false, value: event });
-        } else {
-          this.events.push(event);
+      if (this.signal.aborted) {
+        return;
+      }
+      const execution = runPreparedToolCall(prepared, this.signal, this.options.dispatchContext);
+      while (true) {
+        const next = await execution.next();
+        if (next.done) {
+          this.publish({ type: "tool_result", message: next.value });
+          return;
         }
+        this.publish(next.value);
       }
     });
     void this.execution.catch((error: unknown) => {
@@ -287,6 +349,17 @@ export class SequentialToolCallRunner implements AsyncIterable<ToolRunnerEvent> 
         waiter.reject(error);
       }
     });
+
+    return prepared.type === "ready" ? createToolQueuedEvent(toolCall) : undefined;
+  }
+
+  private publish(event: ToolRunnerEvent): void {
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      waiter.resolve({ done: false, value: event });
+    } else {
+      this.events.push(event);
+    }
   }
 
   finish(): Promise<void> {
@@ -405,102 +478,86 @@ async function* runPhasedToolResult(
   return finalResult;
 }
 
+async function* runPreparedToolCall(
+  prepared: PreparedToolCall,
+  signal: AbortSignal,
+  dispatchContext: ToolDispatchContext,
+): AsyncGenerator<ToolRunnerEvent, ToolResultMessage, void> {
+  if (prepared.type === "rejected") {
+    yield { type: "notice", severity: "error", text: prepared.message };
+    return prepared.result;
+  }
+
+  const { toolCall, definition } = prepared;
+  try {
+    const dispatched = await definition.dispatch(toolCall, signal, dispatchContext);
+    if (dispatched.kind === "phased" && dispatched.startedUiEvent) {
+      yield { type: "tool_ui", uiEvent: dispatched.startedUiEvent };
+    }
+    const result =
+      dispatched.kind === "phased" ? yield* runPhasedToolResult(dispatched) : dispatched;
+    if (result.uiEvent) {
+      yield { type: "tool_ui", uiEvent: result.uiEvent };
+    }
+    return result.toolResult;
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    yield {
+      type: "notice",
+      severity: "error",
+      text: `Tool '${toolCall.name}' (${toolCall.id}) execution failed: ${errorMessage}`,
+    };
+    return createToolError(toolCall, `Tool '${toolCall.name}' execution failed: ${errorMessage}`);
+  }
+}
+
 export async function* runToolCalls(
   options: RunToolCallsOptions,
 ): AsyncGenerator<ToolRunnerEvent, void, void> {
-  const {
-    toolCalls,
-    toolRegistry,
-    enabledTools,
-    extraToolDefinitions = [],
-    signal,
-    dispatchContext,
-    toolErrorMessages,
-  } = options;
-  const enabledToolNames = new Set(enabledTools.map((tool) => tool.name));
-
+  const { toolCalls, signal, dispatchContext, ...preparationOptions } = options;
+  const preparedCalls: PreparedToolCall[] = [];
+  for (const toolCall of toolCalls) {
+    if (signal.aborted) {
+      break;
+    }
+    preparedCalls.push(prepareToolCall(toolCall, preparationOptions));
+  }
   const resultsByIndex = new Map<number, ToolResultMessage>();
-  const validToolCalls: Array<{ index: number; toolCall: ToolCall; def: ToolDefinition }> = [];
 
-  for (let i = 0; i < toolCalls.length; i++) {
-    if (signal.aborted) break;
-
-    const toolCall = toolCalls[i]!;
-
-    if (!enabledToolNames.has(toolCall.name)) {
-      const msg =
-        toolErrorMessages?.notEnabled?.(toolCall) ??
-        `Tool '${toolCall.name}' is not enabled for this session.`;
-      const toolError = createToolError(toolCall, msg);
-      resultsByIndex.set(i, toolError);
-      yield { type: "notice", severity: "error", text: msg };
+  for (const [index, prepared] of preparedCalls.entries()) {
+    if (signal.aborted) {
+      break;
+    }
+    if (prepared.type !== "rejected") {
       continue;
     }
+    resultsByIndex.set(index, prepared.result);
+    yield { type: "notice", severity: "error", text: prepared.message };
+  }
 
-    const def =
-      toolRegistry.get(toolCall.name) ??
-      extraToolDefinitions.find((definition) => definition.schema.name === toolCall.name);
-    if (!def) {
-      const msg =
-        toolErrorMessages?.unsupported?.(toolCall) ??
-        `Tool '${toolCall.name}' is not supported by tau.`;
-      const toolError = createToolError(toolCall, msg);
-      resultsByIndex.set(i, toolError);
-      yield { type: "notice", severity: "error", text: msg };
+  for (const prepared of preparedCalls) {
+    if (signal.aborted) {
+      break;
+    }
+    if (prepared.type === "ready") {
+      yield createToolQueuedEvent(prepared.toolCall);
+    }
+  }
+
+  for (const [index, prepared] of preparedCalls.entries()) {
+    if (signal.aborted) {
+      break;
+    }
+    if (prepared.type === "rejected") {
       continue;
     }
-
-    validToolCalls.push({ index: i, toolCall, def });
+    resultsByIndex.set(index, yield* runPreparedToolCall(prepared, signal, dispatchContext));
   }
 
-  for (const { toolCall } of validToolCalls) {
-    if (signal.aborted) break;
-    yield {
-      type: "tool_ui",
-      uiEvent: {
-        type: "tool_call_queued",
-        toolCallId: toolCall.id,
-        toolName: toolCall.name,
-        headerTarget: toolCall.name,
-      },
-    };
-  }
-
-  for (const entry of validToolCalls) {
-    if (signal.aborted) break;
-
-    const { index, toolCall, def } = entry;
-    try {
-      const dispatched = await def.dispatch(toolCall, signal, dispatchContext);
-      if (dispatched.kind === "phased" && dispatched.startedUiEvent) {
-        yield { type: "tool_ui", uiEvent: dispatched.startedUiEvent };
-      }
-      const result =
-        dispatched.kind === "phased" ? yield* runPhasedToolResult(dispatched) : dispatched;
-      const { toolResult, uiEvent } = result;
-      resultsByIndex.set(index, toolResult);
-      if (uiEvent) {
-        yield { type: "tool_ui", uiEvent };
-      }
-    } catch (error) {
-      const errorMsg = error instanceof Error ? error.message : String(error);
-      const toolError = createToolError(
-        toolCall,
-        `Tool '${toolCall.name}' execution failed: ${errorMsg}`,
-      );
-      resultsByIndex.set(index, toolError);
-      yield {
-        type: "notice",
-        severity: "error",
-        text: `Tool '${toolCall.name}' (${toolCall.id}) execution failed: ${errorMsg}`,
-      };
-    }
-  }
-
-  for (let i = 0; i < toolCalls.length; i++) {
-    const toolResult = resultsByIndex.get(i);
-    if (toolResult) {
-      yield { type: "tool_result", message: toolResult };
+  for (const [index] of toolCalls.entries()) {
+    const result = resultsByIndex.get(index);
+    if (result) {
+      yield { type: "tool_result", message: result };
     }
   }
 }

--- a/src/core/session/session_engine.ts
+++ b/src/core/session/session_engine.ts
@@ -16,7 +16,12 @@ import {
   type NormalizedAutoCompactConfig,
   normalizeAutoCompactConfig,
 } from "../config/index.js";
-import type { CoreCompactionResult, CoreEvent, CoreSubagentUiEvent } from "../events/types.js";
+import type {
+  CoreCompactionResult,
+  CoreEvent,
+  CoreSubagentUiEvent,
+  CoreToolUiEvent,
+} from "../events/types.js";
 import type { ModelResolver } from "../models/catalog.js";
 import type { CoreDeps } from "../runtime/deps.js";
 import { createDefaultCoreDeps } from "../runtime/deps.js";
@@ -1218,9 +1223,13 @@ export class SessionEngine {
             if (signal.aborted) {
               continue;
             }
+            const queuedEvents: CoreToolUiEvent[] = [];
             for (const toolCall of event.snapshot.toolCalls.slice(streamedToolCalls.length)) {
               streamedToolCalls.push(toolCall);
-              toolRunner.enqueue(toolCall);
+              const queuedEvent = toolRunner.enqueue(toolCall);
+              if (queuedEvent) {
+                queuedEvents.push(queuedEvent);
+              }
             }
             const partialEvent: CoreEvent = {
               type: "assistant_partial",
@@ -1229,6 +1238,10 @@ export class SessionEngine {
             };
             this.emitEvent(partialEvent);
             yield partialEvent;
+            for (const queuedEvent of queuedEvents) {
+              this.emitEvent(queuedEvent);
+              yield queuedEvent;
+            }
             continue;
           }
 

--- a/test/core_runtime.test.js
+++ b/test/core_runtime.test.js
@@ -613,13 +613,29 @@ describe("core session rewind APIs", () => {
 
     session.addUserText("use both tools");
     const events = [];
+    let markSecondQueued;
+    const secondQueued = new Promise((resolve) => {
+      markSecondQueued = resolve;
+    });
     const turn = (async () => {
       for await (const event of session.events(new AbortController().signal)) {
         events.push(event);
+        if (
+          event.type === "tool_ui" &&
+          event.uiEvent.type === "tool_call_queued" &&
+          event.uiEvent.toolCallId === secondCall.id
+        ) {
+          markSecondQueued();
+        }
       }
     })();
 
-    await firstStarted;
+    await Promise.all([firstStarted, secondQueued]);
+    expect(
+      events
+        .filter((event) => event.type === "tool_ui" && event.uiEvent.type === "tool_call_queued")
+        .map((event) => event.uiEvent.toolCallId),
+    ).toEqual([firstCall.id, secondCall.id]);
     expect(secondHasStarted).toBe(false);
     releaseFirst();
     await secondStarted;

--- a/test/local_session_host.test.js
+++ b/test/local_session_host.test.js
@@ -1,3 +1,7 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import { createLocalToolExecutionBackend, ToolCatalog } from "../dist/core/index.js";
 import { resolveModel } from "../dist/core/models/catalog.js";
@@ -754,6 +758,104 @@ describe("LocalSessionHost", () => {
       messageId: "assistant-streaming-tool",
       contentIndex: 0,
     });
+  });
+
+  it("publishes later streamed tool calls as queued before they execute", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "tau-tool-streaming-"));
+    const executionEnvironment = createTestExecutionEnvironment({
+      kind: "local",
+      cwd,
+      home: cwd,
+    });
+    const host = createHostForEnvironment(new MemorySessionStore(), executionEnvironment);
+
+    try {
+      const hostedSession = await host.createSession({
+        executionEnvironment: { kind: "local", cwd },
+      });
+      const firstCall = fauxToolCall(
+        "bash",
+        { command: `node -e "setTimeout(() => process.stdout.write('first'), 100)"` },
+        { id: "first-call" },
+      );
+      const secondCall = fauxToolCall("bash", { command: "printf second" }, { id: "second-call" });
+      const toolMessage = fauxAssistantMessage(
+        [{ type: "text", text: "running commands" }, firstCall, secondCall],
+        { stopReason: "toolUse" },
+      );
+      const finalMessage = fauxAssistantMessage("done");
+      const responses = [toolMessage, finalMessage];
+
+      hostedSession.runtime.session.engine.modelRuntime.streamModel = () => {
+        const response = responses.shift();
+        return {
+          async *[Symbol.asyncIterator]() {
+            if (response !== toolMessage) {
+              return;
+            }
+            yield { type: "text_delta", contentIndex: 0, delta: "running commands" };
+            yield { type: "toolcall_start", contentIndex: 1 };
+            yield { type: "toolcall_end", contentIndex: 1, toolCall: firstCall };
+            yield { type: "toolcall_start", contentIndex: 2 };
+            yield { type: "toolcall_end", contentIndex: 2, toolCall: secondCall };
+          },
+          async result() {
+            return response;
+          },
+        };
+      };
+
+      const events = [];
+      let resolveFirstStarted;
+      const firstStarted = new Promise((resolve) => {
+        resolveFirstStarted = resolve;
+      });
+      let resolveSecondQueued;
+      const secondQueued = new Promise((resolve) => {
+        resolveSecondQueued = resolve;
+      });
+      hostedSession.onDelta((delta) => {
+        for (const change of delta.delta.changes ?? []) {
+          if (change.type !== "facet.set" || change.facet.kind !== "tau.tool-ui-events") {
+            continue;
+          }
+          const event = change.facet.data.events.at(-1);
+          events.push(event);
+          if (event.type === "bash_started" && event.toolCallId === firstCall.id) {
+            resolveFirstStarted();
+          } else if (event.type === "tool_call_queued" && event.toolCallId === secondCall.id) {
+            resolveSecondQueued();
+          }
+        }
+      });
+
+      await hostedSession.record({ text: "run both" });
+      const turn = hostedSession.runTurn();
+      await Promise.all([firstStarted, secondQueued]);
+
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ type: "tool_call_queued", toolCallId: firstCall.id }),
+          expect.objectContaining({ type: "bash_started", toolCallId: firstCall.id }),
+          expect.objectContaining({ type: "tool_call_queued", toolCallId: secondCall.id }),
+        ]),
+      );
+      expect(events).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ type: "bash_execution", toolCallId: firstCall.id }),
+        ]),
+      );
+      expect(events).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ type: "bash_started", toolCallId: secondCall.id }),
+        ]),
+      );
+
+      await turn;
+    } finally {
+      await host.shutdown();
+      rmSync(cwd, { recursive: true, force: true });
+    }
   });
 
   it("replaces a tool-only draft when later text changes the content shape", async () => {


### PR DESCRIPTION
## why

Streamed tool calls begin executing as soon as they are complete, but later calls remain invisible in the TUI until the sequential runner reaches them. When a model emits several calls together, this makes known work appear only after earlier calls finish and hides the latency improvement from the user.

## what

Separate tool-call admission from execution. Calls are validated when they enter the sequential runner, and accepted calls publish their queued UI state immediately after the assistant partial that introduced them. Dispatch remains strictly sequential, so only the active call transitions to running while later calls stay visibly queued.

The runner now shares one preparation and execution path between streamed sequential calls and ordinary batched tool execution, preserving disabled-tool, unsupported-tool, failure, interruption, and ordered-result behavior. Integration coverage verifies that a later bash call reaches the hosted session as queued while the first call is still running.
