### PR TITLE
restore terminal idle notifications

### DIFF
--- a/src/tui/session_chat_controller.ts
+++ b/src/tui/session_chat_controller.ts
@@ -131,6 +131,8 @@ export class SessionChatController {
   private pendingUserMessagesUnsubscribe?: () => void;
   private snapshotRecovery?: Promise<void>;
   private readonly snapshotRecoveryDeltas: SessionProtocolDeltaMessage[] = [];
+  private hasPendingUserMessages = false;
+  private pendingIdleNotification = false;
   private isStreaming = false;
   private submittedTurnInProgress = false;
   private manualCompactionInProgress = false;
@@ -1069,7 +1071,9 @@ export class SessionChatController {
   }
 
   private onSdkPendingUserMessages(message: SessionProtocolPendingUserMessagesMessage): void {
+    this.hasPendingUserMessages = message.state.messages.length > 0;
     this.view.setPendingUserMessages(message.state.messages);
+    this.sendPendingIdleNotification();
   }
 
   private onSdkDelta(delta: SessionProtocolDeltaMessage): void {
@@ -1391,6 +1395,17 @@ export class SessionChatController {
     }
 
     void this.stopTurnCaffeinate();
+    this.pendingIdleNotification = true;
+    this.sendPendingIdleNotification();
+  }
+
+  private sendPendingIdleNotification(): void {
+    if (!this.pendingIdleNotification || this.isStreaming || this.hasPendingUserMessages) {
+      return;
+    }
+
+    this.pendingIdleNotification = false;
+    this.view.sendTerminalNotification("tau is waiting for your input");
   }
 
   private stopVisibleSessionTurn(): boolean {

--- a/test/session_chat_controller.test.js
+++ b/test/session_chat_controller.test.js
@@ -547,6 +547,7 @@ class FakeView {
   subagentSelectionCycles = [];
   selectedSubagentId;
   pendingUserMessages = [];
+  terminalNotifications = [];
   renderRequests = 0;
   workingIconStarts = 0;
   workingIconStops = 0;
@@ -614,7 +615,9 @@ class FakeView {
   getSelectedSubagentId() {
     return this.selectedSubagentId;
   }
-  sendTerminalNotification() {}
+  sendTerminalNotification(title) {
+    this.terminalNotifications.push(title);
+  }
   setPendingUserMessages(messages) {
     this.pendingUserMessages = structuredClone(messages);
   }
@@ -1455,6 +1458,27 @@ describe("SessionChatController", () => {
       expect.objectContaining({ historyEntryId: expect.stringMatching(/^session-user-/) }),
     );
     expect(session.queue).not.toHaveBeenCalled();
+  });
+
+  it("notifies when a session turn becomes idle", async () => {
+    const session = new FakeSession();
+    const view = new FakeView();
+    const controller = new SessionChatController({
+      view,
+      session,
+      snapshot: await session.snapshot(),
+      targetLabel: "in-process",
+    });
+    controller.start();
+
+    session.emit({ type: "assistant_start", historyEntryId: "assistant-1" });
+    session.emit({
+      type: "assistant_final",
+      historyEntryId: "assistant-1",
+      message: createAssistantMessage("done"),
+    });
+
+    expect(view.terminalNotifications).toEqual(["tau is waiting for your input"]);
   });
 
   it("renders pending queue and steering messages from session pending state", async () => {


### PR DESCRIPTION
## why

Terminal notifications stopped firing after queued messages moved to protocol-owned pending state. The notification writer remained in place, but the controller no longer called it when a turn finished.

## what

Restore notifications when a running session becomes idle. If queued or steering messages remain, defer the notification until they clear, then send `tau is waiting for your input`.

Add controller coverage for the lifecycle transition and notification content.
