### PR TITLE
serialize TUI session lifecycle

### DIFF
--- a/src/tui/chat_controller/diff_review_service.ts
+++ b/src/tui/chat_controller/diff_review_service.ts
@@ -36,8 +36,10 @@ export type DiffReviewServiceOptions = {
     diffTool: DiffToolConfig;
     signal: AbortSignal;
   }) => Promise<StartedDiffReviewBridge>;
-  onReviewReturned: (review: DiffReviewReturnedReview) => void;
+  onReviewReturned: (review: DiffReviewReturnedReview) => Promise<void>;
 };
+
+type LocalDiffReviewCallbacks = Pick<DiffReviewServiceOptions, "startSession" | "onReviewReturned">;
 
 type DiffReviewState = {
   phase: "preparing" | "active";
@@ -65,7 +67,7 @@ export class DiffReviewService {
     diffTool: DiffToolConfig;
     signal: AbortSignal;
   }) => Promise<StartedDiffReviewBridge>;
-  private readonly onReviewReturned: (review: DiffReviewReturnedReview) => void;
+  private readonly onReviewReturned: (review: DiffReviewReturnedReview) => Promise<void>;
   private state?: DiffReviewState;
 
   constructor(options: DiffReviewServiceOptions) {
@@ -93,7 +95,13 @@ export class DiffReviewService {
       : "diff review active, finish in the tool or press esc to cancel";
   }
 
-  async start(argsText: string): Promise<void> {
+  async start(
+    argsText: string,
+    callbacks: LocalDiffReviewCallbacks = {
+      startSession: this.startSession,
+      onReviewReturned: this.onReviewReturned,
+    },
+  ): Promise<void> {
     if (this.state) {
       this.view.addSystemMessage("diff review is already active.", "warn");
       return;
@@ -156,7 +164,7 @@ export class DiffReviewService {
     this.interruptLifecycle.beginBusyTask(busyTask);
 
     try {
-      const started = await this.startSession({
+      const started = await callbacks.startSession({
         source: { kind: "git_diff", diffArgs },
         diffTool,
         signal: abortController.signal,
@@ -170,7 +178,7 @@ export class DiffReviewService {
       this.attachStartedSession(state, started);
 
       const result = await started.result;
-      this.handleResult(state, result);
+      await this.handleResult(state, result, callbacks.onReviewReturned);
     } catch (error) {
       if (abortController.signal.aborted) {
         finalizeDiffReviewMessage(state, this.view, "cancelled");
@@ -312,7 +320,11 @@ export class DiffReviewService {
     this.refreshStatus();
   }
 
-  private handleResult(state: DiffReviewState, result: DiffReviewResult): void {
+  private async handleResult(
+    state: DiffReviewState,
+    result: DiffReviewResult,
+    onReviewReturned: (review: DiffReviewReturnedReview) => Promise<void>,
+  ): Promise<void> {
     if (result.status === "returned") {
       state.messageFinalized = true;
       this.view.replaceMessage(state.messageId, {
@@ -320,7 +332,7 @@ export class DiffReviewService {
         text: result.review,
         kind: "review",
       });
-      this.onReviewReturned({
+      await onReviewReturned({
         diffCommand: state.diffCommand,
         reviewedFiles: state.reviewedFiles,
         review: result.review,

--- a/src/tui/session_chat_controller.ts
+++ b/src/tui/session_chat_controller.ts
@@ -136,6 +136,7 @@ export class SessionChatController {
   private isStreaming = false;
   private submittedTurnInProgress = false;
   private manualCompactionInProgress = false;
+  private sessionReplacementInProgress = false;
   private isBashMode = false;
   private isBashIncognito = false;
   private isMemoryMode = false;
@@ -201,8 +202,8 @@ export class SessionChatController {
       startTurnTimer: () => this.startTurnTimer(),
       stopTurnTimer: () => this.stopTurnTimer(),
       getDiffToolConfig: () => this.resolveDiffToolConfig(),
-      startSession: (args) => this.startDiffReviewBridge(args),
-      onReviewReturned: (review) => void this.handleReturnedDiffReview(review),
+      startSession: (args) => this.startDiffReviewBridge(args, this.session, this.snapshot),
+      onReviewReturned: (review) => this.handleReturnedDiffReview(review, this.session),
     });
   }
 
@@ -270,7 +271,7 @@ export class SessionChatController {
       return true;
     }
 
-    if (this.manualCompactionInProgress) {
+    if (this.isBlockingSessionOperationActive()) {
       return false;
     }
 
@@ -314,6 +315,10 @@ export class SessionChatController {
     this.lastEmptySubmitAt = undefined;
 
     if (this.isSessionOperationActive()) {
+      if (this.isBlockingSessionOperationActive()) {
+        this.view.addSystemMessage("wait for tau to become idle before submitting input", "warn");
+        return;
+      }
       if (trimmed.startsWith("/") && this.isSingleLineInput(text)) {
         const parsed = this.commandRegistry.parse(trimmed);
         if (parsed.type !== "unknown") {
@@ -622,6 +627,11 @@ export class SessionChatController {
 
     if (!this.isSessionOperationActive()) {
       await this.submitUserText(trimmed);
+      return;
+    }
+
+    if (this.isBlockingSessionOperationActive()) {
+      this.view.addSystemMessage("wait for tau to become idle before submitting input", "warn");
       return;
     }
 
@@ -998,7 +1008,10 @@ export class SessionChatController {
 
   private async createNewSession(): Promise<void> {
     if (this.isSessionOperationActive()) {
-      this.view.addSystemMessage("cannot create a new session while a turn is running", "warn");
+      this.view.addSystemMessage(
+        "cannot create a new session while another session operation is running",
+        "warn",
+      );
       return;
     }
 
@@ -1007,21 +1020,38 @@ export class SessionChatController {
       return;
     }
 
+    const createInput: SessionProtocolCreateParams = {
+      executionEnvironment: this.createExecutionEnvironmentInputFromSnapshot(),
+      personaId: this.snapshot.settings.personaId,
+      ...(this.snapshot.settings.reasoning !== undefined
+        ? { reasoning: this.snapshot.settings.reasoning }
+        : {}),
+    };
+    this.sessionReplacementInProgress = true;
+    this.refreshStatus();
+
+    let nextSession: TauSdkSession | undefined;
+    let nextEventUnsubscribe: (() => void) | undefined;
+    let nextPendingUserMessagesUnsubscribe: (() => void) | undefined;
+    let installed = false;
     try {
-      const previousUnsubscribe = this.eventUnsubscribe;
-      const previousPendingUserMessagesUnsubscribe = this.pendingUserMessagesUnsubscribe;
+      nextSession = await this.createSession(createInput);
+      const nextSnapshot = await nextSession.snapshot();
+      nextEventUnsubscribe = nextSession.onDelta((delta) => this.onSdkDelta(delta));
+      nextPendingUserMessagesUnsubscribe = nextSession.onPendingUserMessages((message) =>
+        this.onSdkPendingUserMessages(message),
+      );
+
       const previousSession = this.session;
-      const nextSession = await this.createSession({
-        executionEnvironment: this.createExecutionEnvironmentInputFromSnapshot(),
-        personaId: this.snapshot.settings.personaId,
-        ...(this.snapshot.settings.reasoning !== undefined
-          ? { reasoning: this.snapshot.settings.reasoning }
-          : {}),
-      });
-      this.eventUnsubscribe = undefined;
-      this.pendingUserMessagesUnsubscribe = undefined;
-      previousUnsubscribe?.();
-      previousPendingUserMessagesUnsubscribe?.();
+      this.eventUnsubscribe?.();
+      this.pendingUserMessagesUnsubscribe?.();
+      this.session = nextSession;
+      this.snapshot = nextSnapshot;
+      this.observedSessionRevision = nextSnapshot.revision;
+      this.eventUnsubscribe = nextEventUnsubscribe;
+      this.pendingUserMessagesUnsubscribe = nextPendingUserMessagesUnsubscribe;
+      installed = true;
+
       try {
         await previousSession.unobserve();
       } catch (detachError) {
@@ -1030,21 +1060,22 @@ export class SessionChatController {
           "warn",
         );
       }
-      this.session = nextSession;
-      this.snapshot = await this.session.snapshot();
-      this.observedSessionRevision = this.snapshot.revision;
-      this.eventUnsubscribe = this.session.onDelta((delta) => this.onSdkDelta(delta));
-      this.pendingUserMessagesUnsubscribe = this.session.onPendingUserMessages((message) =>
-        this.onSdkPendingUserMessages(message),
-      );
+
       this.view.resetToolUiSession();
       this.assistantMessages = [];
       this.startLocalUiSession();
       this.addSessionIdentityMessage();
       this.renderSnapshot(this.snapshot);
-      this.refreshStatus();
     } catch (error) {
+      if (!installed && nextSession) {
+        nextEventUnsubscribe?.();
+        nextPendingUserMessagesUnsubscribe?.();
+        await nextSession.unobserve().catch(() => undefined);
+      }
       this.view.addSystemMessage(`new session failed: ${(error as Error).message}`, "error");
+    } finally {
+      this.sessionReplacementInProgress = false;
+      this.refreshStatus();
     }
   }
 
@@ -1432,7 +1463,17 @@ export class SessionChatController {
   }
 
   private isSessionOperationActive(): boolean {
-    return this.isStreaming || this.submittedTurnInProgress || this.manualCompactionInProgress;
+    return (
+      this.isStreaming || this.submittedTurnInProgress || this.isBlockingSessionOperationActive()
+    );
+  }
+
+  private isBlockingSessionOperationActive(): boolean {
+    return (
+      this.manualCompactionInProgress ||
+      this.sessionReplacementInProgress ||
+      this.diffReviewService.isActive()
+    );
   }
 
   private async recoverFromRevisionGap(): Promise<void> {
@@ -2040,18 +2081,21 @@ export class SessionChatController {
       return;
     }
 
-    await this.diffReviewService.start(argsText);
+    const session = this.session;
+    const snapshot = this.snapshot;
+    await this.diffReviewService.start(argsText, {
+      startSession: (args) => this.startDiffReviewBridge(args, session, snapshot),
+      onReviewReturned: (review) => this.handleReturnedDiffReview(review, session),
+    });
   }
 
   private isDiffReviewIdle(): boolean {
     return (
-      !this.isStreaming &&
-      !this.submittedTurnInProgress &&
+      !this.isSessionOperationActive() &&
       !this.listenRecording &&
       !this.listenTransition &&
       !this.isTranscribingListen &&
-      !this.speakTask &&
-      !this.diffReviewService.isActive()
+      !this.speakTask
     );
   }
 
@@ -2059,26 +2103,30 @@ export class SessionChatController {
     return this.config.diffTool ?? this.defaultDiffTool;
   }
 
-  private async startDiffReviewBridge(args: {
-    source: DiffReviewSnapshotSource;
-    diffTool: DiffToolConfig;
-    signal: AbortSignal;
-  }): Promise<StartedDiffReviewBridge> {
+  private async startDiffReviewBridge(
+    args: {
+      source: DiffReviewSnapshotSource;
+      diffTool: DiffToolConfig;
+      signal: AbortSignal;
+    },
+    session: TauSdkSession,
+    sessionSnapshot: SessionProtocolSnapshot,
+  ): Promise<StartedDiffReviewBridge> {
     const snapshot = await captureDiffReviewSnapshot({
-      cwd: this.snapshot.executionEnvironment.cwd,
+      cwd: sessionSnapshot.executionEnvironment.cwd,
       source: args.source,
       signal: args.signal,
-      deps: createSessionDiffReviewSnapshotDeps(this.session),
+      deps: createSessionDiffReviewSnapshotDeps(session),
     });
-    const ephemeral = await this.session.createEphemeralContext({
+    const ephemeral = await session.createEphemeralContext({
       instructions: buildDiffReviewInstructions(snapshot),
       tools: ["bash", "view_image"],
     });
     const bridge = new DiffReviewBridge({
       snapshot,
-      contextWindow: this.snapshot.bootstrap.model.contextWindow,
+      contextWindow: sessionSnapshot.bootstrap.model.contextWindow,
       submitThreadMessage: (options) =>
-        this.session.submitEphemeralThread({
+        session.submitEphemeralThread({
           contextId: ephemeral.contextId,
           threadId: options.threadId,
           ...(options.forkFromThreadId ? { forkFromThreadId: options.forkFromThreadId } : {}),
@@ -2087,7 +2135,7 @@ export class SessionChatController {
       deps: this.deps,
       ...(this.diffToolLauncher ? { toolLauncher: this.diffToolLauncher } : {}),
     });
-    const unsubscribeEphemeral = this.session.onEphemeral((message) => {
+    const unsubscribeEphemeral = session.onEphemeral((message) => {
       const event = message.event;
       if (
         event.type !== "ephemeral-agent.thread-update" ||
@@ -2111,7 +2159,7 @@ export class SessionChatController {
       await bridge.launchTool(args.diffTool);
     } catch (error) {
       unsubscribeEphemeral();
-      await this.session.closeEphemeralContext(ephemeral.contextId).catch(() => undefined);
+      await session.closeEphemeralContext(ephemeral.contextId).catch(() => undefined);
       await bridge.cancel("launch_failed").catch(() => undefined);
       await bridge.close().catch(() => undefined);
       throw error;
@@ -2119,13 +2167,16 @@ export class SessionChatController {
 
     const result = bridge.result.finally(async () => {
       unsubscribeEphemeral();
-      await this.session.closeEphemeralContext(ephemeral.contextId).catch(() => undefined);
+      await session.closeEphemeralContext(ephemeral.contextId).catch(() => undefined);
     });
 
     return { bridge, result };
   }
 
-  private async handleReturnedDiffReview(review: DiffReviewReturnedReview): Promise<void> {
+  private async handleReturnedDiffReview(
+    review: DiffReviewReturnedReview,
+    session: TauSdkSession,
+  ): Promise<void> {
     const model: ChatMessageModel = {
       type: "user",
       text: review.review,
@@ -2137,10 +2188,12 @@ export class SessionChatController {
     }
 
     try {
-      const result = await this.session.record(formatDiffReviewUserMessage(review), {
+      const result = await session.record(formatDiffReviewUserMessage(review), {
         historyEntryId: review.historyEntryId,
       });
-      this.syncRenderedHistory(result.snapshot);
+      if (this.session === session) {
+        this.syncRenderedHistory(result.snapshot);
+      }
     } catch (error) {
       this.view.addSystemMessage(
         `failed to add diff review to session: ${(error as Error).message}`,

--- a/src/tui/session_chat_controller.ts
+++ b/src/tui/session_chat_controller.ts
@@ -136,6 +136,7 @@ export class SessionChatController {
   private isStreaming = false;
   private submittedTurnInProgress = false;
   private manualCompactionInProgress = false;
+  private localDiffReviewInProgress = false;
   private sessionReplacementInProgress = false;
   private isBashMode = false;
   private isBashIncognito = false;
@@ -1037,10 +1038,23 @@ export class SessionChatController {
     try {
       nextSession = await this.createSession(createInput);
       const nextSnapshot = await nextSession.snapshot();
-      nextEventUnsubscribe = nextSession.onDelta((delta) => this.onSdkDelta(delta));
-      nextPendingUserMessagesUnsubscribe = nextSession.onPendingUserMessages((message) =>
-        this.onSdkPendingUserMessages(message),
-      );
+      const pendingDeltas: SessionProtocolDeltaMessage[] = [];
+      const pendingUserMessages: SessionProtocolPendingUserMessagesMessage[] = [];
+      let forwardEvents = false;
+      nextEventUnsubscribe = nextSession.onDelta((delta) => {
+        if (forwardEvents) {
+          this.onSdkDelta(delta);
+        } else {
+          pendingDeltas.push(delta);
+        }
+      });
+      nextPendingUserMessagesUnsubscribe = nextSession.onPendingUserMessages((message) => {
+        if (forwardEvents) {
+          this.onSdkPendingUserMessages(message);
+        } else {
+          pendingUserMessages.push(message);
+        }
+      });
 
       const previousSession = this.session;
       this.eventUnsubscribe?.();
@@ -1052,6 +1066,19 @@ export class SessionChatController {
       this.pendingUserMessagesUnsubscribe = nextPendingUserMessagesUnsubscribe;
       installed = true;
 
+      this.view.resetToolUiSession();
+      this.assistantMessages = [];
+      this.startLocalUiSession();
+      this.addSessionIdentityMessage();
+      this.renderSnapshot(this.snapshot);
+      for (const delta of pendingDeltas) {
+        this.onSdkDelta(delta);
+      }
+      for (const message of pendingUserMessages) {
+        this.onSdkPendingUserMessages(message);
+      }
+      forwardEvents = true;
+
       try {
         await previousSession.unobserve();
       } catch (detachError) {
@@ -1060,12 +1087,6 @@ export class SessionChatController {
           "warn",
         );
       }
-
-      this.view.resetToolUiSession();
-      this.assistantMessages = [];
-      this.startLocalUiSession();
-      this.addSessionIdentityMessage();
-      this.renderSnapshot(this.snapshot);
     } catch (error) {
       if (!installed && nextSession) {
         nextEventUnsubscribe?.();
@@ -1471,8 +1492,8 @@ export class SessionChatController {
   private isBlockingSessionOperationActive(): boolean {
     return (
       this.manualCompactionInProgress ||
-      this.sessionReplacementInProgress ||
-      this.diffReviewService.isActive()
+      this.localDiffReviewInProgress ||
+      this.sessionReplacementInProgress
     );
   }
 
@@ -2083,10 +2104,17 @@ export class SessionChatController {
 
     const session = this.session;
     const snapshot = this.snapshot;
-    await this.diffReviewService.start(argsText, {
-      startSession: (args) => this.startDiffReviewBridge(args, session, snapshot),
-      onReviewReturned: (review) => this.handleReturnedDiffReview(review, session),
-    });
+    this.localDiffReviewInProgress = true;
+    this.refreshStatus();
+    try {
+      await this.diffReviewService.start(argsText, {
+        startSession: (args) => this.startDiffReviewBridge(args, session, snapshot),
+        onReviewReturned: (review) => this.handleReturnedDiffReview(review, session),
+      });
+    } finally {
+      this.localDiffReviewInProgress = false;
+      this.refreshStatus();
+    }
   }
 
   private isDiffReviewIdle(): boolean {

--- a/test/session_chat_controller.test.js
+++ b/test/session_chat_controller.test.js
@@ -3239,6 +3239,52 @@ describe("SessionChatController", () => {
     );
   });
 
+  it("blocks prompts and session replacement until a local diff review is recorded", async () => {
+    const session = new FakeSession();
+    const nextSession = new FakeSession();
+    const createSession = vi.fn(async () => nextSession);
+    const recordStarted = deferred();
+    const releaseRecord = deferred();
+    const record = session.record;
+    session.record = vi.fn(async (...args) => {
+      recordStarted.resolve();
+      await releaseRecord.promise;
+      return await record(...args);
+    });
+    const view = new FakeView();
+    const controller = new SessionChatController({
+      view,
+      session,
+      snapshot: await session.snapshot(),
+      createSession,
+      targetLabel: "ssh host tau rpc",
+      defaultDiffTool: { command: "inline-diff-tool" },
+      diffToolLauncher: launchInlineDiffTool,
+    });
+    controller.start();
+
+    const review = controller.onUserInput("/diff -- src/main.ts");
+    await recordStarted.promise;
+
+    await controller.onUserInput("start another turn");
+    await controller.onUserInput("/new");
+
+    expect(session.submit).not.toHaveBeenCalled();
+    expect(session.queue).not.toHaveBeenCalled();
+    expect(createSession).not.toHaveBeenCalled();
+    expect(view.systems).toContainEqual({
+      text: "wait for tau to become idle before submitting input",
+      kind: "warn",
+      options: undefined,
+    });
+
+    releaseRecord.resolve();
+    await review;
+
+    expect(session.record).toHaveBeenCalledTimes(1);
+    expect(session.closeEphemeralContext).toHaveBeenCalledWith("ephemeral-1");
+  });
+
   it("shows the diff review card while a model-launched diff_review tool is active", async () => {
     const session = new FakeSession();
     const view = new FakeView();
@@ -3637,6 +3683,75 @@ describe("SessionChatController", () => {
     expect(view.systems).toContainEqual(
       expect.objectContaining({ text: "session id: session-2", kind: "muted" }),
     );
+  });
+
+  it("serializes concurrent new-session requests", async () => {
+    const session = new FakeSession();
+    const nextSession = new FakeSession();
+    nextSession.id = "session-2";
+    nextSession.snapshotValue = {
+      ...nextSession.snapshotValue,
+      sessionId: "session-2",
+    };
+    const sessionCreated = deferred();
+    const createSession = vi.fn(async () => await sessionCreated.promise);
+    const view = new FakeView();
+    const controller = new SessionChatController({
+      view,
+      session,
+      snapshot: await session.snapshot(),
+      createSession,
+      targetLabel: "ssh host tau rpc",
+    });
+    controller.start();
+
+    const firstNewSession = controller.onUserInput("/new");
+    await waitUntil(() => createSession.mock.calls.length === 1);
+    await controller.onUserInput("/new");
+
+    expect(createSession).toHaveBeenCalledTimes(1);
+    expect(session.unobserve).not.toHaveBeenCalled();
+    expect(view.systems).toContainEqual({
+      text: "wait for tau to become idle before submitting input",
+      kind: "warn",
+      options: undefined,
+    });
+
+    sessionCreated.resolve(nextSession);
+    await firstNewSession;
+
+    expect(session.unobserve).toHaveBeenCalledTimes(1);
+    expect(nextSession.listeners.size).toBe(1);
+    expect(nextSession.pendingUserMessagesListeners.size).toBe(1);
+  });
+
+  it("unobserves a newly created session when its initial snapshot fails", async () => {
+    const session = new FakeSession();
+    const nextSession = new FakeSession();
+    nextSession.snapshot = vi.fn(async () => {
+      throw new Error("snapshot unavailable");
+    });
+    const createSession = vi.fn(async () => nextSession);
+    const view = new FakeView();
+    const controller = new SessionChatController({
+      view,
+      session,
+      snapshot: await session.snapshot(),
+      createSession,
+      targetLabel: "ssh host tau rpc",
+    });
+    controller.start();
+
+    await controller.onUserInput("/new");
+
+    expect(nextSession.unobserve).toHaveBeenCalledTimes(1);
+    expect(session.unobserve).not.toHaveBeenCalled();
+    expect(session.listeners.size).toBe(1);
+    expect(view.systems).toContainEqual({
+      text: "new session failed: snapshot unavailable",
+      kind: "error",
+      options: undefined,
+    });
   });
 
   it("rewinds session history from the selected user message", async () => {

--- a/test/session_chat_controller.test.js
+++ b/test/session_chat_controller.test.js
@@ -3285,7 +3285,7 @@ describe("SessionChatController", () => {
     expect(session.closeEphemeralContext).toHaveBeenCalledWith("ephemeral-1");
   });
 
-  it("shows the diff review card while a model-launched diff_review tool is active", async () => {
+  it("keeps an active model-launched diff review visible and steerable", async () => {
     const session = new FakeSession();
     const view = new FakeView();
     const controller = new SessionChatController({
@@ -3310,6 +3310,20 @@ describe("SessionChatController", () => {
           message.model.status === "active" &&
           message.model.uiText === "http://127.0.0.1:4321",
       ),
+    );
+
+    controller.isStreaming = true;
+    await controller.onUserInput("queue after review");
+    controller.getInputHandlers().onSteerSubmit?.("adjust the review");
+    await flush();
+
+    expect(session.queue).toHaveBeenCalledWith(
+      "queue after review",
+      expect.objectContaining({ historyEntryId: expect.stringMatching(/^session-queue-/) }),
+    );
+    expect(session.steer).toHaveBeenCalledWith(
+      "adjust the review",
+      expect.objectContaining({ historyEntryId: expect.stringMatching(/^session-steer-/) }),
     );
 
     await expect(result).resolves.toContain("Diff review completed.");
@@ -3683,6 +3697,53 @@ describe("SessionChatController", () => {
     expect(view.systems).toContainEqual(
       expect.objectContaining({ text: "session id: session-2", kind: "muted" }),
     );
+  });
+
+  it("applies replacement-session deltas buffered during listener installation", async () => {
+    const session = new FakeSession(updateSnapshot(createSnapshot(), { revision: 10 }));
+    const nextSession = new FakeSession();
+    nextSession.id = "session-2";
+    nextSession.snapshotValue = {
+      ...nextSession.snapshotValue,
+      sessionId: "session-2",
+    };
+    const message = {
+      id: "next-session-message",
+      state: "committed",
+      modelVisible: true,
+      message: { role: "user", content: [{ type: "text", text: "arrived during handoff" }] },
+    };
+    const delta = createMessageAppendDelta(
+      nextSession.id,
+      nextSession.snapshotValue.revision,
+      message,
+    );
+    nextSession.onDelta = vi.fn((listener) => {
+      nextSession.listeners.add(listener);
+      nextSession.snapshotValue = applySessionProtocolDelta(nextSession.snapshotValue, delta);
+      listener(delta);
+      return () => nextSession.listeners.delete(listener);
+    });
+    const view = new FakeView();
+    const controller = new SessionChatController({
+      view,
+      session,
+      snapshot: await session.snapshot(),
+      createSession: vi.fn(async () => nextSession),
+      targetLabel: "ssh host tau rpc",
+    });
+    controller.start();
+
+    await controller.onUserInput("/new");
+
+    const dividerIndex = view.messages.findIndex((entry) => entry.model.type === "session_divider");
+    const messageIndex = view.messages.findIndex((entry) => entry.id === message.id);
+    expect(dividerIndex).toBeGreaterThanOrEqual(0);
+    expect(messageIndex).toBeGreaterThan(dividerIndex);
+    expect(view.messages[messageIndex]).toEqual({
+      id: message.id,
+      model: { type: "user", text: "arrived during handoff" },
+    });
   });
 
   it("serializes concurrent new-session requests", async () => {


### PR DESCRIPTION
## why

Local diff reviews and session replacement were not part of one controller-owned operation lifecycle. A review could return into a replaced session or interrupt newer work while recording, and concurrent `/new` requests could race to install sessions and listeners.

## what

Treats local diff review and session replacement as blocking controller operations. Diff review callbacks retain the originating SDK session through snapshot capture, ephemeral work, cleanup, and returned-review recording, and the review remains active until recording settles.

Serializes `/new` from request start through installation, prepares the replacement snapshot before detaching the current session, and cleans up a newly created session if preparation fails. Regression coverage exercises input and `/new` during review recording, concurrent replacement requests, and failed replacement initialization.
