### PR TITLE
own session teardown

### DIFF
--- a/src/core/session/session_engine.ts
+++ b/src/core/session/session_engine.ts
@@ -499,6 +499,7 @@ export class SessionEngine {
         timestamp: this.deps.clock.now(),
       },
     };
+    options.signal?.throwIfAborted();
     this.replaceHistoryEntries([summaryEntry]);
 
     return {
@@ -540,6 +541,7 @@ export class SessionEngine {
         ...(smartSelection !== undefined ? { smartSelection } : {}),
       },
     });
+    options.signal?.throwIfAborted();
     this.replaceHistoryEntries(nextHistoryEntries);
     return result;
   }

--- a/src/execution/cloudflare_sandbox_execution_environment.ts
+++ b/src/execution/cloudflare_sandbox_execution_environment.ts
@@ -145,6 +145,14 @@ export function createCloudflareSandboxToolExecutionBackend(options: {
   const { client, sandboxId } = options;
   const commandSessions = new Map<string, Promise<{ id: string; cwd: string }>>();
   const commandQueues = new Map<string, Promise<void>>();
+  const disposeAbortController = new AbortController();
+  let disposed = false;
+
+  const assertActive = (): void => {
+    if (disposed) {
+      throw new Error("Cloudflare Sandbox execution backend is disposed");
+    }
+  };
 
   const ensureCommandSession = async (cwd: string): Promise<string> => {
     const existing = commandSessions.get(cwd);
@@ -187,9 +195,19 @@ export function createCloudflareSandboxToolExecutionBackend(options: {
     );
   };
 
-  const runQueued = async <T>(cwd: string, task: () => Promise<T>): Promise<T> => {
+  const runQueued = async <T>(
+    cwd: string,
+    signal: AbortSignal,
+    task: () => Promise<T>,
+  ): Promise<T> => {
+    assertActive();
     const previous = commandQueues.get(cwd) ?? Promise.resolve();
-    const run = previous.catch(() => undefined).then(task);
+    const run = (async () => {
+      await waitForQueue(previous, signal);
+      signal.throwIfAborted();
+      assertActive();
+      return await task();
+    })();
     const tail = run.then(
       () => undefined,
       () => undefined,
@@ -209,7 +227,10 @@ export function createCloudflareSandboxToolExecutionBackend(options: {
     runOptions: { timeoutMs?: number; signal?: AbortSignal; cwd?: string } = {},
   ): Promise<BashExecutionResult> => {
     const cwd = runOptions.cwd ?? options.cwd;
-    return await runQueued(cwd, async () => {
+    const signal = runOptions.signal
+      ? AbortSignal.any([runOptions.signal, disposeAbortController.signal])
+      : disposeAbortController.signal;
+    return await runQueued(cwd, signal, async () => {
       const sessionId = await ensureCommandSession(cwd);
 
       try {
@@ -217,7 +238,7 @@ export function createCloudflareSandboxToolExecutionBackend(options: {
           argv: ["sh", "-lc", command],
           cwd,
           timeoutMs: runOptions.timeoutMs,
-          signal: runOptions.signal,
+          signal,
           sessionId,
           onAbort: () => resetCommandSession(cwd),
         });
@@ -232,6 +253,12 @@ export function createCloudflareSandboxToolExecutionBackend(options: {
 
   return {
     async dispose() {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      disposeAbortController.abort();
+      await Promise.allSettled(commandQueues.values());
       await resetAllCommandSessions();
     },
 
@@ -239,7 +266,10 @@ export function createCloudflareSandboxToolExecutionBackend(options: {
 
     async runNodeScript(script, args = [], runOptions = {}) {
       const cwd = runOptions.cwd ?? options.cwd;
-      return await runQueued(cwd, async () => {
+      const signal = runOptions.signal
+        ? AbortSignal.any([runOptions.signal, disposeAbortController.signal])
+        : disposeAbortController.signal;
+      return await runQueued(cwd, signal, async () => {
         const sessionId = await ensureCommandSession(cwd);
 
         try {
@@ -247,7 +277,7 @@ export function createCloudflareSandboxToolExecutionBackend(options: {
             argv: ["node", "-e", script, ...args],
             cwd,
             timeoutMs: runOptions.timeoutMs,
-            signal: runOptions.signal,
+            signal,
             maxCaptureBytes: runOptions.maxCaptureBytes,
             sessionId,
             onAbort: () => resetCommandSession(cwd),
@@ -262,11 +292,13 @@ export function createCloudflareSandboxToolExecutionBackend(options: {
     },
 
     async readFile(path) {
+      assertActive();
       const content = await client.readFile(sandboxId, path);
       return { path, content: content.toString("utf-8") };
     },
 
     async readFileBinary(path, readOptions = {}) {
+      assertActive();
       const content = await client.readFile(sandboxId, path);
       const bytes = content.byteLength;
       assertFileWithinMaxBytes(bytes, readOptions.maxBytes);
@@ -274,6 +306,7 @@ export function createCloudflareSandboxToolExecutionBackend(options: {
     },
 
     async writeFile(path, content) {
+      assertActive();
       const dir = dirname(path);
       if (dir && dir !== ".") {
         await exec(`mkdir -p ${shellQuote(dir)}`);
@@ -283,6 +316,7 @@ export function createCloudflareSandboxToolExecutionBackend(options: {
     },
 
     async writeFileBinary(path, content) {
+      assertActive();
       const dir = dirname(path);
       if (dir && dir !== ".") {
         await exec(`mkdir -p ${shellQuote(dir)}`);
@@ -292,6 +326,7 @@ export function createCloudflareSandboxToolExecutionBackend(options: {
     },
 
     async listDir(path) {
+      assertActive();
       const result = await exec(`node -e ${shellQuote(NODE_LIST_DIR_SCRIPT)} ${shellQuote(path)}`);
       if (result.exitCode !== 0) {
         throw new Error(result.output.trim() || `list failed for ${path}`);
@@ -301,6 +336,7 @@ export function createCloudflareSandboxToolExecutionBackend(options: {
     },
 
     async grep(grepOptions) {
+      assertActive();
       const resolvedPaths = resolveSandboxGrepPaths(grepOptions.paths);
 
       if (grepOptions.dryRun) {
@@ -326,6 +362,27 @@ export function createCloudflareSandboxToolExecutionBackend(options: {
       }
     },
   };
+}
+
+async function waitForQueue(queue: Promise<void>, signal: AbortSignal): Promise<void> {
+  signal.throwIfAborted();
+  await new Promise<void>((resolve, reject) => {
+    const onAbort = () => {
+      signal.removeEventListener("abort", onAbort);
+      reject(signal.reason);
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    void queue.then(
+      () => {
+        signal.removeEventListener("abort", onAbort);
+        resolve();
+      },
+      (error) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
 }
 
 export class CloudflareSandboxBridgeClient {

--- a/src/host/local_session_host.ts
+++ b/src/host/local_session_host.ts
@@ -538,6 +538,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
   private readonly maintenancePromises = new Set<Promise<unknown>>();
   private activeTurnPromise?: Promise<SessionProtocolUserMessageTurnResult["turn"]>;
   private disposePromise?: Promise<void>;
+  private disposing = false;
   private costTotal = 0;
   private forceNextSnapshotRevision: boolean;
   private disposed = false;
@@ -1026,6 +1027,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
 
   async dispose(): Promise<void> {
     if (!this.disposePromise) {
+      this.disposing = true;
       this.disposePromise = this.disposeNow();
     }
     return await this.disposePromise;
@@ -1096,7 +1098,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
   }
 
   private async writeSnapshot(): Promise<SessionProtocolSnapshot> {
-    this.assertActive();
+    this.assertNotDisposed();
     const draft = this.buildSnapshotDraft();
 
     if (this.committedSessionId !== draft.sessionId) {
@@ -1133,7 +1135,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
     revision: number,
     options: { persist?: boolean } = {},
   ): Promise<SessionProtocolSnapshot> {
-    this.assertActive();
+    this.assertNotDisposed();
     const draft = this.buildSnapshotDraft();
     const persist = options.persist ?? true;
 
@@ -1374,6 +1376,12 @@ class LocalHostedSessionHandle implements LocalHostedSession {
   }
 
   private assertActive(): void {
+    if (this.disposing || this.disposed) {
+      throw new Error(`session is shut down: ${this.committedSessionId}`);
+    }
+  }
+
+  private assertNotDisposed(): void {
     if (this.disposed) {
       throw new Error(`session is shut down: ${this.committedSessionId}`);
     }

--- a/src/host/local_session_host.ts
+++ b/src/host/local_session_host.ts
@@ -184,22 +184,32 @@ export class LocalSessionHost implements TauSessionHost {
     snapshot: SessionProtocolSnapshot,
     executionEnvironment: ExecutionEnvironment,
   ): Promise<LocalHostedSession> {
-    const recovered = normalizeRecoveredSnapshot(snapshot);
-    const hostedSession = await this.createLocalSessionHandle(
-      executionEnvironment,
-      recovered.snapshot,
-      undefined,
-      recovered.changed,
-    );
-    hostedSession.session.restoreState({
-      sessionId: recovered.snapshot.sessionId,
-      historyEntries: recovered.snapshot.messages.flatMap((entry) =>
-        entry.modelVisible && isCoreMessage(entry.message)
-          ? [{ id: entry.id, message: entry.message }]
-          : [],
-      ),
-    });
-    return hostedSession;
+    let hostedSession: LocalHostedSessionHandle | undefined;
+    try {
+      const recovered = normalizeRecoveredSnapshot(snapshot);
+      hostedSession = await this.createLocalSessionHandle(
+        executionEnvironment,
+        recovered.snapshot,
+        undefined,
+        recovered.changed,
+      );
+      hostedSession.session.restoreState({
+        sessionId: recovered.snapshot.sessionId,
+        historyEntries: recovered.snapshot.messages.flatMap((entry) =>
+          entry.modelVisible && isCoreMessage(entry.message)
+            ? [{ id: entry.id, message: entry.message }]
+            : [],
+        ),
+      });
+      return hostedSession;
+    } catch (error) {
+      if (hostedSession) {
+        await hostedSession.dispose();
+      } else {
+        await executionEnvironment.dispose();
+      }
+      throw error;
+    }
   }
 
   private async createLocalSessionHandle(
@@ -442,6 +452,20 @@ export class LocalSessionHost implements TauSessionHost {
     }
 
     for (const session of this.sessions) {
+      session.interruptTurn();
+      session.interruptMaintenance();
+    }
+
+    const settlementResults = await Promise.allSettled(
+      [...this.sessions].map((session) => session.waitForActiveWork()),
+    );
+    for (const result of settlementResults) {
+      if (result.status === "rejected") {
+        errors.push(result.reason);
+      }
+    }
+
+    for (const session of this.sessions) {
       try {
         await session.snapshot();
       } catch (error) {
@@ -510,6 +534,10 @@ class LocalHostedSessionHandle implements LocalHostedSession {
   private readonly unsubscribeSubagentEvent: () => void;
   private runtimeEventQueue: Promise<void> = Promise.resolve();
   private snapshotQueue: Promise<unknown> = Promise.resolve();
+  private readonly maintenanceAbortControllers = new Set<AbortController>();
+  private readonly maintenancePromises = new Set<Promise<unknown>>();
+  private activeTurnPromise?: Promise<SessionProtocolUserMessageTurnResult["turn"]>;
+  private disposePromise?: Promise<void>;
   private costTotal = 0;
   private forceNextSnapshotRevision: boolean;
   private disposed = false;
@@ -587,6 +615,18 @@ class LocalHostedSessionHandle implements LocalHostedSession {
 
   async runTurn(): Promise<SessionProtocolUserMessageTurnResult["turn"]> {
     this.assertActive();
+    const run = this.runTurnNow();
+    this.activeTurnPromise = run;
+    try {
+      return await run;
+    } finally {
+      if (this.activeTurnPromise === run) {
+        this.activeTurnPromise = undefined;
+      }
+    }
+  }
+
+  private async runTurnNow(): Promise<SessionProtocolUserMessageTurnResult["turn"]> {
     try {
       const result = await this.runtime.runTurn({
         onEvent: (event) => this.recordTurnRuntimeEvent(event),
@@ -609,6 +649,25 @@ class LocalHostedSessionHandle implements LocalHostedSession {
   interruptTurn(): boolean {
     this.assertActive();
     return this.runtime.interruptTurn();
+  }
+
+  interruptMaintenance(): boolean {
+    let interrupted = false;
+    for (const abortController of this.maintenanceAbortControllers) {
+      if (!abortController.signal.aborted) {
+        abortController.abort();
+        interrupted = true;
+      }
+    }
+    return interrupted;
+  }
+
+  async waitForActiveWork(): Promise<void> {
+    await Promise.allSettled([
+      ...(this.activeTurnPromise ? [this.activeTurnPromise] : []),
+      ...this.maintenancePromises,
+    ]);
+    await this.runtimeEventQueue;
   }
 
   requestTurnBoundaryStop(): boolean {
@@ -823,45 +882,65 @@ class LocalHostedSessionHandle implements LocalHostedSession {
   async compact(
     options: Omit<SessionProtocolCompactParams, "sessionId">,
   ): Promise<SessionProtocolCompactResult> {
-    this.assertActive();
-    const result = await this.session.compact({
-      mode: options.mode === "summary-only" ? "only-summary" : "with-last-assistant",
-      ...(options.guidance !== undefined ? { guidance: options.guidance } : {}),
-    });
+    return await this.runMaintenance(async (signal) => {
+      const result = await this.session.compact({
+        mode: options.mode === "summary-only" ? "only-summary" : "with-last-assistant",
+        ...(options.guidance !== undefined ? { guidance: options.guidance } : {}),
+        signal,
+      });
 
-    await this.runtimeEventQueue;
-    this.reconcileProjections();
-    const snapshot = await this.commitSnapshot();
-    this.emitSnapshotReset("maintenance", snapshot);
-    return {
-      snapshot,
-      compactionMessage: result.compactionMessage,
-      includedLastAssistant: result.includedLastAssistant,
-    };
+      signal.throwIfAborted();
+      await this.runtimeEventQueue;
+      this.reconcileProjections();
+      const snapshot = await this.commitSnapshot();
+      this.emitSnapshotReset("maintenance", snapshot);
+      return {
+        snapshot,
+        compactionMessage: result.compactionMessage,
+        includedLastAssistant: result.includedLastAssistant,
+      };
+    });
   }
 
   async pruneToolResults(
     options: Omit<SessionProtocolPruneParams, "sessionId">,
   ): Promise<SessionProtocolPruneResult> {
-    this.assertActive();
-    const result = await this.session.pruneToolResults({
-      strategy: options.strategy,
-      fraction: options.fraction,
-      ...(options.guidance !== undefined ? { guidance: options.guidance } : {}),
-    });
+    return await this.runMaintenance(async (signal) => {
+      const result = await this.session.pruneToolResults({
+        strategy: options.strategy,
+        fraction: options.fraction,
+        ...(options.guidance !== undefined ? { guidance: options.guidance } : {}),
+        signal,
+      });
 
-    this.reconcileProjections({ prunedToolResults: result.prunedToolResults });
-    const snapshot = await this.commitSnapshot();
-    this.emitSnapshotReset("maintenance", snapshot);
-    return {
-      snapshot,
-      message: result.message,
-      noop: result.noop,
-      bashResultsPruned: result.bashResultsPruned,
-      editCallsPruned: result.editCallsPruned,
-      editResultsPruned: result.editResultsPruned,
-      bytesPruned: result.bytesPruned,
-    };
+      signal.throwIfAborted();
+      this.reconcileProjections({ prunedToolResults: result.prunedToolResults });
+      const snapshot = await this.commitSnapshot();
+      this.emitSnapshotReset("maintenance", snapshot);
+      return {
+        snapshot,
+        message: result.message,
+        noop: result.noop,
+        bashResultsPruned: result.bashResultsPruned,
+        editCallsPruned: result.editCallsPruned,
+        editResultsPruned: result.editResultsPruned,
+        bytesPruned: result.bytesPruned,
+      };
+    });
+  }
+
+  private async runMaintenance<T>(operation: (signal: AbortSignal) => Promise<T>): Promise<T> {
+    this.assertActive();
+    const abortController = new AbortController();
+    this.maintenanceAbortControllers.add(abortController);
+    const promise = operation(abortController.signal);
+    this.maintenancePromises.add(promise);
+    try {
+      return await promise;
+    } finally {
+      this.maintenanceAbortControllers.delete(abortController);
+      this.maintenancePromises.delete(promise);
+    }
   }
 
   async rewindToHistoryEntryId(historyEntryId: string): Promise<SessionProtocolRewindResult> {
@@ -946,20 +1025,56 @@ class LocalHostedSessionHandle implements LocalHostedSession {
   }
 
   async dispose(): Promise<void> {
+    if (!this.disposePromise) {
+      this.disposePromise = this.disposeNow();
+    }
+    return await this.disposePromise;
+  }
+
+  private async disposeNow(): Promise<void> {
     if (this.disposed) {
       return;
     }
+
+    const errors: unknown[] = [];
+    this.runtime.interruptTurn();
+    this.interruptMaintenance();
+    try {
+      await this.waitForActiveWork();
+    } catch (error) {
+      errors.push(error);
+    }
+
     this.disposed = true;
     try {
       this.unsubscribeSubagentEvent();
-      for (const session of this.ephemeralAgentSessions.values()) {
+    } catch (error) {
+      errors.push(error);
+    }
+    for (const session of this.ephemeralAgentSessions.values()) {
+      try {
         session.dispose();
+      } catch (error) {
+        errors.push(error);
       }
-      this.ephemeralAgentSessions.clear();
+    }
+    this.ephemeralAgentSessions.clear();
+    try {
       this.session.dispose();
+    } catch (error) {
+      errors.push(error);
+    }
+
+    try {
       await this.executionEnvironment.dispose();
+    } catch (error) {
+      errors.push(error);
     } finally {
       this.removeFromHost(this);
+    }
+
+    if (errors.length > 0) {
+      throw new AggregateError(errors, "failed to dispose hosted session");
     }
   }
 

--- a/src/host/session_host.ts
+++ b/src/host/session_host.ts
@@ -46,6 +46,8 @@ export type TauHostedSession = {
   ): Promise<SessionProtocolRecordResult>;
   runTurn(): Promise<SessionProtocolUserMessageTurnResult["turn"]>;
   interruptTurn(): boolean;
+  interruptMaintenance(): boolean;
+  waitForActiveWork(): Promise<void>;
   requestTurnBoundaryStop(): boolean;
   cancelTurnBoundaryStop(): boolean;
   exec(

--- a/src/host/session_protocol_handler.ts
+++ b/src/host/session_protocol_handler.ts
@@ -293,17 +293,24 @@ export class SessionProtocolHandler {
       if (interruptActiveTurns && (state.live.activeSubmit || state.session.isTurnRunning)) {
         state.session.interruptTurn();
       }
+      if (interruptActiveTurns) {
+        state.session.interruptMaintenance();
+      }
       if (interruptActiveTurns && state.live.activeBash) {
         state.live.activeBash.abortController.abort();
       }
     }
 
     if (interruptActiveTurns) {
+      await Promise.allSettled(states.map((state) => state.session.waitForActiveWork()));
       await Promise.allSettled(
         states.map((state) => state.live.activeSubmit?.promise).filter((promise) => promise),
       );
       await Promise.allSettled(
         states.map((state) => state.live.activeBash?.promise).filter((promise) => promise),
+      );
+      await Promise.allSettled(
+        states.map((state) => getSessionMutationQueueState(state.session).queue),
       );
     }
 
@@ -1055,14 +1062,15 @@ export class SessionProtocolHandler {
       return;
     }
 
-    const interrupted = state.session.interruptTurn();
+    const interruptedTurn = state.session.interruptTurn();
+    const interruptedMaintenance = state.session.interruptMaintenance();
     const interruptedBash = Boolean(state.live.activeBash);
     state.live.activeBash?.abortController.abort();
     this.rejectPendingSteeringSubmits(state, "session was interrupted");
 
     const result: SessionProtocolResultByMethod["session.interrupt"] = {
-      interrupted: interrupted || interruptedBash,
-      isTurnRunning: state.session.isTurnRunning || interruptedBash,
+      interrupted: interruptedTurn || interruptedMaintenance || interruptedBash,
+      isTurnRunning: state.session.isTurnRunning || interruptedMaintenance || interruptedBash,
     };
 
     this.sendMessage(createSessionProtocolSuccessResponse(request.id, "session.interrupt", result));
@@ -1195,7 +1203,7 @@ export class SessionProtocolHandler {
   private async handleTerminateSubagent(
     request: Extract<SessionProtocolRequestMessage, { method: "session.terminateSubagent" }>,
   ): Promise<void> {
-    await this.withSessionMutation(request, "subagent termination requested", async (state) => {
+    await this.withNonInterruptingSessionMutation(request, async (state) => {
       this.sendMessage(
         createSessionProtocolSuccessResponse(
           request.id,
@@ -1275,6 +1283,9 @@ export class SessionProtocolHandler {
     }
 
     await this.runSessionMutation(state, async () => {
+      if (this.closed) {
+        return;
+      }
       if (state.session.sessionId !== request.params.sessionId) {
         this.sendSessionNotFound(request.id, request.params.sessionId);
         return;
@@ -1282,6 +1293,28 @@ export class SessionProtocolHandler {
       await this.interruptAndWaitForActiveSubmit(state);
       this.rejectPendingSteeringSubmits(state, queuedSteeringRejectionMessage);
       this.rejectPendingQueuedSubmits(state, queuedSteeringRejectionMessage);
+      await handler(state);
+    });
+  }
+
+  private async withNonInterruptingSessionMutation(
+    request: SessionProtocolMutationRequest,
+    handler: (state: SessionProtocolHandlerSessionState) => Promise<void>,
+  ): Promise<void> {
+    const state = await this.getSessionState(request.params.sessionId);
+    if (!state) {
+      this.sendSessionNotFound(request.id, request.params.sessionId);
+      return;
+    }
+
+    await this.runSessionMutation(state, async () => {
+      if (this.closed) {
+        return;
+      }
+      if (state.session.sessionId !== request.params.sessionId) {
+        this.sendSessionNotFound(request.id, request.params.sessionId);
+        return;
+      }
       await handler(state);
     });
   }

--- a/test/cloudflare_sandbox_execution_environment.test.js
+++ b/test/cloudflare_sandbox_execution_environment.test.js
@@ -205,6 +205,106 @@ describe("Cloudflare Sandbox execution environment", () => {
     expect(sessionRequests).toHaveLength(1);
   });
 
+  it("cancels a queued command before it reaches the bridge", async () => {
+    const encoder = new TextEncoder();
+    const execStreams = [];
+    const fetchMock = async (url) => {
+      if (String(url).endsWith("/v1/sandbox/sandbox-1/session")) {
+        return jsonResponse({ id: "tau-session-1" });
+      }
+      if (String(url).endsWith("/v1/sandbox/sandbox-1/exec")) {
+        const stream = {};
+        const body = new ReadableStream({
+          start(controller) {
+            stream.controller = controller;
+          },
+        });
+        execStreams.push(stream);
+        return new Response(body, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        });
+      }
+      return jsonResponse({});
+    };
+    const client = new CloudflareSandboxBridgeClient({
+      bridgeId: "default",
+      baseUrl: "https://bridge.example",
+      fetch: fetchMock,
+    });
+    const backend = createCloudflareSandboxToolExecutionBackend({
+      client,
+      sandboxId: "sandbox-1",
+      cwd: "/workspace/repo",
+    });
+
+    const first = backend.runBash("one");
+    await waitFor(() => execStreams.length === 1);
+    const controller = new AbortController();
+    const second = backend.runBash("two", { signal: controller.signal });
+    controller.abort();
+
+    await expect(second).rejects.toMatchObject({ name: "AbortError" });
+    expect(execStreams).toHaveLength(1);
+    execStreams[0].controller.enqueue(encoder.encode(execSse({ stdout: "one\n" }).join("")));
+    execStreams[0].controller.close();
+    await expect(first).resolves.toMatchObject({ output: "one\n" });
+    await backend.dispose();
+  });
+
+  it("cancels active and queued commands and rejects new work on dispose", async () => {
+    const requests = [];
+    let execCount = 0;
+    const fetchMock = async (url, init = {}) => {
+      requests.push({ url: String(url), init });
+      if (String(url).endsWith("/v1/sandbox/sandbox-1/session")) {
+        return jsonResponse({ id: "tau-session-1" });
+      }
+      if (String(url).endsWith("/v1/sandbox/sandbox-1/exec")) {
+        execCount += 1;
+        const body = new ReadableStream({
+          start(controller) {
+            init.signal.addEventListener("abort", () => controller.error(init.signal.reason), {
+              once: true,
+            });
+          },
+        });
+        return new Response(body, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        });
+      }
+      if (String(url).includes("/v1/sandbox/sandbox-1/session/tau-session-1")) {
+        return jsonResponse({});
+      }
+      return jsonResponse({ error: "not found" }, { status: 404 });
+    };
+
+    const client = new CloudflareSandboxBridgeClient({
+      bridgeId: "default",
+      baseUrl: "https://bridge.example",
+      fetch: fetchMock,
+    });
+    const backend = createCloudflareSandboxToolExecutionBackend({
+      client,
+      sandboxId: "sandbox-1",
+      cwd: "/workspace/repo",
+    });
+
+    const first = backend.runBash("one");
+    await waitFor(() => execCount === 1);
+    const second = backend.runBash("two");
+    const firstResult = expect(first).rejects.toMatchObject({ name: "AbortError" });
+    const secondResult = expect(second).rejects.toMatchObject({ name: "AbortError" });
+
+    await backend.dispose();
+    await firstResult;
+    await secondResult;
+    expect(execCount).toBe(1);
+    await expect(backend.runBash("three")).rejects.toThrow("backend is disposed");
+    expect(requests.filter((request) => request.url.endsWith("/exec"))).toHaveLength(1);
+  });
+
   it("serializes node scripts with bash commands that share a command session", async () => {
     const encoder = new TextEncoder();
     const requests = [];
@@ -390,7 +490,7 @@ describe("Cloudflare Sandbox execution environment", () => {
     ]);
   });
 
-  it("deletes the command session when bridge exec receives an already-aborted signal", async () => {
+  it("does not create a command session for an already-aborted signal", async () => {
     const requests = [];
     const fetchMock = async (url, init = {}) => {
       requests.push({ url: String(url), init });
@@ -425,7 +525,7 @@ describe("Cloudflare Sandbox execution environment", () => {
     await expect(backend.runBash("sleep 10", { signal: controller.signal })).rejects.toMatchObject({
       name: "AbortError",
     });
-    expect(requests.filter((request) => request.init.method === "DELETE")).toHaveLength(1);
+    expect(requests).toHaveLength(0);
   });
 
   it("uses real execution-environment paths for bridge file reads", async () => {

--- a/test/core_runtime.test.js
+++ b/test/core_runtime.test.js
@@ -454,6 +454,90 @@ describe("core session rewind APIs", () => {
     }
   });
 
+  it("leaves session history unchanged when compaction is aborted", async () => {
+    const session = new CoreSession({
+      persona: personas[0],
+      systemPrompt: "system",
+      subagentPrompts: {},
+      toolRegistry: new ToolRegistry([]),
+    });
+    session.addUserText("remember this");
+    session.addMessage(fauxAssistantMessage("remembered"));
+    const before = session.rawHistoryEntries;
+    const controller = new AbortController();
+    let markStreamStarted;
+    const streamStarted = new Promise((resolve) => {
+      markStreamStarted = resolve;
+    });
+    session.engine.modelRuntime.streamModel = (_model, _context, options) => ({
+      async *[Symbol.asyncIterator]() {},
+      async result() {
+        markStreamStarted();
+        await new Promise((resolve) => {
+          options.signal.addEventListener("abort", resolve, { once: true });
+        });
+        return fauxAssistantMessage(compactionSummary("## Goal\nContinue"));
+      },
+    });
+
+    const compact = session.compact({ mode: "only-summary", signal: controller.signal });
+    await streamStarted;
+    controller.abort();
+
+    await expect(compact).rejects.toMatchObject({ name: "AbortError" });
+    expect(session.rawHistoryEntries).toEqual(before);
+  });
+
+  it("leaves session history unchanged when smart pruning is aborted", async () => {
+    const session = new CoreSession({
+      persona: personas[0],
+      systemPrompt: "system",
+      subagentPrompts: {},
+      toolRegistry: new ToolRegistry([]),
+    });
+    const toolCall = fauxToolCall(
+      TOOL_NAME_BASH,
+      { command: "printf output" },
+      { id: "bash-call" },
+    );
+    session.addMessage(fauxAssistantMessage([toolCall]));
+    session.addMessage({
+      role: "toolResult",
+      toolCallId: toolCall.id,
+      toolName: toolCall.name,
+      content: [{ type: "text", text: `output ${"x".repeat(15000)}` }],
+      isError: false,
+      timestamp: 1,
+    });
+    const before = session.rawHistoryEntries;
+    const controller = new AbortController();
+    let markStreamStarted;
+    const streamStarted = new Promise((resolve) => {
+      markStreamStarted = resolve;
+    });
+    session.engine.modelRuntime.streamModel = (_model, _context, options) => ({
+      async *[Symbol.asyncIterator]() {},
+      async result() {
+        markStreamStarted();
+        await new Promise((resolve) => {
+          options.signal.addEventListener("abort", resolve, { once: true });
+        });
+        return fauxAssistantMessage(JSON.stringify({ prune: [toolCall.id] }));
+      },
+    });
+
+    const prune = session.pruneToolResults({
+      strategy: "smart",
+      fraction: 1,
+      signal: controller.signal,
+    });
+    await streamStarted;
+    controller.abort();
+
+    await expect(prune).rejects.toMatchObject({ name: "AbortError" });
+    expect(session.rawHistoryEntries).toEqual(before);
+  });
+
   it("leaves session history unchanged when pruning fails", async () => {
     const session = new CoreSession({
       persona: personas[0],

--- a/test/in_process_session_transport.test.js
+++ b/test/in_process_session_transport.test.js
@@ -121,6 +121,8 @@ function createHostedSession(sessionId, sessions, options = {}) {
       releaseTurn();
       return true;
     }),
+    interruptMaintenance: vi.fn(() => false),
+    async waitForActiveWork() {},
     async exec() {
       return createProtocolExecResult({
         output: "/repo\n",

--- a/test/local_session_host.test.js
+++ b/test/local_session_host.test.js
@@ -2161,6 +2161,34 @@ describe("LocalSessionHost", () => {
     );
   });
 
+  it("disposes a restored environment when recovered runtime initialization fails", async () => {
+    const store = new MemorySessionStore();
+    const storedSnapshot = createStoredSnapshot({
+      sessionId: "failed-recovery",
+      revision: 1,
+      historyEntries: [],
+    });
+    await store.commitSessionSnapshot(storedSnapshot);
+
+    const restoredEnvironment = createTestExecutionEnvironment();
+    restoredEnvironment.resolveRuntimeContext = vi.fn(async () => {
+      throw new Error("runtime context failed");
+    });
+    restoredEnvironment.dispose = vi.fn(async () => {});
+    const host = createHost(store, {
+      executionEnvironmentResolver: {
+        resolve: async () => createTestExecutionEnvironment(),
+        canRestore: () => true,
+        restore: async () => restoredEnvironment,
+      },
+    });
+
+    await expect(host.observeSession(storedSnapshot.sessionId)).rejects.toThrow(
+      "runtime context failed",
+    );
+    expect(restoredEnvironment.dispose).toHaveBeenCalledTimes(1);
+  });
+
   it("disposes a resolved create-session environment when shutdown wins the resolver race", async () => {
     const store = new MemorySessionStore();
     let releaseResolve;
@@ -2221,6 +2249,84 @@ describe("LocalSessionHost", () => {
     expect(resolve).toHaveBeenCalledTimes(1);
     expect(resolvedEnvironment.dispose).toHaveBeenCalledTimes(1);
     await expect(host.listSessions()).resolves.toEqual([]);
+  });
+
+  it("settles an active turn before disposing its execution environment", async () => {
+    const store = new MemorySessionStore();
+    const executionEnvironment = createTestExecutionEnvironment();
+    let hostedSession;
+    executionEnvironment.dispose = vi.fn(async () => {
+      expect(hostedSession.isTurnRunning).toBe(false);
+    });
+    const host = createHostForEnvironment(store, executionEnvironment);
+    hostedSession = await host.createSession(localCreateInput);
+    await hostedSession.record({ text: "keep running until disposal" });
+
+    let markStreamStarted;
+    const streamStarted = new Promise((resolve) => {
+      markStreamStarted = resolve;
+    });
+    hostedSession.runtime.session.engine.modelRuntime.streamModel = (
+      _model,
+      _context,
+      options,
+    ) => ({
+      async *[Symbol.asyncIterator]() {
+        markStreamStarted();
+        await new Promise((resolve) => {
+          options.signal.addEventListener("abort", resolve, { once: true });
+        });
+      },
+      async result() {
+        return fauxAssistantMessage("", { stopReason: "aborted" });
+      },
+    });
+
+    const turn = hostedSession.runTurn();
+    await streamStarted;
+    await hostedSession.dispose();
+    await expect(turn).resolves.toMatchObject({ aborted: true });
+    expect(executionEnvironment.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("aborts and settles maintenance before the shutdown snapshot", async () => {
+    const store = new MemorySessionStore();
+    const executionEnvironment = createTestExecutionEnvironment();
+    executionEnvironment.dispose = vi.fn(async () => {});
+    const host = createHostForEnvironment(store, executionEnvironment);
+    const hostedSession = await host.createSession(localCreateInput);
+    hostedSession.session.addUserText("original user message");
+    hostedSession.session.addMessage(fauxAssistantMessage("original assistant response"));
+    const before = await hostedSession.snapshot();
+
+    let markStreamStarted;
+    const streamStarted = new Promise((resolve) => {
+      markStreamStarted = resolve;
+    });
+    hostedSession.runtime.session.engine.modelRuntime.streamModel = (
+      _model,
+      _context,
+      options,
+    ) => ({
+      async *[Symbol.asyncIterator]() {},
+      async result() {
+        markStreamStarted();
+        await new Promise((resolve) => {
+          options.signal.addEventListener("abort", resolve, { once: true });
+        });
+        return fauxAssistantMessage("summary");
+      },
+    });
+
+    const compact = hostedSession.compact({ mode: "summary-only" });
+    const compactResult = expect(compact).rejects.toThrow();
+    await streamStarted;
+    await expect(host.shutdown()).resolves.toBeUndefined();
+    await compactResult;
+
+    const stored = await store.loadSession(before.sessionId);
+    expect(stored.messages).toEqual(before.messages);
+    expect(executionEnvironment.dispose).toHaveBeenCalledTimes(1);
   });
 
   it("removes directly disposed live handles from host recovery bookkeeping", async () => {

--- a/test/local_session_host.test.js
+++ b/test/local_session_host.test.js
@@ -2284,8 +2284,20 @@ describe("LocalSessionHost", () => {
 
     const turn = hostedSession.runTurn();
     await streamStarted;
-    await hostedSession.dispose();
+    const dispose = hostedSession.dispose();
+    const lateRecord = hostedSession.record({ text: "do not admit during disposal" });
+    await dispose;
+    await expect(lateRecord).rejects.toThrow("session is shut down");
     await expect(turn).resolves.toMatchObject({ aborted: true });
+    expect(
+      hostedSession.session.rawHistoryEntries.some(
+        (entry) =>
+          entry.message.role === "user" &&
+          entry.message.content.some(
+            (content) => content.type === "text" && content.text === "do not admit during disposal",
+          ),
+      ),
+    ).toBe(false);
     expect(executionEnvironment.dispose).toHaveBeenCalledTimes(1);
   });
 
@@ -2314,7 +2326,9 @@ describe("LocalSessionHost", () => {
         await new Promise((resolve) => {
           options.signal.addEventListener("abort", resolve, { once: true });
         });
-        return fauxAssistantMessage("summary");
+        return fauxAssistantMessage(
+          "## Goal\nContinue\n\n<preserved-user-message-ids>\n[]\n</preserved-user-message-ids>",
+        );
       },
     });
 

--- a/test/rpc_server.test.js
+++ b/test/rpc_server.test.js
@@ -299,6 +299,9 @@ function createHarness(options = {}) {
         releaseTurn();
         return true;
       },
+      interruptMaintenance: vi.fn(() => false),
+      waitForActiveWork: vi.fn(async () => {}),
+      terminateSubagent: vi.fn(async () => ({ found: true })),
       releaseTurn: () => releaseTurn?.(),
       canReleaseTurn: () => Boolean(releaseTurn),
       emitNotice: (text, revision = historyEntries.length + 1) => {
@@ -967,6 +970,34 @@ describe("rpc_server", () => {
     );
 
     expect(harness.lines).toHaveLength(lineCount);
+  });
+
+  it("terminates a subagent without interrupting an active foreground turn", async () => {
+    const harness = createHarness();
+
+    const submit = harness.server.handleLine(
+      request("submit-1", "session.submit", {
+        sessionId: "session-1",
+        text: "keep this turn running",
+      }),
+    );
+    await waitFor(() => harness.seededSession.canReleaseTurn());
+
+    await harness.server.handleLine(
+      request("terminate-1", "session.terminateSubagent", {
+        sessionId: "session-1",
+        subagentId: "agent-1",
+      }),
+    );
+
+    expect(harness.seededSession.isTurnRunning).toBe(true);
+    expect(harness.seededSession.terminateSubagent).toHaveBeenCalledWith("agent-1");
+    expect(
+      harness.lines.find((line) => line.type === "response" && line.id === "terminate-1"),
+    ).toMatchObject({ ok: true, result: { found: true } });
+
+    harness.releaseTurn();
+    await submit;
   });
 
   it("changes reasoning during an active turn without interrupting or rejecting queued submits", async () => {

--- a/test/websocket_session_transport.test.js
+++ b/test/websocket_session_transport.test.js
@@ -122,6 +122,8 @@ function createHostedSession(sessionId, sessions, options = {}) {
       releaseTurn();
       return true;
     }),
+    interruptMaintenance: vi.fn(() => false),
+    async waitForActiveWork() {},
     async exec() {
       return createProtocolExecResult({
         output: "/repo\n",


### PR DESCRIPTION
## why

Session shutdown did not consistently own the work using its execution environment. Active turns and maintenance calls could outlive snapshots or disposal, Cloudflare commands could remain queued past cancellation, and recovery failures could leak restored environments. Subagent termination also used an interrupting mutation path and could stop unrelated foreground work.

## what

Hosted sessions now track active turns and maintenance operations, abort and settle them before the final shutdown snapshot, and dispose resources in a simple ordered cleanup flow. Ordinary client detach still preserves shared session work, while explicit interrupt also cancels model-backed maintenance.

Cloudflare command queues now observe cancellation while waiting, abort active and queued work during disposal, and reject all work after the backend reaches its terminal state. Recovery transfers environment ownership explicitly and disposes it on every failed initialization path. Subagent termination uses a serialized non-interrupting mutation path.

## details

This resolves Nook findings 22, 24, 25, 42, and 56. Regression coverage exercises active-turn disposal ordering, maintenance cancellation before shutdown persistence, queued Cloudflare cancellation and terminal admission, failed recovery cleanup, and subagent termination during foreground work.
