### PR TITLE
reconcile projections after history changes

### DIFF
--- a/src/core/events/parser.ts
+++ b/src/core/events/parser.ts
@@ -117,7 +117,6 @@ function stripCoreEvent(value: UnknownRecord): CoreEvent {
       return {
         type: "subagent_ui",
         event: value.event as Extract<CoreEvent, { type: "subagent_ui" }>["event"],
-        originHistoryEntryId: value.originHistoryEntryId as string,
       };
     case "tool_result":
       return {
@@ -192,7 +191,7 @@ function isValidCoreEvent(value: UnknownRecord, eventType: string): boolean {
     case "tool_ui":
       return isToolUiEvent(value.uiEvent);
     case "subagent_ui":
-      return typeof value.originHistoryEntryId === "string" && isSubagentUiEvent(value.event);
+      return isSubagentUiEvent(value.event);
     case "tool_result":
       return typeof value.historyEntryId === "string" && isToolResultMessage(value.message);
     case "tool_recovery":

--- a/src/core/events/types.ts
+++ b/src/core/events/types.ts
@@ -36,7 +36,6 @@ export type CoreToolUiEvent = {
 export type CoreSubagentUiEvent = {
   type: "subagent_ui";
   event: SubagentUiEvent;
-  originHistoryEntryId: string;
 };
 
 export type CoreToolResultEvent = {

--- a/src/core/session/compaction.ts
+++ b/src/core/session/compaction.ts
@@ -527,7 +527,6 @@ export function buildAutoCompactionContinuationMessage(args: {
   cutType: AutoCompactionCutType;
   now: number;
   modelNotice?: string;
-  subagentStatus?: string;
 }): Message {
   const lines = [
     "The conversation context before this point has been compacted.",
@@ -539,11 +538,6 @@ export function buildAutoCompactionContinuationMessage(args: {
     lines.push(
       "The retained messages begin in the middle of the latest assistant/tool turn. The summary contains the original request and earlier tool work from that turn.",
     );
-  }
-
-  const subagentStatus = args.subagentStatus?.trim();
-  if (subagentStatus) {
-    lines.push("", "<active-subagents>", subagentStatus, "</active-subagents>");
   }
 
   const hiddenSystemMessages = [args.modelNotice?.trim() || undefined, lines.join("\n")].filter(

--- a/src/core/session/core_session.ts
+++ b/src/core/session/core_session.ts
@@ -92,6 +92,10 @@ export class CoreSession {
     return this.engine.onSubagentEvent(handler);
   }
 
+  hasSubagent(id: string): boolean {
+    return this.engine.hasSubagent(id);
+  }
+
   async terminateSubagent(id: string): Promise<boolean> {
     return await this.engine.terminateSubagent(id);
   }

--- a/src/core/session/pruning.ts
+++ b/src/core/session/pruning.ts
@@ -515,8 +515,11 @@ function pruneEditToolHistory(
       }
 
       const args = getToolCallArgumentsObject(toolCall);
-      const oldText = getRequiredEditArgument(args, "oldText", toolCall.id);
-      const newText = getRequiredEditArgument(args, "newText", toolCall.id);
+      const oldText = getEditArgument(args, "oldText");
+      const newText = getEditArgument(args, "newText");
+      if (oldText === undefined || newText === undefined) {
+        return block;
+      }
 
       if (oldText === PRUNED_EDIT_ARGUMENT_MARKER && newText === PRUNED_EDIT_ARGUMENT_MARKER) {
         return block;
@@ -616,23 +619,18 @@ function getAssistantContentOrThrow(
 function getToolCallArgumentsObject(toolCall: ToolCall): Record<string, unknown> {
   const { arguments: argumentsValue } = toolCall;
   if (!argumentsValue || typeof argumentsValue !== "object" || Array.isArray(argumentsValue)) {
-    throw new Error(`invalid edit tool call arguments (tool_call_id=${toolCall.id})`);
+    return {};
   }
 
   return argumentsValue as Record<string, unknown>;
 }
 
-function getRequiredEditArgument(
+function getEditArgument(
   args: Record<string, unknown>,
   key: "oldText" | "newText",
-  toolCallId: string,
-): string {
+): string | undefined {
   const value = args[key];
-  if (typeof value !== "string") {
-    throw new Error(`missing edit argument '${key}' (tool_call_id=${toolCallId})`);
-  }
-
-  return value;
+  return typeof value === "string" ? value : undefined;
 }
 
 function buildPrunedEditToolResult(diff: EditPruneCallDiff): string {

--- a/src/core/session/pruning.ts
+++ b/src/core/session/pruning.ts
@@ -514,10 +514,12 @@ function pruneEditToolHistory(
         return block;
       }
 
-      const args = getToolCallArgumentsObject(toolCall);
-      const oldText = getEditArgument(args, "oldText");
-      const newText = getEditArgument(args, "newText");
-      if (oldText === undefined || newText === undefined) {
+      const args = toolCall.arguments;
+      if (!args || typeof args !== "object" || Array.isArray(args)) {
+        return block;
+      }
+      const { oldText, newText } = args as Record<string, unknown>;
+      if (typeof oldText !== "string" || typeof newText !== "string") {
         return block;
       }
 
@@ -614,23 +616,6 @@ function getAssistantContentOrThrow(
   }
 
   return assistant.content;
-}
-
-function getToolCallArgumentsObject(toolCall: ToolCall): Record<string, unknown> {
-  const { arguments: argumentsValue } = toolCall;
-  if (!argumentsValue || typeof argumentsValue !== "object" || Array.isArray(argumentsValue)) {
-    return {};
-  }
-
-  return argumentsValue as Record<string, unknown>;
-}
-
-function getEditArgument(
-  args: Record<string, unknown>,
-  key: "oldText" | "newText",
-): string | undefined {
-  const value = args[key];
-  return typeof value === "string" ? value : undefined;
 }
 
 function buildPrunedEditToolResult(diff: EditPruneCallDiff): string {

--- a/src/core/session/session_engine.ts
+++ b/src/core/session/session_engine.ts
@@ -106,6 +106,7 @@ export type SessionCompactionOptions = {
 };
 
 export type SessionCompactionResult = {
+  summaryHistoryEntryId: string;
   compactionMessage: string;
   includedLastAssistant: boolean;
 };
@@ -223,7 +224,6 @@ export class SessionEngine {
       id: entry.id,
       message: structuredClone(entry.message),
     }));
-    this.subagentControlPlane.retainOrigins(new Set(this.historyEntries.map((entry) => entry.id)));
   }
 
   dispose(): void {
@@ -382,6 +382,9 @@ export class SessionEngine {
 
     const removedEntryIds = this.historyEntries.slice(historyIndex).map((item) => item.id);
     this.replaceHistoryEntries(this.historyEntries.slice(0, historyIndex));
+    this.subagentControlPlane.retainOrigins(
+      new Set(this.historyEntries.map((historyEntry) => historyEntry.id)),
+    );
 
     return {
       historyEntryId: entry.id,
@@ -490,8 +493,10 @@ export class SessionEngine {
       },
     };
     this.replaceHistoryEntries([summaryEntry]);
+    this.subagentControlPlane.rebaseMissingOrigins(new Set([summaryEntry.id]), summaryEntry.id);
 
     return {
+      summaryHistoryEntryId: summaryEntry.id,
       compactionMessage,
       includedLastAssistant,
     };
@@ -966,13 +971,15 @@ export class SessionEngine {
         cutType: preparation.cutType,
         now: this.deps.clock.now(),
         modelNotice,
-        subagentStatus: this.formatAutoCompactionSubagentStatus(
-          new Set(preparation.retainedEntries.map((entry) => entry.id)),
-        ),
+        subagentStatus: this.formatAutoCompactionSubagentStatus(),
       }),
     };
 
     this.replaceHistoryEntries([summaryEntry, ...preparation.retainedEntries, continuationEntry]);
+    this.subagentControlPlane.rebaseMissingOrigins(
+      new Set(this.historyEntries.map((entry) => entry.id)),
+      summaryEntry.id,
+    );
 
     return {
       summaryHistoryEntryId: summaryEntry.id,
@@ -983,18 +990,10 @@ export class SessionEngine {
     };
   }
 
-  private formatAutoCompactionSubagentStatus(
-    retainedHistoryEntryIds: ReadonlySet<string>,
-  ): string | undefined {
+  private formatAutoCompactionSubagentStatus(): string | undefined {
     const running = this.subagentControlPlane
       .listSnapshots()
-      .filter(
-        (snapshot) =>
-          snapshot.status === "running" &&
-          retainedHistoryEntryIds.has(
-            this.subagentControlPlane.getOriginHistoryEntryId(snapshot.id),
-          ),
-      );
+      .filter((snapshot) => snapshot.status === "running");
     if (running.length === 0) {
       return undefined;
     }

--- a/src/core/session/session_engine.ts
+++ b/src/core/session/session_engine.ts
@@ -223,9 +223,6 @@ export class SessionEngine {
       id: entry.id,
       message: structuredClone(entry.message),
     }));
-  }
-
-  private retainSubagentsForCurrentHistory(): void {
     this.subagentControlPlane.retainOrigins(new Set(this.historyEntries.map((entry) => entry.id)));
   }
 
@@ -385,7 +382,6 @@ export class SessionEngine {
 
     const removedEntryIds = this.historyEntries.slice(historyIndex).map((item) => item.id);
     this.replaceHistoryEntries(this.historyEntries.slice(0, historyIndex));
-    this.retainSubagentsForCurrentHistory();
 
     return {
       historyEntryId: entry.id,
@@ -494,7 +490,6 @@ export class SessionEngine {
       },
     };
     this.replaceHistoryEntries([summaryEntry]);
-    this.retainSubagentsForCurrentHistory();
 
     return {
       compactionMessage,
@@ -517,7 +512,7 @@ export class SessionEngine {
         : [];
     }
 
-    const nextHistoryEntries = this.rawHistoryEntriesSnapshot.map((entry) => ({ ...entry }));
+    const nextHistoryEntries = [...this.rawHistoryEntriesSnapshot];
     const result = pruneSessionHistory({
       historyEntries: nextHistoryEntries,
       replaceMessageById: (historyEntryId, message) => {
@@ -971,7 +966,9 @@ export class SessionEngine {
         cutType: preparation.cutType,
         now: this.deps.clock.now(),
         modelNotice,
-        subagentStatus: this.formatAutoCompactionSubagentStatus(),
+        subagentStatus: this.formatAutoCompactionSubagentStatus(
+          new Set(preparation.retainedEntries.map((entry) => entry.id)),
+        ),
       }),
     };
 
@@ -986,10 +983,18 @@ export class SessionEngine {
     };
   }
 
-  private formatAutoCompactionSubagentStatus(): string | undefined {
+  private formatAutoCompactionSubagentStatus(
+    retainedHistoryEntryIds: ReadonlySet<string>,
+  ): string | undefined {
     const running = this.subagentControlPlane
       .listSnapshots()
-      .filter((snapshot) => snapshot.status === "running");
+      .filter(
+        (snapshot) =>
+          snapshot.status === "running" &&
+          retainedHistoryEntryIds.has(
+            this.subagentControlPlane.getOriginHistoryEntryId(snapshot.id),
+          ),
+      );
     if (running.length === 0) {
       return undefined;
     }

--- a/src/core/session/session_engine.ts
+++ b/src/core/session/session_engine.ts
@@ -225,6 +225,10 @@ export class SessionEngine {
     }));
   }
 
+  private retainSubagentsForCurrentHistory(): void {
+    this.subagentControlPlane.retainOrigins(new Set(this.historyEntries.map((entry) => entry.id)));
+  }
+
   dispose(): void {
     this.closeProviderSessions();
     this.subagentControlPlane.reset();
@@ -380,7 +384,8 @@ export class SessionEngine {
     }
 
     const removedEntryIds = this.historyEntries.slice(historyIndex).map((item) => item.id);
-    this.historyEntries = this.historyEntries.slice(0, historyIndex);
+    this.replaceHistoryEntries(this.historyEntries.slice(0, historyIndex));
+    this.retainSubagentsForCurrentHistory();
 
     return {
       historyEntryId: entry.id,
@@ -489,6 +494,7 @@ export class SessionEngine {
       },
     };
     this.replaceHistoryEntries([summaryEntry]);
+    this.retainSubagentsForCurrentHistory();
 
     return {
       compactionMessage,
@@ -511,10 +517,17 @@ export class SessionEngine {
         : [];
     }
 
-    return pruneSessionHistory({
-      historyEntries: this.historyEntries,
-      replaceMessageById: (historyEntryId, message) =>
-        this.replaceMessageById(historyEntryId, message),
+    const nextHistoryEntries = this.rawHistoryEntriesSnapshot.map((entry) => ({ ...entry }));
+    const result = pruneSessionHistory({
+      historyEntries: nextHistoryEntries,
+      replaceMessageById: (historyEntryId, message) => {
+        const index = nextHistoryEntries.findIndex((entry) => entry.id === historyEntryId);
+        if (index < 0) {
+          return false;
+        }
+        nextHistoryEntries[index] = { ...nextHistoryEntries[index]!, message };
+        return true;
+      },
       options: {
         strategy: options.strategy,
         fraction: options.fraction,
@@ -522,6 +535,8 @@ export class SessionEngine {
         ...(smartSelection !== undefined ? { smartSelection } : {}),
       },
     });
+    this.replaceHistoryEntries(nextHistoryEntries);
+    return result;
   }
 
   private async runSmartPruneSelection(

--- a/src/core/session/session_engine.ts
+++ b/src/core/session/session_engine.ts
@@ -106,7 +106,6 @@ export type SessionCompactionOptions = {
 };
 
 export type SessionCompactionResult = {
-  summaryHistoryEntryId: string;
   compactionMessage: string;
   includedLastAssistant: boolean;
 };
@@ -282,6 +281,10 @@ export class SessionEngine {
     return () => this.subagentEventListeners.delete(handler);
   }
 
+  hasSubagent(id: string): boolean {
+    return this.subagentControlPlane.getSnapshot(id) !== undefined;
+  }
+
   async terminateSubagent(id: string): Promise<boolean> {
     const result = await this.subagentControlPlane.terminate(id);
     return Boolean(result);
@@ -378,6 +381,9 @@ export class SessionEngine {
       isTauUserMessageHidden(entry.message)
     ) {
       return undefined;
+    }
+    if (this.subagentControlPlane.getActiveCount() > 0) {
+      throw new Error("cannot rewind while subagents are running");
     }
 
     const removedEntryIds = this.historyEntries.slice(historyIndex).map((item) => item.id);
@@ -493,10 +499,8 @@ export class SessionEngine {
       },
     };
     this.replaceHistoryEntries([summaryEntry]);
-    this.subagentControlPlane.rebaseMissingOrigins(new Set([summaryEntry.id]), summaryEntry.id);
 
     return {
-      summaryHistoryEntryId: summaryEntry.id,
       compactionMessage,
       includedLastAssistant,
     };
@@ -659,12 +663,9 @@ export class SessionEngine {
   }
 
   private emitSubagentEvent(event: SubagentUiEvent): void {
-    const subagentId = this.getSubagentEventId(event);
-    const originHistoryEntryId = this.subagentControlPlane.getOriginHistoryEntryId(subagentId);
     const coreEvent: CoreSubagentUiEvent = {
       type: "subagent_ui",
       event,
-      originHistoryEntryId,
     };
     for (const listener of this.subagentEventListeners) {
       listener(coreEvent);
@@ -675,18 +676,6 @@ export class SessionEngine {
   private emitEvent(event: CoreEvent): void {
     for (const listener of this.eventListeners) {
       listener(event);
-    }
-  }
-
-  private getSubagentEventId(event: SubagentUiEvent): string {
-    switch (event.type) {
-      case "subagent_spawned":
-      case "subagent_finished":
-        return event.state.id;
-      case "subagent_progress":
-      case "subagent_emit_output":
-      case "subagent_abort_requested":
-        return event.id;
     }
   }
 
@@ -976,10 +965,6 @@ export class SessionEngine {
     };
 
     this.replaceHistoryEntries([summaryEntry, ...preparation.retainedEntries, continuationEntry]);
-    this.subagentControlPlane.rebaseMissingOrigins(
-      new Set(this.historyEntries.map((entry) => entry.id)),
-      summaryEntry.id,
-    );
 
     return {
       summaryHistoryEntryId: summaryEntry.id,

--- a/src/core/session/session_engine.ts
+++ b/src/core/session/session_engine.ts
@@ -49,6 +49,7 @@ import {
   getAutoCompactionMetadataFromMessage,
   hasAutoCompactionContinuationMetadata,
   isTauUserMessageHidden,
+  prependTauHiddenSystemMessages,
   prependTauUserMetadata,
   stripTauUserDisplayText,
   stripTauUserMetadata,
@@ -477,11 +478,11 @@ export class SessionEngine {
       preservedUserMessages: summaryResult.preservedUserMessages,
     });
 
-    const textWithModelNotice = prependModelNotice(
+    const textWithContext = this.prependCompactionContext(
       compactionMessage,
       resolveModelNotice(this.config, this.persona.model),
     );
-    const textWithMetadata = prependTauUserMetadata(textWithModelNotice, [
+    const textWithMetadata = prependTauUserMetadata(textWithContext, [
       {
         type: "compaction",
         version: 1,
@@ -934,8 +935,8 @@ export class SessionEngine {
     const compactionMessage = buildCompactionUserMessage({ summary: compactionSummary });
     const retainedMessageCount = preparation.retainedEntries.length;
     const modelNotice = resolveModelNotice(this.config, this.persona.model);
-    const textWithModelNotice = prependModelNotice(compactionMessage, modelNotice);
-    const textWithMetadata = prependTauUserMetadata(textWithModelNotice, [
+    const textWithContext = this.prependCompactionContext(compactionMessage, modelNotice);
+    const textWithMetadata = prependTauUserMetadata(textWithContext, [
       {
         type: "auto-compaction",
         version: 1,
@@ -960,7 +961,6 @@ export class SessionEngine {
         cutType: preparation.cutType,
         now: this.deps.clock.now(),
         modelNotice,
-        subagentStatus: this.formatAutoCompactionSubagentStatus(),
       }),
     };
 
@@ -975,7 +975,14 @@ export class SessionEngine {
     };
   }
 
-  private formatAutoCompactionSubagentStatus(): string | undefined {
+  private prependCompactionContext(text: string, modelNotice?: string): string {
+    const hiddenSystemMessages = [modelNotice, this.formatCompactionSubagentStatus()].filter(
+      (message): message is string => message !== undefined,
+    );
+    return prependTauHiddenSystemMessages(text, hiddenSystemMessages);
+  }
+
+  private formatCompactionSubagentStatus(): string | undefined {
     const running = this.subagentControlPlane
       .listSnapshots()
       .filter((snapshot) => snapshot.status === "running");
@@ -983,12 +990,13 @@ export class SessionEngine {
       return undefined;
     }
 
-    return running
+    const entries = running
       .map((snapshot) => {
         const abort = snapshot.abortRequested ? ", abort requested" : "";
         return `- ${snapshot.id}: ${snapshot.title} (name: ${snapshot.name}, status: ${snapshot.status}${abort})`;
       })
       .join("\n");
+    return `<active-subagents>\n${entries}\n</active-subagents>`;
   }
 
   private shouldRunAutoCompaction(): boolean {

--- a/src/core/subagents/control_plane.ts
+++ b/src/core/subagents/control_plane.ts
@@ -133,17 +133,6 @@ export class SubagentControlPlane {
     }
   }
 
-  rebaseMissingOrigins(
-    retainedOriginHistoryEntryIds: ReadonlySet<string>,
-    replacementOriginHistoryEntryId: string,
-  ): void {
-    for (const record of this.records.values()) {
-      if (!retainedOriginHistoryEntryIds.has(record.originHistoryEntryId)) {
-        record.originHistoryEntryId = replacementOriginHistoryEntryId;
-      }
-    }
-  }
-
   getActiveCount(): number {
     let count = 0;
     for (const record of this.records.values()) {
@@ -336,14 +325,6 @@ export class SubagentControlPlane {
 
   listSnapshots(): SubagentStateSnapshot[] {
     return [...this.records.values()].map((record) => this.toSnapshot(record));
-  }
-
-  getOriginHistoryEntryId(id: string): string {
-    const record = this.records.get(id);
-    if (!record) {
-      throw new Error(`Unknown subagent ID: ${id}`);
-    }
-    return record.originHistoryEntryId;
   }
 
   private startRun(options: {

--- a/src/core/subagents/control_plane.ts
+++ b/src/core/subagents/control_plane.ts
@@ -116,14 +116,21 @@ export class SubagentControlPlane {
   }
 
   reset(): void {
-    for (const record of this.records.values()) {
+    this.retainOrigins(new Set());
+  }
+
+  retainOrigins(originHistoryEntryIds: ReadonlySet<string>): void {
+    for (const [id, record] of this.records) {
+      if (originHistoryEntryIds.has(record.originHistoryEntryId)) {
+        continue;
+      }
+      this.records.delete(id);
       cleanupSessionResources(record.id);
       if (record.status === "running") {
         record.abortRequested = true;
         record.controller.abort();
       }
     }
-    this.records.clear();
   }
 
   getActiveCount(): number {

--- a/src/core/subagents/control_plane.ts
+++ b/src/core/subagents/control_plane.ts
@@ -133,6 +133,17 @@ export class SubagentControlPlane {
     }
   }
 
+  rebaseMissingOrigins(
+    retainedOriginHistoryEntryIds: ReadonlySet<string>,
+    replacementOriginHistoryEntryId: string,
+  ): void {
+    for (const record of this.records.values()) {
+      if (!retainedOriginHistoryEntryIds.has(record.originHistoryEntryId)) {
+        record.originHistoryEntryId = replacementOriginHistoryEntryId;
+      }
+    }
+  }
+
   getActiveCount(): number {
     let count = 0;
     for (const record of this.records.values()) {

--- a/src/host/local_session_host.ts
+++ b/src/host/local_session_host.ts
@@ -495,6 +495,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
   private readonly timelineExtras: SessionProtocolTimelineItem[] = [];
   private readonly tools = new Map<string, SessionProtocolToolRun>();
   private readonly agents = new Map<string, SessionProtocolAgentRun>();
+  private readonly agentCostTotals = new Map<string, number>();
   private readonly facets = new Map<string, SessionProtocolFacet>();
   private readonly deltaListeners = new Set<(delta: SessionProtocolDeltaMessage) => void>();
   private readonly ephemeralListeners = new Set<
@@ -828,6 +829,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
       ...(options.guidance !== undefined ? { guidance: options.guidance } : {}),
     });
 
+    await this.runtimeEventQueue;
     this.reconcileProjections();
     const snapshot = await this.commitSnapshot();
     this.emitSnapshotReset("maintenance", snapshot);
@@ -869,6 +871,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
       throw new Error("rewind failed");
     }
 
+    await this.runtimeEventQueue;
     this.reconcileProjections();
     const snapshot = await this.commitSnapshot();
     this.emitSnapshotReset("maintenance", snapshot);
@@ -1069,10 +1072,13 @@ class LocalHostedSessionHandle implements LocalHostedSession {
     for (const [id, agent] of this.agents) {
       if (!messageIds.has(agent.originMessageId)) {
         this.agents.delete(id);
+        this.agentCostTotals.delete(id);
       }
     }
 
-    const timelineExtraIds = new Set(this.timelineExtras.map((item) => item.id));
+    const operationIds = new Set(
+      this.timelineExtras.filter((item) => item.type === "operation").map((item) => item.id),
+    );
     const prunedByToolId = new Map(
       prunedToolResults.map((result) => [result.toolCallId, result.content]),
     );
@@ -1082,7 +1088,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
         (facet.subject.type === "message" && messageIds.has(facet.subject.id)) ||
         (facet.subject.type === "tool" && this.tools.has(facet.subject.id)) ||
         (facet.subject.type === "agent" && this.agents.has(facet.subject.id)) ||
-        (facet.subject.type === "operation" && timelineExtraIds.has(facet.subject.id));
+        (facet.subject.type === "operation" && operationIds.has(facet.subject.id));
       if (!subjectExists) {
         this.facets.delete(id);
         continue;
@@ -1228,8 +1234,10 @@ class LocalHostedSessionHandle implements LocalHostedSession {
       this.tools.set(id, structuredClone(tool));
     }
     this.agents.clear();
+    this.agentCostTotals.clear();
     for (const [id, agent] of Object.entries(snapshot.agents)) {
       this.agents.set(id, structuredClone(agent));
+      this.agentCostTotals.set(id, agent.costTotal);
     }
     this.costTotal = snapshot.costTotal;
     this.facets.clear();
@@ -1476,6 +1484,11 @@ class LocalHostedSessionHandle implements LocalHostedSession {
 
   private async recordToolUiEvent(event: ToolUiEvent): Promise<void> {
     const toolCallId = event.toolCallId;
+    const existingTool = this.tools.get(toolCallId);
+    if (!existingTool) {
+      return;
+    }
+
     const facetId = `tool-ui-${toolCallId}`;
     const existing = this.facets.get(facetId);
     const events = Array.isArray(existing?.data.events) ? existing.data.events : [];
@@ -1488,19 +1501,11 @@ class LocalHostedSessionHandle implements LocalHostedSession {
     };
     this.facets.set(facet.id, facet);
 
-    const existingTool = this.tools.get(toolCallId);
-    const toolChange = existingTool
-      ? {
-          type: "tool.set" as const,
-          tool: this.updateToolRunFromUiEvent(existingTool, event),
-        }
-      : undefined;
-    if (toolChange) {
-      this.tools.set(toolChange.tool.id, toolChange.tool);
-    }
+    const tool = this.updateToolRunFromUiEvent(existingTool, event);
+    this.tools.set(tool.id, tool);
 
     await this.emitPatch("tool-run", [
-      ...(toolChange ? [toolChange] : []),
+      { type: "tool.set", tool },
       { type: "facet.set", facet: structuredClone(facet) },
     ]);
   }
@@ -1540,7 +1545,12 @@ class LocalHostedSessionHandle implements LocalHostedSession {
     if (!agent) {
       return;
     }
-    this.costTotal += Math.max(0, agent.costTotal - (existing?.costTotal ?? 0));
+    const previousCost = this.agentCostTotals.get(agent.id) ?? 0;
+    this.costTotal += Math.max(0, agent.costTotal - previousCost);
+    this.agentCostTotals.set(agent.id, agent.costTotal);
+    if (!this.session.rawHistoryEntries.some((entry) => entry.id === originHistoryEntryId)) {
+      return;
+    }
     this.agents.set(agent.id, agent);
     await this.emitPatch("agent-run", [
       { type: "cost.set", costTotal: this.costTotal },

--- a/src/host/local_session_host.ts
+++ b/src/host/local_session_host.ts
@@ -830,7 +830,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
     });
 
     await this.runtimeEventQueue;
-    this.reconcileProjections({ agentFallbackOriginMessageId: result.summaryHistoryEntryId });
+    this.reconcileProjections();
     const snapshot = await this.commitSnapshot();
     this.emitSnapshotReset("maintenance", snapshot);
     return {
@@ -872,7 +872,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
     }
 
     await this.runtimeEventQueue;
-    this.reconcileProjections();
+    this.reconcileProjections({ removeMissingAgents: true });
     const snapshot = await this.commitSnapshot();
     this.emitSnapshotReset("maintenance", snapshot);
     return {
@@ -1058,7 +1058,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
   private reconcileProjections(
     options: {
       prunedToolResults?: readonly { toolCallId: string; content: string }[];
-      agentFallbackOriginMessageId?: string;
+      removeMissingAgents?: boolean;
     } = {},
   ): void {
     const messageIds = new Set(this.session.rawHistoryEntries.map((entry) => entry.id));
@@ -1072,18 +1072,12 @@ class LocalHostedSessionHandle implements LocalHostedSession {
         this.tools.delete(id);
       }
     }
-    for (const [id, agent] of this.agents) {
-      if (messageIds.has(agent.originMessageId)) {
-        continue;
-      }
-      if (options.agentFallbackOriginMessageId !== undefined) {
-        this.agents.set(id, {
-          ...agent,
-          originMessageId: options.agentFallbackOriginMessageId,
-        });
-      } else {
-        this.agents.delete(id);
-        this.agentCostTotals.delete(id);
+    if (options.removeMissingAgents) {
+      for (const id of this.agents.keys()) {
+        if (!this.session.hasSubagent(id)) {
+          this.agents.delete(id);
+          this.agentCostTotals.delete(id);
+        }
       }
     }
 
@@ -1477,18 +1471,14 @@ class LocalHostedSessionHandle implements LocalHostedSession {
       }
       case "compaction_end":
         this.clearRunningAutoCompactionOperations();
-        this.reconcileProjections(
-          event.outcome === "compacted"
-            ? { agentFallbackOriginMessageId: event.result.summaryHistoryEntryId }
-            : {},
-        );
+        this.reconcileProjections();
         await this.emitSnapshotReset("maintenance", await this.commitSnapshot());
         return;
       case "tool_ui":
         await this.recordToolUiEvent(event.uiEvent);
         return;
       case "subagent_ui":
-        await this.recordSubagentUiEvent(event.event, event.originHistoryEntryId);
+        await this.recordSubagentUiEvent(event.event);
         return;
     }
   }
@@ -1551,19 +1541,16 @@ class LocalHostedSessionHandle implements LocalHostedSession {
     return next;
   }
 
-  private async recordSubagentUiEvent(
-    event: SubagentUiEvent,
-    originHistoryEntryId: string,
-  ): Promise<void> {
+  private async recordSubagentUiEvent(event: SubagentUiEvent): Promise<void> {
     const existing = "id" in event ? this.agents.get(event.id) : this.agents.get(event.state.id);
-    const agent = agentRunFromSubagentEvent(event, originHistoryEntryId, existing);
+    const agent = agentRunFromSubagentEvent(event, existing);
     if (!agent) {
       return;
     }
     const previousCost = this.agentCostTotals.get(agent.id) ?? 0;
     this.costTotal += Math.max(0, agent.costTotal - previousCost);
     this.agentCostTotals.set(agent.id, agent.costTotal);
-    if (!this.session.rawHistoryEntries.some((entry) => entry.id === originHistoryEntryId)) {
+    if (!this.session.hasSubagent(agent.id)) {
       return;
     }
     this.agents.set(agent.id, agent);
@@ -1969,7 +1956,6 @@ function createInterruptedAssistantMessageFromModelSnapshot(
 
 function agentRunFromSubagentEvent(
   event: SubagentUiEvent,
-  originHistoryEntryId: string,
   existing?: SessionProtocolAgentRun,
 ): SessionProtocolAgentRun | undefined {
   const state =
@@ -2007,7 +1993,6 @@ function agentRunFromSubagentEvent(
           : state.status === "aborted"
             ? "cancelled"
             : "running",
-    originMessageId: originHistoryEntryId,
     ...(state.modelLabel !== undefined ? { modelLabel: state.modelLabel } : {}),
     costTotal: state.costTotal,
     turns: state.turns,

--- a/src/host/local_session_host.ts
+++ b/src/host/local_session_host.ts
@@ -828,6 +828,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
       ...(options.guidance !== undefined ? { guidance: options.guidance } : {}),
     });
 
+    this.reconcileProjections();
     const snapshot = await this.commitSnapshot();
     this.emitSnapshotReset("maintenance", snapshot);
     return {
@@ -847,6 +848,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
       ...(options.guidance !== undefined ? { guidance: options.guidance } : {}),
     });
 
+    this.reconcileProjections(result.prunedToolResults);
     const snapshot = await this.commitSnapshot();
     this.emitSnapshotReset("maintenance", snapshot);
     return {
@@ -867,6 +869,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
       throw new Error("rewind failed");
     }
 
+    this.reconcileProjections();
     const snapshot = await this.commitSnapshot();
     this.emitSnapshotReset("maintenance", snapshot);
     return {
@@ -1047,6 +1050,57 @@ class LocalHostedSessionHandle implements LocalHostedSession {
       this.committedSnapshot = cloneSessionProtocolSnapshot(snapshot);
     }
     return this.committedSnapshot;
+  }
+
+  private reconcileProjections(
+    prunedToolResults: readonly { toolCallId: string; content: string }[] = [],
+  ): void {
+    const messageIds = new Set(this.session.rawHistoryEntries.map((entry) => entry.id));
+    messageIds.add("system");
+
+    for (const [id, tool] of this.tools) {
+      if (
+        !messageIds.has(tool.call.messageId) ||
+        (tool.resultMessageId !== undefined && !messageIds.has(tool.resultMessageId))
+      ) {
+        this.tools.delete(id);
+      }
+    }
+    for (const [id, agent] of this.agents) {
+      if (!messageIds.has(agent.originMessageId)) {
+        this.agents.delete(id);
+      }
+    }
+
+    const prunedByToolId = new Map(
+      prunedToolResults.map((result) => [result.toolCallId, result.content]),
+    );
+    const timelineIds = new Set(this.timelineExtras.map((item) => item.id));
+    for (const [id, facet] of this.facets) {
+      const subjectExists =
+        facet.subject.type === "session" ||
+        (facet.subject.type === "message" && messageIds.has(facet.subject.id)) ||
+        (facet.subject.type === "tool" && this.tools.has(facet.subject.id)) ||
+        (facet.subject.type === "agent" && this.agents.has(facet.subject.id)) ||
+        (facet.subject.type === "operation" && timelineIds.has(facet.subject.id));
+      if (!subjectExists) {
+        this.facets.delete(id);
+        continue;
+      }
+
+      if (facet.subject.type === "tool") {
+        const toolCallId = facet.subject.id;
+        const content = prunedByToolId.get(toolCallId);
+        if (content !== undefined && facet.kind === "tau.tool-ui-events") {
+          this.facets.set(id, {
+            ...facet,
+            data: {
+              events: [{ type: "tool_pruned", toolCallId, content }],
+            },
+          });
+        }
+      }
+    }
   }
 
   private buildSnapshotDraft(): Omit<SessionProtocolSnapshot, "revision"> {
@@ -1404,6 +1458,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
       }
       case "compaction_end":
         this.clearRunningAutoCompactionOperations();
+        this.reconcileProjections();
         await this.emitSnapshotReset("maintenance", await this.commitSnapshot());
         return;
       case "tool_ui":

--- a/src/host/local_session_host.ts
+++ b/src/host/local_session_host.ts
@@ -1072,7 +1072,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
       }
     }
 
-    this.timelineExtras.length = 0;
+    const timelineExtraIds = new Set(this.timelineExtras.map((item) => item.id));
     const prunedByToolId = new Map(
       prunedToolResults.map((result) => [result.toolCallId, result.content]),
     );
@@ -1081,7 +1081,8 @@ class LocalHostedSessionHandle implements LocalHostedSession {
         facet.subject.type === "session" ||
         (facet.subject.type === "message" && messageIds.has(facet.subject.id)) ||
         (facet.subject.type === "tool" && this.tools.has(facet.subject.id)) ||
-        (facet.subject.type === "agent" && this.agents.has(facet.subject.id));
+        (facet.subject.type === "agent" && this.agents.has(facet.subject.id)) ||
+        (facet.subject.type === "operation" && timelineExtraIds.has(facet.subject.id));
       if (!subjectExists) {
         this.facets.delete(id);
         continue;

--- a/src/host/local_session_host.ts
+++ b/src/host/local_session_host.ts
@@ -830,7 +830,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
     });
 
     await this.runtimeEventQueue;
-    this.reconcileProjections();
+    this.reconcileProjections({ agentFallbackOriginMessageId: result.summaryHistoryEntryId });
     const snapshot = await this.commitSnapshot();
     this.emitSnapshotReset("maintenance", snapshot);
     return {
@@ -850,7 +850,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
       ...(options.guidance !== undefined ? { guidance: options.guidance } : {}),
     });
 
-    this.reconcileProjections(result.prunedToolResults);
+    this.reconcileProjections({ prunedToolResults: result.prunedToolResults });
     const snapshot = await this.commitSnapshot();
     this.emitSnapshotReset("maintenance", snapshot);
     return {
@@ -1056,7 +1056,10 @@ class LocalHostedSessionHandle implements LocalHostedSession {
   }
 
   private reconcileProjections(
-    prunedToolResults: readonly { toolCallId: string; content: string }[] = [],
+    options: {
+      prunedToolResults?: readonly { toolCallId: string; content: string }[];
+      agentFallbackOriginMessageId?: string;
+    } = {},
   ): void {
     const messageIds = new Set(this.session.rawHistoryEntries.map((entry) => entry.id));
     messageIds.add("system");
@@ -1070,7 +1073,15 @@ class LocalHostedSessionHandle implements LocalHostedSession {
       }
     }
     for (const [id, agent] of this.agents) {
-      if (!messageIds.has(agent.originMessageId)) {
+      if (messageIds.has(agent.originMessageId)) {
+        continue;
+      }
+      if (options.agentFallbackOriginMessageId !== undefined) {
+        this.agents.set(id, {
+          ...agent,
+          originMessageId: options.agentFallbackOriginMessageId,
+        });
+      } else {
         this.agents.delete(id);
         this.agentCostTotals.delete(id);
       }
@@ -1080,7 +1091,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
       this.timelineExtras.filter((item) => item.type === "operation").map((item) => item.id),
     );
     const prunedByToolId = new Map(
-      prunedToolResults.map((result) => [result.toolCallId, result.content]),
+      (options.prunedToolResults ?? []).map((result) => [result.toolCallId, result.content]),
     );
     for (const [id, facet] of this.facets) {
       const subjectExists =
@@ -1466,7 +1477,11 @@ class LocalHostedSessionHandle implements LocalHostedSession {
       }
       case "compaction_end":
         this.clearRunningAutoCompactionOperations();
-        this.reconcileProjections();
+        this.reconcileProjections(
+          event.outcome === "compacted"
+            ? { agentFallbackOriginMessageId: event.result.summaryHistoryEntryId }
+            : {},
+        );
         await this.emitSnapshotReset("maintenance", await this.commitSnapshot());
         return;
       case "tool_ui":

--- a/src/host/local_session_host.ts
+++ b/src/host/local_session_host.ts
@@ -1072,17 +1072,16 @@ class LocalHostedSessionHandle implements LocalHostedSession {
       }
     }
 
+    this.timelineExtras.length = 0;
     const prunedByToolId = new Map(
       prunedToolResults.map((result) => [result.toolCallId, result.content]),
     );
-    const timelineIds = new Set(this.timelineExtras.map((item) => item.id));
     for (const [id, facet] of this.facets) {
       const subjectExists =
         facet.subject.type === "session" ||
         (facet.subject.type === "message" && messageIds.has(facet.subject.id)) ||
         (facet.subject.type === "tool" && this.tools.has(facet.subject.id)) ||
-        (facet.subject.type === "agent" && this.agents.has(facet.subject.id)) ||
-        (facet.subject.type === "operation" && timelineIds.has(facet.subject.id));
+        (facet.subject.type === "agent" && this.agents.has(facet.subject.id));
       if (!subjectExists) {
         this.facets.delete(id);
         continue;

--- a/src/protocol/session_protocol.ts
+++ b/src/protocol/session_protocol.ts
@@ -532,7 +532,6 @@ export type SessionProtocolAgentRun = {
   name: string;
   title: string;
   status: "running" | "succeeded" | "failed" | "cancelled";
-  originMessageId: string;
   modelLabel?: string;
   costTotal: number;
   turns: number;
@@ -1511,7 +1510,6 @@ const sessionProtocolAgentRunSchema = z
     name: nonEmptyStringSchema,
     title: nonEmptyStringSchema,
     status: z.enum(["running", "succeeded", "failed", "cancelled"]),
-    originMessageId: nonEmptyStringSchema,
     modelLabel: z.string().optional(),
     costTotal: z.number().finite(),
     turns: z.number().finite(),
@@ -1672,20 +1670,6 @@ const sessionProtocolSnapshotSchema = z
           code: "custom",
           path: ["agents", id],
           message: `agent map key '${id}' does not match embedded id '${agent.id}'`,
-        });
-      }
-      const originMessage = messagesById.get(agent.originMessageId);
-      if (originMessage === undefined) {
-        ctx.addIssue({
-          code: "custom",
-          path: ["agents", id, "originMessageId"],
-          message: `agent '${id}' references unknown origin message '${agent.originMessageId}'`,
-        });
-      } else if (originMessage.message.role !== "user") {
-        ctx.addIssue({
-          code: "custom",
-          path: ["agents", id, "originMessageId"],
-          message: `agent '${id}' origin does not reference a user message`,
         });
       }
     }

--- a/src/protocol/session_protocol.ts
+++ b/src/protocol/session_protocol.ts
@@ -1562,19 +1562,20 @@ const sessionProtocolSnapshotSchema = z
   })
   .strip()
   .superRefine((snapshot, ctx) => {
-    const messageIds = new Set<string>();
+    const messagesById = new Map<string, SessionProtocolMessage>();
     for (const message of snapshot.messages) {
-      if (messageIds.has(message.id)) {
+      if (messagesById.has(message.id)) {
         ctx.addIssue({
           code: "custom",
           path: ["messages"],
           message: `duplicate message id '${message.id}'`,
         });
       }
-      messageIds.add(message.id);
+      messagesById.set(message.id, message);
     }
 
     const timelineIds = new Set<string>();
+    const operationIds = new Set<string>();
     for (const item of snapshot.timeline) {
       if (timelineIds.has(item.id)) {
         ctx.addIssue({
@@ -1584,12 +1585,15 @@ const sessionProtocolSnapshotSchema = z
         });
       }
       timelineIds.add(item.id);
-      if (item.type === "message" && !messageIds.has(item.messageId)) {
+      if (item.type === "message" && !messagesById.has(item.messageId)) {
         ctx.addIssue({
           code: "custom",
           path: ["timeline"],
           message: `timeline message item '${item.id}' references unknown message '${item.messageId}'`,
         });
+      }
+      if (item.type === "operation") {
+        operationIds.add(item.id);
       }
     }
 
@@ -1601,19 +1605,54 @@ const sessionProtocolSnapshotSchema = z
           message: `tool map key '${id}' does not match embedded identity`,
         });
       }
-      if (!messageIds.has(tool.call.messageId)) {
+      const callMessage = messagesById.get(tool.call.messageId);
+      if (callMessage === undefined) {
         ctx.addIssue({
           code: "custom",
           path: ["tools", id, "call", "messageId"],
           message: `tool '${id}' references unknown call message '${tool.call.messageId}'`,
         });
+      } else {
+        const callContent =
+          callMessage.message.role === "assistant"
+            ? callMessage.message.content[tool.call.contentIndex]
+            : undefined;
+        if (
+          typeof callContent !== "object" ||
+          callContent === null ||
+          !("type" in callContent) ||
+          callContent.type !== "toolCall" ||
+          !("id" in callContent) ||
+          callContent.id !== tool.toolCallId ||
+          !("name" in callContent) ||
+          callContent.name !== tool.toolName
+        ) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["tools", id, "call"],
+            message: `tool '${id}' does not match its call message content`,
+          });
+        }
       }
-      if (tool.resultMessageId !== undefined && !messageIds.has(tool.resultMessageId)) {
-        ctx.addIssue({
-          code: "custom",
-          path: ["tools", id, "resultMessageId"],
-          message: `tool '${id}' references unknown result message '${tool.resultMessageId}'`,
-        });
+      if (tool.resultMessageId !== undefined) {
+        const resultMessage = messagesById.get(tool.resultMessageId);
+        if (resultMessage === undefined) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["tools", id, "resultMessageId"],
+            message: `tool '${id}' references unknown result message '${tool.resultMessageId}'`,
+          });
+        } else if (
+          resultMessage.message.role !== "toolResult" ||
+          resultMessage.message.toolCallId !== tool.toolCallId ||
+          resultMessage.message.toolName !== tool.toolName
+        ) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["tools", id, "resultMessageId"],
+            message: `tool '${id}' does not match its result message`,
+          });
+        }
       }
       for (const facetId of tool.facetIds) {
         const facet = snapshot.facets[facetId];
@@ -1635,11 +1674,18 @@ const sessionProtocolSnapshotSchema = z
           message: `agent map key '${id}' does not match embedded id '${agent.id}'`,
         });
       }
-      if (!messageIds.has(agent.originMessageId)) {
+      const originMessage = messagesById.get(agent.originMessageId);
+      if (originMessage === undefined) {
         ctx.addIssue({
           code: "custom",
           path: ["agents", id, "originMessageId"],
           message: `agent '${id}' references unknown origin message '${agent.originMessageId}'`,
+        });
+      } else if (originMessage.message.role !== "user") {
+        ctx.addIssue({
+          code: "custom",
+          path: ["agents", id, "originMessageId"],
+          message: `agent '${id}' origin does not reference a user message`,
         });
       }
     }
@@ -1654,10 +1700,10 @@ const sessionProtocolSnapshotSchema = z
       }
       const subjectExists =
         facet.subject.type === "session" ||
-        (facet.subject.type === "message" && messageIds.has(facet.subject.id)) ||
+        (facet.subject.type === "message" && messagesById.has(facet.subject.id)) ||
         (facet.subject.type === "tool" && snapshot.tools[facet.subject.id] !== undefined) ||
         (facet.subject.type === "agent" && snapshot.agents[facet.subject.id] !== undefined) ||
-        (facet.subject.type === "operation" && timelineIds.has(facet.subject.id));
+        (facet.subject.type === "operation" && operationIds.has(facet.subject.id));
       if (!subjectExists) {
         ctx.addIssue({
           code: "custom",

--- a/src/protocol/session_protocol.ts
+++ b/src/protocol/session_protocol.ts
@@ -1592,6 +1592,80 @@ const sessionProtocolSnapshotSchema = z
         });
       }
     }
+
+    for (const [id, tool] of Object.entries(snapshot.tools)) {
+      if (id !== tool.id || id !== tool.toolCallId) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["tools", id],
+          message: `tool map key '${id}' does not match embedded identity`,
+        });
+      }
+      if (!messageIds.has(tool.call.messageId)) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["tools", id, "call", "messageId"],
+          message: `tool '${id}' references unknown call message '${tool.call.messageId}'`,
+        });
+      }
+      if (tool.resultMessageId !== undefined && !messageIds.has(tool.resultMessageId)) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["tools", id, "resultMessageId"],
+          message: `tool '${id}' references unknown result message '${tool.resultMessageId}'`,
+        });
+      }
+      for (const facetId of tool.facetIds) {
+        const facet = snapshot.facets[facetId];
+        if (facet === undefined || facet.subject.type !== "tool" || facet.subject.id !== id) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["tools", id, "facetIds"],
+            message: `tool '${id}' references invalid facet '${facetId}'`,
+          });
+        }
+      }
+    }
+
+    for (const [id, agent] of Object.entries(snapshot.agents)) {
+      if (id !== agent.id) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["agents", id],
+          message: `agent map key '${id}' does not match embedded id '${agent.id}'`,
+        });
+      }
+      if (!messageIds.has(agent.originMessageId)) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["agents", id, "originMessageId"],
+          message: `agent '${id}' references unknown origin message '${agent.originMessageId}'`,
+        });
+      }
+    }
+
+    for (const [id, facet] of Object.entries(snapshot.facets)) {
+      if (id !== facet.id) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["facets", id],
+          message: `facet map key '${id}' does not match embedded id '${facet.id}'`,
+        });
+      }
+      const subjectExists =
+        facet.subject.type === "session" ||
+        (facet.subject.type === "message" && messageIds.has(facet.subject.id)) ||
+        (facet.subject.type === "tool" && snapshot.tools[facet.subject.id] !== undefined) ||
+        (facet.subject.type === "agent" && snapshot.agents[facet.subject.id] !== undefined) ||
+        (facet.subject.type === "operation" && timelineIds.has(facet.subject.id));
+      if (!subjectExists) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["facets", id, "subject"],
+          message: `facet '${id}' references unknown ${facet.subject.type} subject`,
+        });
+      }
+    }
   }) as z.ZodType<SessionProtocolSnapshot>;
 
 const sessionProtocolDeltaReasonSchema = z.enum([

--- a/test/core_runtime.test.js
+++ b/test/core_runtime.test.js
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { fauxAssistantMessage, fauxProvider, fauxToolCall } from "@earendil-works/pi-ai";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createCommandRegistry } from "../dist/core/commands/index.js";
 import { safeParseCoreEventEnvelope } from "../dist/core/events/parser.js";
 import { personas } from "../dist/core/personas.js";
@@ -286,6 +286,24 @@ describe("core session rewind APIs", () => {
     expect(remaining[1]?.role).toBe("assistant");
 
     expect(session.rewindToHistoryEntryId("missing-id")).toBeUndefined();
+  });
+
+  it("rejects rewind while a subagent is running", () => {
+    const session = new CoreSession({
+      persona: personas[0],
+      systemPrompt: "system",
+      subagentPrompts: {},
+      toolRegistry: new ToolRegistry([]),
+    });
+    const historyEntryId = session.addUserText("keep this turn");
+    session.addMessage(fauxAssistantMessage("working"));
+    const before = session.rawHistoryEntries;
+    vi.spyOn(session.engine.subagentControlPlane, "getActiveCount").mockReturnValue(1);
+
+    expect(() => session.rewindToHistoryEntryId(historyEntryId)).toThrow(
+      "cannot rewind while subagents are running",
+    );
+    expect(session.rawHistoryEntries).toEqual(before);
   });
 
   it("keeps tau metadata in raw history and strips it from visible history", () => {

--- a/test/core_runtime.test.js
+++ b/test/core_runtime.test.js
@@ -433,10 +433,22 @@ describe("core session rewind APIs", () => {
       const sessionId = session.sessionId;
       session.addUserText("remember this");
       session.addMessage(fauxAssistantMessage("remembered"));
+      vi.spyOn(session.engine.subagentControlPlane, "listSnapshots").mockReturnValue([
+        {
+          id: "agent-1",
+          name: "default",
+          title: "research",
+          status: "running",
+          abortRequested: false,
+        },
+      ]);
 
       await session.compact({ mode: "only-summary" });
 
       expect(session.sessionId).toBe(sessionId);
+      expect(stripTauUserMetadata(session.rawHistory[0].content[0].text)).toContain(
+        "<active-subagents>\n- agent-1: research",
+      );
     } finally {
       unregisterFauxProvider();
     }
@@ -512,6 +524,15 @@ describe("core session rewind APIs", () => {
         },
       });
 
+      vi.spyOn(session.engine.subagentControlPlane, "listSnapshots").mockReturnValue([
+        {
+          id: "agent-1",
+          name: "default",
+          title: "research",
+          status: "running",
+          abortRequested: false,
+        },
+      ]);
       session.addUserText("old request", { historyEntryId: "old-request" });
       session.addMessage(assistantMessageWithUsage("old answer", 1000));
       session.addUserText(`middle request ${"x".repeat(6000)}`, {
@@ -527,6 +548,9 @@ describe("core session rewind APIs", () => {
       }
 
       expect(session.sessionId).toBe(sessionId);
+      expect(stripTauUserMetadata(session.rawHistory[0].content[0].text)).toContain(
+        "<active-subagents>\n- agent-1: research",
+      );
 
       const compactionEnd = events.find(
         (event) => event.type === "compaction_end" && event.outcome === "compacted",
@@ -2162,7 +2186,6 @@ describe("compaction context message", () => {
     const continuation = buildAutoCompactionContinuationMessage({
       cutType: "turn-boundary",
       now: 2,
-      subagentStatus: "- agent-1: check tests (name: default, status: running)",
     });
     const entries = historyEntries([
       userMessage(previousSummaryText),
@@ -2196,8 +2219,6 @@ describe("compaction context message", () => {
       cutType: "turn-boundary",
       retainedMessageCount: 2,
     });
-    expect(stripTauUserMetadata(continuation.content[0].text)).toContain("<active-subagents>");
-    expect(stripTauUserMetadata(continuation.content[0].text)).toContain("agent-1");
     expect(hasAutoCompactionContinuationMetadata(continuation)).toBe(true);
   });
 });

--- a/test/core_runtime.test.js
+++ b/test/core_runtime.test.js
@@ -424,6 +424,39 @@ describe("core session rewind APIs", () => {
     }
   });
 
+  it("leaves session history unchanged when pruning fails", async () => {
+    const session = new CoreSession({
+      persona: personas[0],
+      systemPrompt: "system",
+      subagentPrompts: {},
+      toolRegistry: new ToolRegistry([]),
+    });
+    session.addMessage(
+      fauxAssistantMessage([
+        fauxToolCall(
+          TOOL_NAME_EDIT,
+          { path: "src/a.ts", oldText: "before", newText: "after" },
+          { id: "edit-valid" },
+        ),
+      ]),
+      { historyEntryId: "valid-edit" },
+    );
+    session.addMessage(
+      {
+        role: "assistant",
+        content: "malformed",
+        timestamp: 2,
+      },
+      { historyEntryId: "malformed-assistant" },
+    );
+    const before = session.rawHistoryEntries;
+
+    await expect(session.pruneToolResults({ strategy: "earliest", fraction: 1 })).rejects.toThrow(
+      "invalid assistant message content while pruning edit tool calls",
+    );
+    expect(session.rawHistoryEntries).toEqual(before);
+  });
+
   it("clamps auto-compaction retention to the threshold budget", async () => {
     const faux = fauxProvider({
       provider: "faux-auto-clamp",

--- a/test/local_session_host.test.js
+++ b/test/local_session_host.test.js
@@ -581,9 +581,10 @@ describe("LocalSessionHost", () => {
     );
   });
 
-  it("accounts for queued subagent progress and rebases the projection after compaction", async () => {
+  it("accounts for queued subagent progress and preserves the projection after compaction", async () => {
     const host = createHost(new MemorySessionStore());
     const hostedSession = await host.createSession(localCreateInput);
+    vi.spyOn(hostedSession.session, "hasSubagent").mockReturnValue(true);
     hostedSession.session.addUserText("old request", { historyEntryId: "old-user" });
     await hostedSession.snapshot();
 
@@ -597,7 +598,6 @@ describe("LocalSessionHost", () => {
     };
     await hostedSession.enqueueRuntimeEvent({
       type: "subagent_ui",
-      originHistoryEntryId: "old-user",
       event: {
         type: "subagent_spawned",
         state: {
@@ -630,7 +630,6 @@ describe("LocalSessionHost", () => {
     });
     await hostedSession.enqueueRuntimeEvent({
       type: "subagent_ui",
-      originHistoryEntryId: "old-user",
       event: {
         type: "subagent_progress",
         id: "agent-1",
@@ -658,7 +657,7 @@ describe("LocalSessionHost", () => {
       expect.objectContaining({
         costTotal: 0.5,
         agents: {
-          "agent-1": expect.objectContaining({ originMessageId: "compaction-summary" }),
+          "agent-1": expect.objectContaining({ status: "running" }),
         },
       }),
     );

--- a/test/local_session_host.test.js
+++ b/test/local_session_host.test.js
@@ -581,6 +581,84 @@ describe("LocalSessionHost", () => {
     );
   });
 
+  it("accounts for queued subagent progress without restoring a removed projection", async () => {
+    const host = createHost(new MemorySessionStore());
+    const hostedSession = await host.createSession(localCreateInput);
+    hostedSession.session.addUserText("old request", { historyEntryId: "old-user" });
+    await hostedSession.snapshot();
+
+    const usage = {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      contextWindowUsageTokens: 0,
+      contextWindow: 1000,
+    };
+    await hostedSession.enqueueRuntimeEvent({
+      type: "subagent_ui",
+      originHistoryEntryId: "old-user",
+      event: {
+        type: "subagent_spawned",
+        state: {
+          id: "agent-1",
+          name: "default",
+          title: "research",
+          status: "running",
+          costTotal: 0,
+          turns: 0,
+          toolCalls: 0,
+          usage,
+          startedAt: 1,
+          abortRequested: false,
+        },
+      },
+    });
+
+    hostedSession.session.restoreState({
+      sessionId: hostedSession.session.sessionId,
+      historyEntries: [
+        {
+          id: "compaction-summary",
+          message: {
+            role: "user",
+            content: [{ type: "text", text: "compacted summary" }],
+            timestamp: 2,
+          },
+        },
+      ],
+    });
+    await hostedSession.enqueueRuntimeEvent({
+      type: "subagent_ui",
+      originHistoryEntryId: "old-user",
+      event: {
+        type: "subagent_progress",
+        id: "agent-1",
+        text: "late progress",
+        costTotal: 0.5,
+        turns: 1,
+        toolCalls: 0,
+        usage,
+      },
+    });
+    await hostedSession.enqueueRuntimeEvent({
+      type: "compaction_end",
+      reason: "threshold",
+      outcome: "compacted",
+      result: {
+        summaryHistoryEntryId: "compaction-summary",
+        continuationHistoryEntryId: "compaction-continuation",
+        compactionMessage: "compacted summary",
+        cutType: "turn-boundary",
+        retainedMessageCount: 1,
+      },
+    });
+
+    await expect(hostedSession.snapshot()).resolves.toEqual(
+      expect.objectContaining({ costTotal: 0.5, agents: {} }),
+    );
+  });
+
   it("preserves cumulative session cost when compaction replaces message history", async () => {
     const store = new MemorySessionStore();
     const host = createHost(store);

--- a/test/local_session_host.test.js
+++ b/test/local_session_host.test.js
@@ -445,6 +445,17 @@ describe("LocalSessionHost", () => {
 
     const deltas = [];
     hostedSession.onDelta((delta) => deltas.push(delta));
+    hostedSession.session.addMessage(
+      assistantMessageWithToolCalls([
+        {
+          type: "toolCall",
+          id: "tool-a",
+          name: "bash",
+          arguments: { command: "echo a" },
+        },
+      ]),
+      { historyEntryId: "assistant-tools" },
+    );
 
     await Promise.all([
       hostedSession.enqueueRuntimeEvent({
@@ -713,6 +724,15 @@ describe("LocalSessionHost", () => {
       }),
     ]);
 
+    const finalMessage = assistantMessageWithToolCalls([toolCall]);
+    hostedSession.session.addMessage(finalMessage, {
+      historyEntryId: "assistant-streaming-tool",
+    });
+    await hostedSession.enqueueRuntimeEvent({
+      type: "assistant_final",
+      historyEntryId: "assistant-streaming-tool",
+      message: finalMessage,
+    });
     await hostedSession.enqueueRuntimeEvent({
       type: "tool_ui",
       uiEvent: {
@@ -728,9 +748,9 @@ describe("LocalSessionHost", () => {
       expect.arrayContaining([
         expect.objectContaining({
           id: "assistant-streaming-tool",
-          state: "draft",
+          state: "committed",
           message: expect.objectContaining({
-            content: [{ type: "text", text: "running a command" }, toolCall],
+            content: [toolCall],
           }),
         }),
       ]),

--- a/test/local_session_host.test.js
+++ b/test/local_session_host.test.js
@@ -581,7 +581,7 @@ describe("LocalSessionHost", () => {
     );
   });
 
-  it("accounts for queued subagent progress without restoring a removed projection", async () => {
+  it("accounts for queued subagent progress and rebases the projection after compaction", async () => {
     const host = createHost(new MemorySessionStore());
     const hostedSession = await host.createSession(localCreateInput);
     hostedSession.session.addUserText("old request", { historyEntryId: "old-user" });
@@ -655,7 +655,12 @@ describe("LocalSessionHost", () => {
     });
 
     await expect(hostedSession.snapshot()).resolves.toEqual(
-      expect.objectContaining({ costTotal: 0.5, agents: {} }),
+      expect.objectContaining({
+        costTotal: 0.5,
+        agents: {
+          "agent-1": expect.objectContaining({ originMessageId: "compaction-summary" }),
+        },
+      }),
     );
   });
 

--- a/test/local_session_host.test.js
+++ b/test/local_session_host.test.js
@@ -559,6 +559,28 @@ describe("LocalSessionHost", () => {
     );
   });
 
+  it("preserves timeline notices when rewinding history", async () => {
+    const host = createHost(new MemorySessionStore());
+    const hostedSession = await host.createSession(localCreateInput);
+    const historyEntryId = hostedSession.session.addUserText("rewind me");
+    await hostedSession.snapshot();
+
+    await hostedSession.enqueueRuntimeEvent({
+      type: "notice",
+      severity: "warn",
+      text: "keep this notice",
+    });
+    await hostedSession.rewindToHistoryEntryId(historyEntryId);
+
+    const snapshot = await hostedSession.snapshot();
+    expect(snapshot.timeline).toContainEqual(
+      expect.objectContaining({
+        type: "notice",
+        notice: expect.objectContaining({ text: "keep this notice" }),
+      }),
+    );
+  });
+
   it("preserves cumulative session cost when compaction replaces message history", async () => {
     const store = new MemorySessionStore();
     const host = createHost(store);

--- a/test/rpc_server.test.js
+++ b/test/rpc_server.test.js
@@ -39,7 +39,7 @@ function createNoticeDelta(sessionId, revision, text) {
   };
 }
 
-function createAgentDelta(sessionId, revision, event, originMessageId) {
+function createAgentDelta(sessionId, revision, event) {
   return {
     version: SESSION_PROTOCOL_VERSION,
     type: "session.delta",
@@ -57,7 +57,6 @@ function createAgentDelta(sessionId, revision, event, originMessageId) {
             name: "default",
             title: event.title ?? event.id,
             status: event.type === "finished" ? "succeeded" : "running",
-            originMessageId,
             costTotal: event.costTotal ?? 0,
             turns: event.turns ?? 0,
             toolCalls: event.toolCalls ?? 0,
@@ -305,10 +304,8 @@ function createHarness(options = {}) {
       emitNotice: (text, revision = historyEntries.length + 1) => {
         emitDelta(createNoticeDelta(sessionId, revision, text));
       },
-      emitSubagent: (event, originHistoryEntryId) => {
-        emitDelta(
-          createAgentDelta(sessionId, historyEntries.length + 1, event, originHistoryEntryId),
-        );
+      emitSubagent: (event) => {
+        emitDelta(createAgentDelta(sessionId, historyEntries.length + 1, event));
       },
     };
 
@@ -351,8 +348,7 @@ function createHarness(options = {}) {
     seededSession,
     releaseTurn: () => seededSession?.releaseTurn(),
     emitNotice: (text, revision) => seededSession?.emitNotice(text, revision),
-    emitSubagent: (event, originHistoryEntryId) =>
-      seededSession?.emitSubagent(event, originHistoryEntryId),
+    emitSubagent: (event) => seededSession?.emitSubagent(event),
     recoverSession: () => {
       if (!seededSession) {
         throw new Error("no seeded session to recover");
@@ -593,7 +589,7 @@ describe("rpc_server", () => {
           ),
       ),
     );
-    harness.emitSubagent({ type: "spawned", id: "agent-1", title: "research" }, "history-1");
+    harness.emitSubagent({ type: "spawned", id: "agent-1", title: "research" });
 
     await harness.server.handleLine(
       request("submit-2", "session.submit", {
@@ -1079,7 +1075,7 @@ describe("rpc_server", () => {
     const steeringEntry = harness.seededSession.session.historyEntries.find((entry) =>
       entry.message.content[0].text.includes("change direction"),
     );
-    harness.emitSubagent({ type: "spawned", id: "agent-2", title: "research" }, steeringEntry.id);
+    harness.emitSubagent({ type: "spawned", id: "agent-2", title: "research" });
     harness.releaseTurn();
     await Promise.all([steerOne, steerTwo]);
 
@@ -1292,7 +1288,7 @@ describe("rpc_server", () => {
     );
 
     await waitFor(() => harness.lines.some((line) => deltaHasNotice(line, "streaming")));
-    harness.emitSubagent({ type: "spawned", id: "agent-1", title: "research" }, "history-1");
+    harness.emitSubagent({ type: "spawned", id: "agent-1", title: "research" });
     harness.releaseTurn();
     await firstSubmit;
 
@@ -1306,25 +1302,22 @@ describe("rpc_server", () => {
     await waitFor(
       () => harness.lines.filter((line) => deltaHasNotice(line, "streaming")).length >= 2,
     );
-    harness.emitSubagent(
-      {
-        type: "subagent_progress",
-        id: "agent-1",
-        text: "still working",
-        costTotal: 0,
-        turns: 1,
-        toolCalls: 0,
-        usage: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          contextWindowUsageTokens: 0,
-          contextWindow: 200000,
-        },
+    harness.emitSubagent({
+      type: "subagent_progress",
+      id: "agent-1",
+      text: "still working",
+      costTotal: 0,
+      turns: 1,
+      toolCalls: 0,
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        contextWindowUsageTokens: 0,
+        contextWindow: 200000,
       },
-      "history-1",
-    );
+    });
 
     harness.releaseTurn();
     await secondSubmit;

--- a/test/session_chat_controller.test.js
+++ b/test/session_chat_controller.test.js
@@ -113,7 +113,6 @@ function createAgentRun(overrides = {}) {
     name: "default",
     title: "Inspect state",
     status: "running",
-    originMessageId: "assistant-1",
     costTotal: 0.01,
     turns: 1,
     toolCalls: 0,

--- a/test/session_protocol.test.js
+++ b/test/session_protocol.test.js
@@ -1486,6 +1486,149 @@ describe("session_protocol", () => {
     });
   });
 
+  it("rejects semantically mismatched snapshot projections", () => {
+    const messages = [
+      {
+        id: "system",
+        state: "committed",
+        modelVisible: true,
+        message: { role: "system", content: "system prompt", timestamp: 0 },
+      },
+      {
+        id: "user-1",
+        state: "committed",
+        modelVisible: true,
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "run it" }],
+          timestamp: 1,
+        },
+      },
+      {
+        id: "assistant-1",
+        state: "draft",
+        modelVisible: false,
+        message: {
+          role: "assistant",
+          content: [
+            { type: "toolCall", id: "tool-1", name: "bash", arguments: { command: "pwd" } },
+          ],
+          timestamp: 2,
+        },
+      },
+      {
+        id: "result-1",
+        state: "committed",
+        modelVisible: true,
+        message: {
+          role: "toolResult",
+          toolCallId: "tool-1",
+          toolName: "bash",
+          content: [{ type: "text", text: "/repo" }],
+          isError: false,
+          timestamp: 3,
+        },
+      },
+    ];
+    const tool = {
+      id: "tool-1",
+      toolCallId: "tool-1",
+      toolName: "bash",
+      call: { messageId: "assistant-1", contentIndex: 0 },
+      resultMessageId: "result-1",
+      status: "succeeded",
+      facetIds: [],
+    };
+    const agent = {
+      id: "agent-1",
+      name: "default",
+      title: "research",
+      status: "succeeded",
+      originMessageId: "user-1",
+      costTotal: 0,
+      turns: 1,
+      toolCalls: 0,
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        contextWindowUsageTokens: 0,
+        contextWindow: 1000,
+      },
+      startedAt: 1,
+      finishedAt: 2,
+      abortRequested: false,
+    };
+    const snapshot = createProtocolSnapshot({
+      messages,
+      timeline: [
+        { type: "notice", id: "notice-1", notice: { severity: "info", text: "hi", timestamp: 1 } },
+      ],
+      tools: { "tool-1": tool },
+      agents: { "agent-1": agent },
+    });
+
+    expect(
+      validateSessionProtocolResult("session.snapshot", {
+        ...snapshot,
+        tools: {
+          "tool-1": { ...tool, call: { messageId: "assistant-1", contentIndex: 1 } },
+        },
+      }),
+    ).toEqual({
+      ok: false,
+      error: expect.objectContaining({
+        message: expect.stringContaining("tool 'tool-1' does not match its call message content"),
+      }),
+    });
+    expect(
+      validateSessionProtocolResult("session.snapshot", {
+        ...snapshot,
+        tools: { "tool-1": { ...tool, resultMessageId: "user-1" } },
+      }),
+    ).toEqual({
+      ok: false,
+      error: expect.objectContaining({
+        message: expect.stringContaining("tool 'tool-1' does not match its result message"),
+      }),
+    });
+    expect(
+      validateSessionProtocolResult("session.snapshot", {
+        ...snapshot,
+        agents: { "agent-1": { ...agent, originMessageId: "assistant-1" } },
+      }),
+    ).toEqual({
+      ok: false,
+      error: expect.objectContaining({
+        message: expect.stringContaining(
+          "agent 'agent-1' origin does not reference a user message",
+        ),
+      }),
+    });
+    expect(
+      validateSessionProtocolResult("session.snapshot", {
+        ...snapshot,
+        facets: {
+          "operation-facet": {
+            id: "operation-facet",
+            subject: { type: "operation", id: "notice-1" },
+            kind: "test",
+            version: 1,
+            data: {},
+          },
+        },
+      }),
+    ).toEqual({
+      ok: false,
+      error: expect.objectContaining({
+        message: expect.stringContaining(
+          "facet 'operation-facet' references unknown operation subject",
+        ),
+      }),
+    });
+  });
+
   it("parses and constructs pending user message state", () => {
     const message = createSessionProtocolPendingUserMessagesMessage({
       sessionId: "session-1",

--- a/test/session_protocol.test.js
+++ b/test/session_protocol.test.js
@@ -1544,7 +1544,6 @@ describe("session_protocol", () => {
       name: "default",
       title: "research",
       status: "succeeded",
-      originMessageId: "user-1",
       costTotal: 0,
       turns: 1,
       toolCalls: 0,
@@ -1591,19 +1590,6 @@ describe("session_protocol", () => {
       ok: false,
       error: expect.objectContaining({
         message: expect.stringContaining("tool 'tool-1' does not match its result message"),
-      }),
-    });
-    expect(
-      validateSessionProtocolResult("session.snapshot", {
-        ...snapshot,
-        agents: { "agent-1": { ...agent, originMessageId: "assistant-1" } },
-      }),
-    ).toEqual({
-      ok: false,
-      error: expect.objectContaining({
-        message: expect.stringContaining(
-          "agent 'agent-1' origin does not reference a user message",
-        ),
       }),
     });
     expect(

--- a/test/session_runner.test.js
+++ b/test/session_runner.test.js
@@ -826,6 +826,58 @@ describe("session pruning", () => {
     expect(request?.prompt).not.toContain("old summary");
   });
 
+  it("skips malformed rejected edit calls without partially pruning earlier history", () => {
+    const entries = [
+      {
+        id: "valid-edit",
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "edit-valid",
+              name: TOOL_NAME_EDIT,
+              arguments: { path: "src/a.ts", oldText: "before", newText: "after" },
+            },
+          ],
+          timestamp: 1,
+        },
+      },
+      {
+        id: "malformed-edit",
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "edit-malformed",
+              name: TOOL_NAME_EDIT,
+              arguments: { path: "src/b.ts", oldText: 42 },
+            },
+          ],
+          timestamp: 2,
+        },
+      },
+    ];
+
+    const result = pruneSessionHistory({
+      historyEntries: entries,
+      replaceMessageById(historyEntryId, message) {
+        const index = entries.findIndex((entry) => entry.id === historyEntryId);
+        entries[index] = { ...entries[index], message };
+        return true;
+      },
+      options: { strategy: "earliest", fraction: 1 },
+    });
+
+    expect(result.editCallsPruned).toBe(1);
+    expect(entries[0].message.content[0].arguments.oldText).toBe("[Content pruned]");
+    expect(entries[1].message.content[0].arguments).toEqual({
+      path: "src/b.ts",
+      oldText: 42,
+    });
+  });
+
   it("fails fast when a selected prune replacement cannot be applied", () => {
     const entries = [
       {

--- a/test/session_runner.test.js
+++ b/test/session_runner.test.js
@@ -826,7 +826,7 @@ describe("session pruning", () => {
     expect(request?.prompt).not.toContain("old summary");
   });
 
-  it("skips malformed rejected edit calls without partially pruning earlier history", () => {
+  it("skips malformed rejected edit calls while pruning valid calls", () => {
     const entries = [
       {
         id: "valid-edit",

--- a/test/subagent_control_plane.test.js
+++ b/test/subagent_control_plane.test.js
@@ -86,25 +86,6 @@ describe("subagent control plane origin correlation", () => {
     expect(signals.map((signal) => signal.aborted)).toEqual([false, true]);
   });
 
-  it("rebases removed origins without interrupting agents", () => {
-    runSubagentMock.mockReset();
-    const signals = [];
-    runSubagentMock.mockImplementation(({ signal }) => {
-      signals.push(signal);
-      return new Promise(() => {});
-    });
-
-    const controlPlane = createControlPlane();
-    const retainedId = spawnAgent(controlPlane, "retained");
-    const rebasedId = spawnAgent(controlPlane, "rebased");
-
-    controlPlane.rebaseMissingOrigins(new Set(["history-retained"]), "compaction-summary");
-
-    expect(controlPlane.getOriginHistoryEntryId(retainedId)).toBe("history-retained");
-    expect(controlPlane.getOriginHistoryEntryId(rebasedId)).toBe("compaction-summary");
-    expect(signals.map((signal) => signal.aborted)).toEqual([false, false]);
-  });
-
   it("preserves spawn origin history entry across send_input_to_agent runs", async () => {
     runSubagentMock.mockReset();
     runSubagentMock.mockResolvedValue({
@@ -118,7 +99,6 @@ describe("subagent control plane origin correlation", () => {
     const id = spawnAgent(controlPlane, "research");
 
     await controlPlane.waitForAgents([id]);
-    expect(controlPlane.getOriginHistoryEntryId(id)).toBe("history-research");
 
     const sendInputResult = controlPlane.sendInput({
       id,
@@ -130,7 +110,10 @@ describe("subagent control plane origin correlation", () => {
     expect(sendInputResult.ok).toBe(true);
 
     await controlPlane.waitForAgents([id]);
-    expect(controlPlane.getOriginHistoryEntryId(id)).toBe("history-research");
+    expect(runSubagentMock.mock.calls.map(([options]) => options.originHistoryEntryId)).toEqual([
+      "history-research",
+      "history-research",
+    ]);
   });
 });
 

--- a/test/subagent_control_plane.test.js
+++ b/test/subagent_control_plane.test.js
@@ -86,6 +86,25 @@ describe("subagent control plane origin correlation", () => {
     expect(signals.map((signal) => signal.aborted)).toEqual([false, true]);
   });
 
+  it("rebases removed origins without interrupting agents", () => {
+    runSubagentMock.mockReset();
+    const signals = [];
+    runSubagentMock.mockImplementation(({ signal }) => {
+      signals.push(signal);
+      return new Promise(() => {});
+    });
+
+    const controlPlane = createControlPlane();
+    const retainedId = spawnAgent(controlPlane, "retained");
+    const rebasedId = spawnAgent(controlPlane, "rebased");
+
+    controlPlane.rebaseMissingOrigins(new Set(["history-retained"]), "compaction-summary");
+
+    expect(controlPlane.getOriginHistoryEntryId(retainedId)).toBe("history-retained");
+    expect(controlPlane.getOriginHistoryEntryId(rebasedId)).toBe("compaction-summary");
+    expect(signals.map((signal) => signal.aborted)).toEqual([false, false]);
+  });
+
   it("preserves spawn origin history entry across send_input_to_agent runs", async () => {
     runSubagentMock.mockReset();
     runSubagentMock.mockResolvedValue({

--- a/test/subagent_control_plane.test.js
+++ b/test/subagent_control_plane.test.js
@@ -65,6 +65,27 @@ describe("subagent control plane origin correlation", () => {
     });
   });
 
+  it("aborts and removes agents whose origin is no longer retained", () => {
+    runSubagentMock.mockReset();
+    const signals = [];
+    runSubagentMock.mockImplementation(({ signal }) => {
+      signals.push(signal);
+      return new Promise(() => {});
+    });
+
+    const controlPlane = createControlPlane();
+    const retainedId = spawnAgent(controlPlane, "retained");
+    const removedId = spawnAgent(controlPlane, "removed");
+
+    controlPlane.retainOrigins(new Set(["history-retained"]));
+
+    expect(controlPlane.getSnapshot(retainedId)).toEqual(
+      expect.objectContaining({ id: retainedId, status: "running" }),
+    );
+    expect(controlPlane.getSnapshot(removedId)).toBeUndefined();
+    expect(signals.map((signal) => signal.aborted)).toEqual([false, true]);
+  });
+
   it("preserves spawn origin history entry across send_input_to_agent runs", async () => {
     runSubagentMock.mockReset();
     runSubagentMock.mockResolvedValue({


### PR DESCRIPTION
## why

History rewrites could leave tool, agent, facet, and timeline projections referring to messages that no longer exist. Pruning could also mutate part of history before failing, while persisted tool UI facets retained the full output that canonical history had pruned.

## what

Make pruning stage replacements against an immutable copy before committing, and skip malformed rejected edit calls. Reconcile projections after rewind, manual or automatic compaction, and pruning, including terminating subagents from removed branches and replacing pruned tool UI facets. Tighten snapshot validation so orphaned and identity-mismatched projections cannot cross the persistence boundary.