### PR TITLE
harden concurrent session state

### DIFF
--- a/.tau/config.json
+++ b/.tau/config.json
@@ -1,4 +1,5 @@
 {
+  "defaultPersona": "gpt-5.6-sol-chatgpt-coder:high",
   "subagents": {
     "defaultLaunchModels": [
       "openai-codex/gpt-5.6-sol:medium",

--- a/src/core/session/runner.ts
+++ b/src/core/session/runner.ts
@@ -318,11 +318,24 @@ export class SequentialToolCallRunner implements AsyncIterable<ToolRunnerEvent> 
   ) {}
 
   enqueue(toolCall: ToolCall): CoreToolUiEvent | undefined {
+    const prepared = prepareToolCall(toolCall, this.options);
+    this.enqueuePrepared(prepared);
+    return prepared.type === "ready" ? createToolQueuedEvent(toolCall) : undefined;
+  }
+
+  enqueueRejected(toolCall: ToolCall, message: string): void {
+    this.enqueuePrepared({
+      type: "rejected",
+      message,
+      result: createToolError(toolCall, message),
+    });
+  }
+
+  private enqueuePrepared(prepared: PreparedToolCall): void {
     if (this.finished) {
       throw new Error("cannot enqueue a tool call after finishing the runner");
     }
 
-    const prepared = prepareToolCall(toolCall, this.options);
     this.execution = this.execution.then(async () => {
       if (this.signal.aborted) {
         return;
@@ -343,8 +356,6 @@ export class SequentialToolCallRunner implements AsyncIterable<ToolRunnerEvent> 
         waiter.reject(error);
       }
     });
-
-    return prepared.type === "ready" ? createToolQueuedEvent(toolCall) : undefined;
   }
 
   private publish(event: ToolRunnerEvent): void {

--- a/src/core/session/session_engine.ts
+++ b/src/core/session/session_engine.ts
@@ -1125,6 +1125,7 @@ export class SessionEngine {
     const pendingToolResults: ToolResultMessage[] = [];
     const recoveryToolResults: ToolResultMessage[] = [];
     const streamedToolCalls: ToolCall[] = [];
+    const streamedToolCallIds = new Set<string>();
     let modelDone = false;
     let toolDone = false;
     let shouldNoteProviderError = false;
@@ -1213,9 +1214,7 @@ export class SessionEngine {
             }
             if (!toolRecoveryMode) {
               for (const toolResult of pendingToolResults.splice(0)) {
-                const toolHistoryEntryId = this.addMessage(toolResult, {
-                  historyEntryId: toolResult.toolCallId,
-                });
+                const toolHistoryEntryId = this.addMessage(toolResult);
                 const toolEvent: CoreEvent = {
                   type: "tool_result",
                   historyEntryId: toolHistoryEntryId,
@@ -1238,17 +1237,38 @@ export class SessionEngine {
               continue;
             }
             const queuedEvents: CoreToolUiEvent[] = [];
-            for (const toolCall of event.snapshot.toolCalls.slice(streamedToolCalls.length)) {
-              streamedToolCalls.push(toolCall);
-              const queuedEvent = toolRunner.enqueue(toolCall);
-              if (queuedEvent) {
-                queuedEvents.push(queuedEvent);
+            for (const streamedToolCall of event.snapshot.toolCalls.slice(
+              streamedToolCalls.length,
+            )) {
+              const invalidId = !streamedToolCall.id.trim();
+              const duplicateId = streamedToolCallIds.has(streamedToolCall.id);
+              if (!invalidId && !duplicateId) {
+                streamedToolCallIds.add(streamedToolCall.id);
+                streamedToolCalls.push(streamedToolCall);
+                const queuedEvent = toolRunner.enqueue(streamedToolCall);
+                if (queuedEvent) {
+                  queuedEvents.push(queuedEvent);
+                }
+                continue;
               }
+
+              const toolCall = {
+                ...streamedToolCall,
+                id: `invalid-tool-call-${randomUUID()}`,
+              };
+              const message = invalidId
+                ? "Model returned a tool call with an empty ID."
+                : `Model returned duplicate tool call ID '${streamedToolCall.id}'.`;
+              streamedToolCalls.push(toolCall);
+              toolRunner.enqueueRejected(toolCall, message);
             }
             const partialEvent: CoreEvent = {
               type: "assistant_partial",
               historyEntryId,
-              snapshot: event.snapshot,
+              snapshot: {
+                ...event.snapshot,
+                toolCalls: [...streamedToolCalls],
+              },
             };
             this.emitEvent(partialEvent);
             yield partialEvent;
@@ -1284,9 +1304,7 @@ export class SessionEngine {
             continue;
           }
 
-          const toolHistoryEntryId = this.addMessage(event.message, {
-            historyEntryId: event.message.toolCallId,
-          });
+          const toolHistoryEntryId = this.addMessage(event.message);
           const toolEvent: CoreEvent = {
             ...event,
             historyEntryId: toolHistoryEntryId,

--- a/src/host/hosted_ephemeral_agent_session.ts
+++ b/src/host/hosted_ephemeral_agent_session.ts
@@ -25,6 +25,7 @@ import type {
   SessionProtocolEphemeralSubmitResult,
 } from "../protocol/session_protocol.js";
 import { createExecutionEnvironmentSubagentRuntimeResolver } from "./execution_runtime.js";
+import { EphemeralThreadBusyError } from "./session_host.js";
 
 export type EphemeralAgentUsageSnapshot = {
   input: number;
@@ -62,12 +63,6 @@ export type HostedEphemeralAgentSessionOptions = {
   ) => void;
 };
 
-type HostedEphemeralAgentThreadRecord = {
-  thread: EphemeralAgentThread;
-};
-
-export class EphemeralThreadBusyError extends Error {}
-
 export class HostedEphemeralAgentSession {
   private readonly contextId: string;
   private readonly persona: Persona;
@@ -79,7 +74,7 @@ export class HostedEphemeralAgentSession {
   private readonly instructions: string;
   private readonly tools: SubagentToolName[];
   private readonly emitUpdate: HostedEphemeralAgentSessionOptions["emitUpdate"];
-  private readonly threads = new Map<string, HostedEphemeralAgentThreadRecord>();
+  private readonly threads = new Map<string, EphemeralAgentThread>();
   private readonly activeThreadIds = new Set<string>();
   private disposed = false;
 
@@ -119,8 +114,8 @@ export class HostedEphemeralAgentSession {
 
     this.activeThreadIds.add(options.threadId);
     try {
-      const record = await this.getOrCreateThread(options.threadId, options.forkFromThreadId);
-      const response = await record.thread.submitMessage(options.message);
+      const thread = await this.getOrCreateThread(options.threadId, options.forkFromThreadId);
+      const response = await thread.submitMessage(options.message);
       return { threadId: options.threadId, response };
     } finally {
       this.activeThreadIds.delete(options.threadId);
@@ -132,9 +127,9 @@ export class HostedEphemeralAgentSession {
       return;
     }
     this.disposed = true;
-    for (const record of this.threads.values()) {
-      record.thread.interrupt();
-      record.thread.dispose();
+    for (const thread of this.threads.values()) {
+      thread.interrupt();
+      thread.dispose();
     }
     this.threads.clear();
     this.activeThreadIds.clear();
@@ -143,7 +138,7 @@ export class HostedEphemeralAgentSession {
   private async getOrCreateThread(
     threadId: string,
     forkFromThreadId?: string,
-  ): Promise<HostedEphemeralAgentThreadRecord> {
+  ): Promise<EphemeralAgentThread> {
     const existing = this.threads.get(threadId);
     if (existing) {
       return existing;
@@ -153,10 +148,9 @@ export class HostedEphemeralAgentSession {
     if (forkFromThreadId && !forkFrom) {
       throw new Error(`unknown fork source thread '${forkFromThreadId}'`);
     }
-    const thread = await this.createThread(threadId, forkFrom?.thread.createForkSource());
-    const record: HostedEphemeralAgentThreadRecord = { thread };
-    this.threads.set(threadId, record);
-    return record;
+    const thread = await this.createThread(threadId, forkFrom?.createForkSource());
+    this.threads.set(threadId, thread);
+    return thread;
   }
 
   private async createThread(

--- a/src/host/hosted_ephemeral_agent_session.ts
+++ b/src/host/hosted_ephemeral_agent_session.ts
@@ -64,8 +64,9 @@ export type HostedEphemeralAgentSessionOptions = {
 
 type HostedEphemeralAgentThreadRecord = {
   thread: EphemeralAgentThread;
-  activeRequestCount: number;
 };
+
+export class EphemeralThreadBusyError extends Error {}
 
 export class HostedEphemeralAgentSession {
   private readonly contextId: string;
@@ -79,6 +80,7 @@ export class HostedEphemeralAgentSession {
   private readonly tools: SubagentToolName[];
   private readonly emitUpdate: HostedEphemeralAgentSessionOptions["emitUpdate"];
   private readonly threads = new Map<string, HostedEphemeralAgentThreadRecord>();
+  private readonly activeThreadIds = new Set<string>();
   private disposed = false;
 
   constructor(options: HostedEphemeralAgentSessionOptions) {
@@ -104,13 +106,24 @@ export class HostedEphemeralAgentSession {
       );
     }
 
-    const record = await this.getOrCreateThread(options.threadId, options.forkFromThreadId);
-    record.activeRequestCount += 1;
+    if (this.activeThreadIds.has(options.threadId)) {
+      throw new EphemeralThreadBusyError(
+        `thread '${options.threadId}' already has an active request`,
+      );
+    }
+    if (options.forkFromThreadId && this.activeThreadIds.has(options.forkFromThreadId)) {
+      throw new EphemeralThreadBusyError(
+        `thread '${options.forkFromThreadId}' already has an active request and cannot be used as a fork source`,
+      );
+    }
+
+    this.activeThreadIds.add(options.threadId);
     try {
+      const record = await this.getOrCreateThread(options.threadId, options.forkFromThreadId);
       const response = await record.thread.submitMessage(options.message);
       return { threadId: options.threadId, response };
     } finally {
-      record.activeRequestCount -= 1;
+      this.activeThreadIds.delete(options.threadId);
     }
   }
 
@@ -124,6 +137,7 @@ export class HostedEphemeralAgentSession {
       record.thread.dispose();
     }
     this.threads.clear();
+    this.activeThreadIds.clear();
   }
 
   private async getOrCreateThread(
@@ -139,14 +153,8 @@ export class HostedEphemeralAgentSession {
     if (forkFromThreadId && !forkFrom) {
       throw new Error(`unknown fork source thread '${forkFromThreadId}'`);
     }
-    if (forkFrom && forkFrom.activeRequestCount > 0) {
-      throw new Error(
-        `thread '${forkFromThreadId}' already has an active request and cannot be used as a fork source`,
-      );
-    }
-
     const thread = await this.createThread(threadId, forkFrom?.thread.createForkSource());
-    const record: HostedEphemeralAgentThreadRecord = { thread, activeRequestCount: 0 };
+    const record: HostedEphemeralAgentThreadRecord = { thread };
     this.threads.set(threadId, record);
     return record;
   }

--- a/src/host/local_session_host.ts
+++ b/src/host/local_session_host.ts
@@ -513,7 +513,6 @@ class LocalHostedSessionHandle implements LocalHostedSession {
   private committedSessionId: string;
   private committedSnapshot?: SessionProtocolSnapshot;
   private persistedSnapshot?: SessionProtocolSnapshot;
-  private persistedSnapshotRevision?: number;
   private draftAssistantMessage?: SessionProtocolMessage;
   private readonly messageStates = new Map<string, SessionProtocolMessage["state"]>();
   private restoredMessageIds?: Set<string>;
@@ -566,7 +565,6 @@ class LocalHostedSessionHandle implements LocalHostedSession {
     this.persistedSnapshot = committedSnapshot
       ? cloneSessionProtocolSnapshot(committedSnapshot)
       : undefined;
-    this.persistedSnapshotRevision = committedSnapshot?.revision;
     this.forceNextSnapshotRevision = forceNextSnapshotRevision;
     this.restoreProtocolState(committedSnapshot);
     this.unsubscribeSubagentEvent = this.session.onSubagentEvent((event) => {
@@ -1092,89 +1090,71 @@ class LocalHostedSessionHandle implements LocalHostedSession {
     return await write;
   }
 
-  private async commitSnapshotWithRevision(
-    revision: number,
-    options: { persist?: boolean } = {},
-  ): Promise<SessionProtocolSnapshot> {
+  private async commitSnapshotWithRevision(revision: number): Promise<SessionProtocolSnapshot> {
     const write = this.snapshotQueue
       .catch(() => undefined)
-      .then(() => this.writeSnapshotWithRevision(revision, options));
+      .then(() => this.writeSnapshotWithRevision(revision));
     this.snapshotQueue = write.catch(() => undefined);
     return await write;
   }
 
   private async writeSnapshot(): Promise<SessionProtocolSnapshot> {
     this.assertNotDisposed();
+    const generation = this.snapshotGeneration;
     const draft = this.buildSnapshotDraft();
 
-    if (this.committedSessionId !== draft.sessionId) {
-      await this.store.deleteSession(this.committedSessionId, {
-        ...(this.persistedSnapshotRevision !== undefined
-          ? { expectedRevision: this.persistedSnapshotRevision }
-          : {}),
-      });
-      this.committedSessionId = draft.sessionId;
-      this.committedSnapshot = undefined;
-      this.persistedSnapshot = undefined;
-      this.persistedSnapshotRevision = undefined;
-    }
+    await this.switchSnapshotSession(draft.sessionId);
 
     const snapshot: SessionProtocolSnapshot = {
       ...draft,
       revision: this.nextSnapshotRevision(draft),
     };
-    const generation = this.snapshotGeneration;
     if (this.persistedSnapshot && isDeepStrictEqual(this.persistedSnapshot, snapshot)) {
       return cloneSessionProtocolSnapshot(this.committedSnapshot ?? snapshot);
     }
 
     await this.store.commitSessionSnapshot(snapshot, {
-      expectedRevision: this.persistedSnapshotRevision ?? 0,
+      expectedRevision: this.persistedSnapshot?.revision ?? 0,
     });
     this.persistedSnapshot = cloneSessionProtocolSnapshot(snapshot);
-    this.persistedSnapshotRevision = snapshot.revision;
     if (generation !== this.snapshotGeneration) {
       return await this.writeSnapshot();
     }
     return cloneSessionProtocolSnapshot(this.updateCommittedSnapshotAfterWrite(snapshot));
   }
 
-  private async writeSnapshotWithRevision(
-    revision: number,
-    options: { persist?: boolean } = {},
-  ): Promise<SessionProtocolSnapshot> {
+  private async writeSnapshotWithRevision(revision: number): Promise<SessionProtocolSnapshot> {
     this.assertNotDisposed();
+    const generation = this.snapshotGeneration;
     const draft = this.buildSnapshotDraft();
-    const persist = options.persist ?? true;
 
-    if (this.committedSessionId !== draft.sessionId) {
-      await this.store.deleteSession(this.committedSessionId, {
-        ...(this.persistedSnapshotRevision !== undefined
-          ? { expectedRevision: this.persistedSnapshotRevision }
-          : {}),
-      });
-      this.committedSessionId = draft.sessionId;
-      this.committedSnapshot = undefined;
-      this.persistedSnapshot = undefined;
-      this.persistedSnapshotRevision = undefined;
-    }
+    await this.switchSnapshotSession(draft.sessionId);
 
     const snapshot: SessionProtocolSnapshot = {
       ...draft,
       revision,
     };
-    const generation = this.snapshotGeneration;
-    if (persist) {
-      await this.store.commitSessionSnapshot(snapshot, {
-        expectedRevision: this.persistedSnapshotRevision ?? 0,
-      });
-      this.persistedSnapshot = cloneSessionProtocolSnapshot(snapshot);
-      this.persistedSnapshotRevision = snapshot.revision;
-      if (generation !== this.snapshotGeneration) {
-        return await this.writeSnapshot();
-      }
+    await this.store.commitSessionSnapshot(snapshot, {
+      expectedRevision: this.persistedSnapshot?.revision ?? 0,
+    });
+    this.persistedSnapshot = cloneSessionProtocolSnapshot(snapshot);
+    if (generation !== this.snapshotGeneration) {
+      return await this.writeSnapshot();
     }
     return cloneSessionProtocolSnapshot(this.updateCommittedSnapshotAfterWrite(snapshot));
+  }
+
+  private async switchSnapshotSession(sessionId: string): Promise<void> {
+    if (this.committedSessionId === sessionId) {
+      return;
+    }
+
+    await this.store.deleteSession(this.committedSessionId, {
+      ...(this.persistedSnapshot ? { expectedRevision: this.persistedSnapshot.revision } : {}),
+    });
+    this.committedSessionId = sessionId;
+    this.committedSnapshot = undefined;
+    this.persistedSnapshot = undefined;
   }
 
   private updateCommittedSnapshotAfterWrite(
@@ -1753,7 +1733,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
       return;
     }
 
-    const snapshot = await this.commitSnapshotWithRevision(toRevision, options);
+    const snapshot = await this.commitSnapshotWithRevision(toRevision);
     this.emitDelta(
       createSessionProtocolDeltaMessage({
         sessionId: delta.sessionId,

--- a/src/host/local_session_host.ts
+++ b/src/host/local_session_host.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { isDeepStrictEqual } from "node:util";
 import type { Api, AssistantMessage, Message, Model, ToolCall } from "@earendil-works/pi-ai";
 import { type Config, resolvePromptTemplateWithBackend } from "../core/config/index.js";
 import type { CoreEvent } from "../core/events/types.js";
@@ -511,6 +512,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
   readonly session: CoreSession;
   private committedSessionId: string;
   private committedSnapshot?: SessionProtocolSnapshot;
+  private persistedSnapshot?: SessionProtocolSnapshot;
   private persistedSnapshotRevision?: number;
   private draftAssistantMessage?: SessionProtocolMessage;
   private readonly messageStates = new Map<string, SessionProtocolMessage["state"]>();
@@ -534,6 +536,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
   private readonly unsubscribeSubagentEvent: () => void;
   private runtimeEventQueue: Promise<void> = Promise.resolve();
   private snapshotQueue: Promise<unknown> = Promise.resolve();
+  private snapshotGeneration = 0;
   private readonly maintenanceAbortControllers = new Set<AbortController>();
   private readonly maintenancePromises = new Set<Promise<unknown>>();
   private activeTurnPromise?: Promise<SessionProtocolUserMessageTurnResult["turn"]>;
@@ -558,6 +561,9 @@ class LocalHostedSessionHandle implements LocalHostedSession {
     this.session = runtime.session;
     this.committedSessionId = committedSnapshot?.sessionId ?? this.session.sessionId;
     this.committedSnapshot = committedSnapshot
+      ? cloneSessionProtocolSnapshot(committedSnapshot)
+      : undefined;
+    this.persistedSnapshot = committedSnapshot
       ? cloneSessionProtocolSnapshot(committedSnapshot)
       : undefined;
     this.persistedSnapshotRevision = committedSnapshot?.revision;
@@ -707,7 +713,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
       this.emitDelta(
         createSessionProtocolDeltaMessage({
           sessionId: snapshot.sessionId,
-          fromRevision,
+          fromRevision: snapshot.revision - 1,
           toRevision: snapshot.revision,
           reason: "configuration",
           delta: {
@@ -1109,6 +1115,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
       });
       this.committedSessionId = draft.sessionId;
       this.committedSnapshot = undefined;
+      this.persistedSnapshot = undefined;
       this.persistedSnapshotRevision = undefined;
     }
 
@@ -1116,18 +1123,19 @@ class LocalHostedSessionHandle implements LocalHostedSession {
       ...draft,
       revision: this.nextSnapshotRevision(draft),
     };
-    if (
-      this.committedSnapshot &&
-      snapshot.revision === this.committedSnapshot.revision &&
-      this.persistedSnapshotRevision === snapshot.revision
-    ) {
-      return cloneSessionProtocolSnapshot(this.committedSnapshot);
+    const generation = this.snapshotGeneration;
+    if (this.persistedSnapshot && isDeepStrictEqual(this.persistedSnapshot, snapshot)) {
+      return cloneSessionProtocolSnapshot(this.committedSnapshot ?? snapshot);
     }
 
     await this.store.commitSessionSnapshot(snapshot, {
       expectedRevision: this.persistedSnapshotRevision ?? 0,
     });
+    this.persistedSnapshot = cloneSessionProtocolSnapshot(snapshot);
     this.persistedSnapshotRevision = snapshot.revision;
+    if (generation !== this.snapshotGeneration) {
+      return await this.writeSnapshot();
+    }
     return cloneSessionProtocolSnapshot(this.updateCommittedSnapshotAfterWrite(snapshot));
   }
 
@@ -1147,6 +1155,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
       });
       this.committedSessionId = draft.sessionId;
       this.committedSnapshot = undefined;
+      this.persistedSnapshot = undefined;
       this.persistedSnapshotRevision = undefined;
     }
 
@@ -1154,11 +1163,16 @@ class LocalHostedSessionHandle implements LocalHostedSession {
       ...draft,
       revision,
     };
+    const generation = this.snapshotGeneration;
     if (persist) {
       await this.store.commitSessionSnapshot(snapshot, {
         expectedRevision: this.persistedSnapshotRevision ?? 0,
       });
+      this.persistedSnapshot = cloneSessionProtocolSnapshot(snapshot);
       this.persistedSnapshotRevision = snapshot.revision;
+      if (generation !== this.snapshotGeneration) {
+        return await this.writeSnapshot();
+      }
     }
     return cloneSessionProtocolSnapshot(this.updateCommittedSnapshotAfterWrite(snapshot));
   }
@@ -1166,8 +1180,9 @@ class LocalHostedSessionHandle implements LocalHostedSession {
   private updateCommittedSnapshotAfterWrite(
     snapshot: SessionProtocolSnapshot,
   ): SessionProtocolSnapshot {
-    if (!this.committedSnapshot || this.committedSnapshot.revision <= snapshot.revision) {
+    if (!this.committedSnapshot || this.committedSnapshot.revision < snapshot.revision) {
       this.committedSnapshot = cloneSessionProtocolSnapshot(snapshot);
+      this.snapshotGeneration += 1;
     }
     return this.committedSnapshot;
   }
@@ -1733,6 +1748,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
     });
     if (options.persist === false) {
       this.committedSnapshot = applySessionProtocolDelta(this.committedSnapshot, delta);
+      this.snapshotGeneration += 1;
       this.emitDelta(delta);
       return;
     }

--- a/src/host/session_host.ts
+++ b/src/host/session_host.ts
@@ -35,6 +35,8 @@ import type {
   SessionProtocolUserMessageTurnResult,
 } from "../protocol/session_protocol.js";
 
+export class EphemeralThreadBusyError extends Error {}
+
 export type TauHostedSession = {
   readonly sessionId: string;
   readonly isDisposed?: boolean;

--- a/src/host/session_protocol_handler.ts
+++ b/src/host/session_protocol_handler.ts
@@ -18,8 +18,11 @@ import {
   type SessionProtocolRequestMessage,
   type SessionProtocolResultByMethod,
 } from "../protocol/session_protocol.js";
-import { EphemeralThreadBusyError } from "./hosted_ephemeral_agent_session.js";
-import type { TauHostedSession, TauSessionHost } from "./session_host.js";
+import {
+  EphemeralThreadBusyError,
+  type TauHostedSession,
+  type TauSessionHost,
+} from "./session_host.js";
 
 export type SessionProtocolHandlerOptions = {
   host: TauSessionHost;

--- a/src/host/session_protocol_handler.ts
+++ b/src/host/session_protocol_handler.ts
@@ -18,6 +18,7 @@ import {
   type SessionProtocolRequestMessage,
   type SessionProtocolResultByMethod,
 } from "../protocol/session_protocol.js";
+import { EphemeralThreadBusyError } from "./hosted_ephemeral_agent_session.js";
 import type { TauHostedSession, TauSessionHost } from "./session_host.js";
 
 export type SessionProtocolHandlerOptions = {
@@ -1253,7 +1254,9 @@ export class SessionProtocolHandler {
       this.sendMessage(
         createSessionProtocolErrorResponse(
           request.id,
-          SESSION_PROTOCOL_ERROR_CODES.internalError,
+          error instanceof EphemeralThreadBusyError
+            ? SESSION_PROTOCOL_ERROR_CODES.busy
+            : SESSION_PROTOCOL_ERROR_CODES.internalError,
           error instanceof Error ? error.message : String(error),
         ),
       );

--- a/test/core_runtime.test.js
+++ b/test/core_runtime.test.js
@@ -819,6 +819,172 @@ describe("core session rewind APIs", () => {
     ]);
   });
 
+  it("rejects duplicate streamed tool call ids without executing the duplicate", async () => {
+    const firstCall = fauxToolCall("early_tool", { sequence: 1 }, { id: "duplicate-call" });
+    const duplicateCall = fauxToolCall("early_tool", { sequence: 2 }, { id: "duplicate-call" });
+    const toolMessage = fauxAssistantMessage([firstCall, duplicateCall], {
+      stopReason: "toolUse",
+    });
+    const finalMessage = fauxAssistantMessage("continued");
+    const executedSequences = [];
+    const toolRegistry = new ToolRegistry([
+      {
+        schema: {
+          name: "early_tool",
+          description: "test tool",
+          parameters: {
+            type: "object",
+            properties: { sequence: { type: "number" } },
+            required: ["sequence"],
+            additionalProperties: false,
+          },
+        },
+        dispatch: async (call) => {
+          executedSequences.push(call.arguments.sequence);
+          return {
+            run: Promise.resolve({
+              toolResult: {
+                role: "toolResult",
+                toolCallId: call.id,
+                toolName: call.name,
+                content: [{ type: "text", text: "done" }],
+                isError: false,
+                timestamp: 2,
+              },
+            }),
+          };
+        },
+      },
+    ]);
+    const session = new CoreSession({
+      persona: { ...personas[0], tools: ["early_tool"] },
+      systemPrompt: "system",
+      subagentPrompts: {},
+      toolRegistry,
+    });
+    const responses = [toolMessage, finalMessage];
+    session.engine.modelRuntime.streamModel = () => {
+      const response = responses.shift();
+      return {
+        async *[Symbol.asyncIterator]() {
+          if (response === toolMessage) {
+            yield { type: "toolcall_start", contentIndex: 0, partial: response };
+            yield {
+              type: "toolcall_end",
+              contentIndex: 0,
+              toolCall: firstCall,
+              partial: response,
+            };
+            yield { type: "toolcall_start", contentIndex: 1, partial: response };
+            yield {
+              type: "toolcall_end",
+              contentIndex: 1,
+              toolCall: duplicateCall,
+              partial: response,
+            };
+          }
+        },
+        async result() {
+          return response;
+        },
+      };
+    };
+
+    session.addUserText("use the tool twice");
+    const events = [];
+    for await (const event of session.events(new AbortController().signal)) {
+      events.push(event);
+    }
+
+    expect(executedSequences).toEqual([1]);
+    const recovery = events.find((event) => event.type === "tool_recovery");
+    expect(recovery.toolResults).toHaveLength(2);
+    expect(new Set(recovery.toolResults.map((result) => result.toolCallId)).size).toBe(2);
+    expect(recovery.toolResults).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ toolCallId: "duplicate-call", isError: false }),
+        expect.objectContaining({
+          toolCallId: expect.stringMatching(/^invalid-tool-call-/),
+          isError: true,
+        }),
+      ]),
+    );
+    expect(
+      events.some(
+        (event) =>
+          event.type === "notice" && event.text.includes("duplicate tool call ID 'duplicate-call'"),
+      ),
+    ).toBe(true);
+  });
+
+  it("uses independent history ids for tool results", async () => {
+    const toolCall = fauxToolCall("early_tool", {}, { id: "reused-history-id" });
+    const toolMessage = fauxAssistantMessage([toolCall], { stopReason: "toolUse" });
+    const finalMessage = fauxAssistantMessage("done");
+    const toolRegistry = new ToolRegistry([
+      {
+        schema: {
+          name: "early_tool",
+          description: "test tool",
+          parameters: { type: "object", properties: {}, additionalProperties: false },
+        },
+        dispatch: async (call) => ({
+          run: Promise.resolve({
+            toolResult: {
+              role: "toolResult",
+              toolCallId: call.id,
+              toolName: call.name,
+              content: [{ type: "text", text: "done" }],
+              isError: false,
+              timestamp: 2,
+            },
+          }),
+        }),
+      },
+    ]);
+    const session = new CoreSession({
+      persona: { ...personas[0], tools: ["early_tool"] },
+      systemPrompt: "system",
+      subagentPrompts: {},
+      toolRegistry,
+    });
+    const responses = [toolMessage, finalMessage];
+    session.engine.modelRuntime.streamModel = () => {
+      const response = responses.shift();
+      return {
+        async *[Symbol.asyncIterator]() {
+          if (response === toolMessage) {
+            yield { type: "toolcall_start", contentIndex: 0, partial: response };
+            yield {
+              type: "toolcall_end",
+              contentIndex: 0,
+              toolCall,
+              partial: response,
+            };
+          }
+        },
+        async result() {
+          return response;
+        },
+      };
+    };
+
+    session.addUserText("prior", { historyEntryId: "reused-history-id" });
+    session.addUserText("use the tool");
+    for await (const _event of session.events(new AbortController().signal)) {
+    }
+
+    const toolResultEntry = session.rawHistoryEntries.find(
+      (entry) => entry.message.role === "toolResult",
+    );
+    expect(toolResultEntry).toEqual(
+      expect.objectContaining({
+        id: expect.not.stringMatching(/^reused-history-id$/),
+        message: expect.objectContaining({ toolCallId: "reused-history-id" }),
+      }),
+    );
+  });
+
   it("continues from hidden tool recovery context after a terminal model error", async () => {
     const toolCall = fauxToolCall("early_tool", { path: "result.txt" }, { id: "early-call" });
     const errorMessage = fauxAssistantMessage([toolCall], {

--- a/test/local_session_host.test.js
+++ b/test/local_session_host.test.js
@@ -7,6 +7,10 @@ import { createLocalToolExecutionBackend, ToolCatalog } from "../dist/core/index
 import { resolveModel } from "../dist/core/models/catalog.js";
 import { personas } from "../dist/core/personas.js";
 import { prependTauUserMetadata } from "../dist/core/utils/user_metadata.js";
+import {
+  EphemeralThreadBusyError,
+  HostedEphemeralAgentSession,
+} from "../dist/host/hosted_ephemeral_agent_session.js";
 import { LocalSessionHost } from "../dist/host/local_session_host.js";
 import { MemorySessionStore } from "../dist/store/memory_session_store.js";
 
@@ -280,6 +284,74 @@ class BlockingCommitStore extends MemorySessionStore {
     await super.commitSessionSnapshot(snapshot, options);
   }
 }
+
+describe("HostedEphemeralAgentSession", () => {
+  it("rejects concurrent thread creation, submission, and forking without mutation", async () => {
+    let markCreating;
+    let releaseCreation;
+    const creating = new Promise((resolve) => {
+      markCreating = resolve;
+    });
+    const creationGate = new Promise((resolve) => {
+      releaseCreation = resolve;
+    });
+    const submittedMessages = [];
+    const thread = {
+      async submitMessage(message) {
+        submittedMessages.push(message);
+        return "done";
+      },
+      createForkSource: () => ({ historyEntries: [], usageBaseline: {} }),
+      interrupt: vi.fn(),
+      dispose: vi.fn(),
+    };
+    const session = new HostedEphemeralAgentSession({
+      contextId: "context-1",
+      persona: personas[0],
+      config: {},
+      modelResolver: resolveModel,
+      discoveredSkills: [],
+      includeAgentContext: false,
+      executionEnvironment: createTestExecutionEnvironment(),
+      instructions: "review",
+      tools: [],
+      emitUpdate: vi.fn(),
+    });
+    session.createThread = vi.fn(async () => {
+      markCreating();
+      await creationGate;
+      return thread;
+    });
+
+    const first = session.submitThreadMessage({
+      contextId: "context-1",
+      threadId: "thread-1",
+      message: "first",
+    });
+    await creating;
+
+    await expect(
+      session.submitThreadMessage({
+        contextId: "context-1",
+        threadId: "thread-1",
+        message: "duplicate",
+      }),
+    ).rejects.toBeInstanceOf(EphemeralThreadBusyError);
+    await expect(
+      session.submitThreadMessage({
+        contextId: "context-1",
+        threadId: "thread-2",
+        forkFromThreadId: "thread-1",
+        message: "fork",
+      }),
+    ).rejects.toBeInstanceOf(EphemeralThreadBusyError);
+
+    releaseCreation();
+    await expect(first).resolves.toEqual({ threadId: "thread-1", response: "done" });
+    expect(session.createThread).toHaveBeenCalledTimes(1);
+    expect(submittedMessages).toEqual(["first"]);
+  });
+});
 
 describe("LocalSessionHost", () => {
   it("creates, attaches, lists, snapshots, and shuts down local sessions", async () => {
@@ -1427,6 +1499,73 @@ describe("LocalSessionHost", () => {
             id: "assistant-live-race",
             message: expect.objectContaining({
               content: [{ type: "text", text: "hello world!" }],
+            }),
+          }),
+        ]),
+      }),
+    );
+  });
+
+  it("does not let a reasoning write replace streamed state at the same revision", async () => {
+    const store = new BlockingCommitStore();
+    const host = createHost(store);
+    const hostedSession = await host.createSession(localCreateInput);
+    await hostedSession.snapshot();
+    Object.defineProperty(hostedSession.runtime, "isTurnRunning", {
+      configurable: true,
+      get: () => true,
+    });
+
+    await hostedSession.enqueueRuntimeEvent({
+      type: "assistant_start",
+      historyEntryId: "assistant-reasoning-race",
+    });
+    await hostedSession.enqueueRuntimeEvent({
+      type: "assistant_partial",
+      historyEntryId: "assistant-reasoning-race",
+      snapshot: assistantPartial("hello"),
+    });
+
+    const gate = store.blockNextCommit();
+    const reasoningPromise = hostedSession.setReasoning("high");
+    await gate.started;
+
+    await hostedSession.enqueueRuntimeEvent({
+      type: "assistant_partial",
+      historyEntryId: "assistant-reasoning-race",
+      snapshot: assistantPartial("hello world"),
+    });
+    gate.release();
+
+    await expect(reasoningPromise).resolves.toEqual(
+      expect.objectContaining({
+        revision: 5,
+        settings: expect.objectContaining({ reasoning: "high" }),
+      }),
+    );
+    await expect(hostedSession.snapshot()).resolves.toEqual(
+      expect.objectContaining({
+        revision: 5,
+        settings: expect.objectContaining({ reasoning: "high" }),
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            id: "assistant-reasoning-race",
+            message: expect.objectContaining({
+              content: [{ type: "text", text: "hello world" }],
+            }),
+          }),
+        ]),
+      }),
+    );
+    await expect(store.loadSession(hostedSession.session.sessionId)).resolves.toEqual(
+      expect.objectContaining({
+        revision: 5,
+        settings: expect.objectContaining({ reasoning: "high" }),
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            id: "assistant-reasoning-race",
+            message: expect.objectContaining({
+              content: [{ type: "text", text: "hello world" }],
             }),
           }),
         ]),

--- a/test/local_session_host.test.js
+++ b/test/local_session_host.test.js
@@ -7,11 +7,9 @@ import { createLocalToolExecutionBackend, ToolCatalog } from "../dist/core/index
 import { resolveModel } from "../dist/core/models/catalog.js";
 import { personas } from "../dist/core/personas.js";
 import { prependTauUserMetadata } from "../dist/core/utils/user_metadata.js";
-import {
-  EphemeralThreadBusyError,
-  HostedEphemeralAgentSession,
-} from "../dist/host/hosted_ephemeral_agent_session.js";
+import { HostedEphemeralAgentSession } from "../dist/host/hosted_ephemeral_agent_session.js";
 import { LocalSessionHost } from "../dist/host/local_session_host.js";
+import { EphemeralThreadBusyError } from "../dist/host/session_host.js";
 import { MemorySessionStore } from "../dist/store/memory_session_store.js";
 
 const localCreateInput = {

--- a/test/rpc_server.test.js
+++ b/test/rpc_server.test.js
@@ -1,6 +1,7 @@
 import { PassThrough } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { RpcServer, runRpcServer } from "../dist/core/modes/rpc_server.js";
+import { EphemeralThreadBusyError } from "../dist/host/hosted_ephemeral_agent_session.js";
 import {
   SESSION_PROTOCOL_ERROR_CODES,
   SESSION_PROTOCOL_VERSION,
@@ -302,6 +303,12 @@ function createHarness(options = {}) {
       interruptMaintenance: vi.fn(() => false),
       waitForActiveWork: vi.fn(async () => {}),
       terminateSubagent: vi.fn(async () => ({ found: true })),
+      async submitEphemeralThread(submitOptions) {
+        if (options.submitEphemeralThread) {
+          return await options.submitEphemeralThread(submitOptions);
+        }
+        return { threadId: submitOptions.threadId, response: "done" };
+      },
       releaseTurn: () => releaseTurn?.(),
       canReleaseTurn: () => Boolean(releaseTurn),
       emitNotice: (text, revision = historyEntries.length + 1) => {
@@ -425,6 +432,35 @@ describe("rpc_server", () => {
     await harness.server.handleLine(request("list", "session.list", {}));
     const list = harness.lines.find((line) => line.type === "response" && line.id === "list");
     expect(list.result).toEqual({ sessions: [] });
+  });
+
+  it("returns busy for concurrent ephemeral thread submissions", async () => {
+    const harness = createHarness({
+      submitEphemeralThread: async ({ threadId }) => {
+        throw new EphemeralThreadBusyError(`thread '${threadId}' already has an active request`);
+      },
+    });
+
+    await harness.server.handleLine(
+      request("ephemeral-busy", "session.ephemeral.submit", {
+        sessionId: "session-1",
+        contextId: "context-1",
+        threadId: "thread-1",
+        message: "review",
+      }),
+    );
+
+    expect(
+      harness.lines.find((line) => line.type === "response" && line.id === "ephemeral-busy"),
+    ).toEqual(
+      expect.objectContaining({
+        ok: false,
+        error: {
+          code: SESSION_PROTOCOL_ERROR_CODES.busy,
+          message: "thread 'thread-1' already has an active request",
+        },
+      }),
+    );
   });
 
   it("creates additional sessions and routes requests by session id", async () => {

--- a/test/rpc_server.test.js
+++ b/test/rpc_server.test.js
@@ -1,7 +1,7 @@
 import { PassThrough } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { RpcServer, runRpcServer } from "../dist/core/modes/rpc_server.js";
-import { EphemeralThreadBusyError } from "../dist/host/hosted_ephemeral_agent_session.js";
+import { EphemeralThreadBusyError } from "../dist/host/session_host.js";
 import {
   SESSION_PROTOCOL_ERROR_CODES,
   SESSION_PROTOCOL_VERSION,


### PR DESCRIPTION
## why

Several session paths still allow concurrent work to mutate state before ownership or identity is established. Concurrent ephemeral submissions can alter a thread that reports failure, a slow snapshot write can overwrite or omit state streamed at the same revision, and malformed provider tool-call IDs can collide with Tau history or represent multiple effects with one identity.

These correspond to Nook findings 4, 6, and 53 from the `tau-findings` workspace. Their KV records must remain unresolved until this PR merges.

## what

Reject concurrent ephemeral creation, submission, and forking with the existing protocol `busy` error before thread state changes.

Track in-memory snapshot generations separately from persisted snapshots. When streaming advances state during a store write, rebuild and persist the combined canonical state at the next revision without blocking assistant partial delivery. Equal-revision write completion can no longer replace newer streamed state.

Keep provider tool-call IDs separate from Tau history-entry IDs. Duplicate or empty IDs within one streamed assistant response are replaced with unique rejected-call identities before the invalid call can execute, then handled through the existing tool-recovery path. Valid streamed calls continue executing as soon as they are complete.

## details

After merge, re-read `finding/4`, `finding/6`, and `finding/53`, preserve their current review fields, append implementation notes, and mark them resolved in Nook KV.
