### PR TITLE
harden local persistence

### DIFF
--- a/src/core/auth/auth_storage.ts
+++ b/src/core/auth/auth_storage.ts
@@ -1,6 +1,18 @@
 import { randomUUID } from "node:crypto";
-import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
-import { dirname } from "node:path";
+import type { Stats } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, join } from "node:path";
 import { z } from "zod";
 import type { AuthStorageData } from "./types.js";
 
@@ -60,60 +72,263 @@ const authStorageDataSchema = z
   })
   .passthrough();
 
+type AuthLockOwner = {
+  pid: number;
+  token: string;
+  createdAt: number;
+};
+
+const PRIVATE_DIRECTORY_MODE = 0o700;
+const PRIVATE_FILE_MODE = 0o600;
+const AUTH_LOCK_OWNER_FILENAME = "owner.json";
+const AUTH_LOCK_TIMEOUT_MS = 30_000;
+const AUTH_LOCK_RETRY_MS = 10;
+const AUTH_INCOMPLETE_LOCK_STALE_MS = 1_000;
+const UUID_PATTERN = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
+
 export class AuthStorage {
   private data: AuthStorageData = { providers: {} };
   private invalidReason: string | undefined;
+  private readonly authDirectory: string;
+  private readonly lockPath: string;
+  private readonly tempFilePattern: RegExp;
 
   constructor(private readonly authPath: string) {
+    this.authDirectory = dirname(authPath);
+    this.lockPath = `${authPath}.lock`;
+    this.tempFilePattern = new RegExp(
+      `^${escapeRegExp(basename(authPath))}\\.${UUID_PATTERN}\\.tmp$`,
+    );
     this.reload();
   }
 
   reload(): void {
-    if (!existsSync(this.authPath)) {
-      this.data = { providers: {} };
-      this.invalidReason = undefined;
-      return;
-    }
-
     try {
-      const parsed = JSON.parse(readFileSync(this.authPath, "utf-8")) as unknown;
-      const validated = validateAuthStorageData(parsed);
-      this.data = validated.data;
-      this.invalidReason = validated.invalidReason;
+      this.withLock(() => {
+        this.cleanupTemporaryFiles();
+        this.loadUnlocked();
+      });
     } catch (error) {
       this.data = { providers: {} };
-      this.invalidReason = `failed to parse auth.json: ${(error as Error)?.message ?? String(error)}`;
+      this.invalidReason = `failed to load auth.json: ${formatError(error)}`;
     }
-  }
-
-  private save(): void {
-    const dir = dirname(this.authPath);
-    if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
-
-    const tmpPath = `${this.authPath}.${randomUUID()}.tmp`;
-    writeFileSync(tmpPath, JSON.stringify(this.data, null, 2), { encoding: "utf-8", mode: 0o600 });
-    renameSync(tmpPath, this.authPath);
-    chmodSync(this.authPath, 0o600);
   }
 
   getData(): AuthStorageData {
     return this.data;
   }
 
-  setData(data: AuthStorageData): void {
-    this.data = data;
-    this.invalidReason = undefined;
-    this.save();
-  }
-
-  update(mutator: (data: AuthStorageData) => void): void {
-    mutator(this.data);
-    this.invalidReason = undefined;
-    this.save();
+  update<T>(mutator: (data: AuthStorageData) => T): T {
+    return this.withLock(() => {
+      this.cleanupTemporaryFiles();
+      this.loadUnlocked();
+      const result = mutator(this.data);
+      this.invalidReason = undefined;
+      this.saveUnlocked();
+      return result;
+    });
   }
 
   getInvalidReason(): string | undefined {
     return this.invalidReason;
+  }
+
+  private loadUnlocked(): void {
+    if (!existsSync(this.authPath)) {
+      this.data = { providers: {} };
+      this.invalidReason = undefined;
+      return;
+    }
+
+    const metadata = lstatSync(this.authPath);
+    assertSafeStorageEntry(this.authPath, metadata, "file");
+    chmodSync(this.authPath, PRIVATE_FILE_MODE);
+
+    try {
+      const parsed = JSON.parse(readFileSync(this.authPath, "utf8")) as unknown;
+      const validated = validateAuthStorageData(parsed);
+      this.data = validated.data;
+      this.invalidReason = validated.invalidReason;
+    } catch (error) {
+      this.data = { providers: {} };
+      this.invalidReason = `failed to parse auth.json: ${formatError(error)}`;
+    }
+  }
+
+  private saveUnlocked(): void {
+    const tmpPath = `${this.authPath}.${randomUUID()}.tmp`;
+    try {
+      writeFileSync(tmpPath, JSON.stringify(this.data, null, 2), {
+        encoding: "utf8",
+        flag: "wx",
+        mode: PRIVATE_FILE_MODE,
+      });
+      renameSync(tmpPath, this.authPath);
+      chmodSync(this.authPath, PRIVATE_FILE_MODE);
+    } finally {
+      rmSync(tmpPath, { force: true });
+    }
+  }
+
+  private cleanupTemporaryFiles(): void {
+    for (const entry of readdirSync(this.authDirectory)) {
+      if (!this.tempFilePattern.test(entry)) {
+        continue;
+      }
+      const path = join(this.authDirectory, entry);
+      let metadata: Stats;
+      try {
+        metadata = lstatSync(path);
+      } catch (error) {
+        if (isNotFound(error)) continue;
+        throw error;
+      }
+      if (!metadata.isFile() || !isOwnedByCurrentUser(metadata.uid)) {
+        continue;
+      }
+      rmSync(path, { force: true });
+    }
+  }
+
+  private withLock<T>(handler: () => T): T {
+    ensureSecureDirectory(this.authDirectory);
+    const owner = acquireAuthLock(this.lockPath);
+    try {
+      return handler();
+    } finally {
+      releaseAuthLock(this.lockPath, owner);
+    }
+  }
+}
+
+function ensureSecureDirectory(path: string): void {
+  if (!existsSync(path)) {
+    mkdirSync(path, { recursive: true, mode: PRIVATE_DIRECTORY_MODE });
+  }
+  const metadata = lstatSync(path);
+  assertSafeStorageEntry(path, metadata, "directory");
+  chmodSync(path, PRIVATE_DIRECTORY_MODE);
+}
+
+function assertSafeStorageEntry(path: string, metadata: Stats, type: "file" | "directory"): void {
+  const matchesType = type === "file" ? metadata.isFile() : metadata.isDirectory();
+  if (metadata.isSymbolicLink() || !matchesType) {
+    throw new Error(`auth storage ${type} is not a regular ${type}: ${path}`);
+  }
+  if (!isOwnedByCurrentUser(metadata.uid)) {
+    throw new Error(`auth storage ${type} is not owned by the current user: ${path}`);
+  }
+}
+
+function acquireAuthLock(lockPath: string): AuthLockOwner {
+  const owner: AuthLockOwner = {
+    pid: process.pid,
+    token: randomUUID(),
+    createdAt: Date.now(),
+  };
+  const startedAt = Date.now();
+
+  while (true) {
+    try {
+      mkdirSync(lockPath, { mode: PRIVATE_DIRECTORY_MODE });
+      try {
+        writeFileSync(join(lockPath, AUTH_LOCK_OWNER_FILENAME), JSON.stringify(owner), {
+          encoding: "utf8",
+          flag: "wx",
+          mode: PRIVATE_FILE_MODE,
+        });
+      } catch (error) {
+        rmSync(lockPath, { recursive: true, force: true });
+        throw error;
+      }
+      return owner;
+    } catch (error) {
+      if (!isAlreadyExists(error)) {
+        throw error;
+      }
+      if (recoverStaleAuthLock(lockPath)) {
+        continue;
+      }
+      if (Date.now() - startedAt >= AUTH_LOCK_TIMEOUT_MS) {
+        throw new Error("timed out waiting for auth storage lock");
+      }
+      sleepSync(AUTH_LOCK_RETRY_MS);
+    }
+  }
+}
+
+function recoverStaleAuthLock(lockPath: string): boolean {
+  const owner = readAuthLockOwner(lockPath);
+  if (owner) {
+    if (isProcessAlive(owner.pid)) {
+      return false;
+    }
+    return quarantineStaleAuthLock(lockPath);
+  }
+
+  let lockStat: Stats;
+  try {
+    lockStat = statSync(lockPath);
+  } catch (error) {
+    if (isNotFound(error)) {
+      return true;
+    }
+    throw error;
+  }
+  if (Date.now() - lockStat.mtimeMs < AUTH_INCOMPLETE_LOCK_STALE_MS) {
+    return false;
+  }
+  return quarantineStaleAuthLock(lockPath);
+}
+
+function quarantineStaleAuthLock(lockPath: string): boolean {
+  const stalePath = `${lockPath}.stale.${randomUUID()}`;
+  try {
+    renameSync(lockPath, stalePath);
+  } catch (error) {
+    if (isNotFound(error)) {
+      return true;
+    }
+    throw error;
+  }
+  rmSync(stalePath, { recursive: true, force: true });
+  return true;
+}
+
+function releaseAuthLock(lockPath: string, expectedOwner: AuthLockOwner): void {
+  const owner = readAuthLockOwner(lockPath);
+  if (owner?.token !== expectedOwner.token) {
+    return;
+  }
+  rmSync(lockPath, { recursive: true, force: true });
+}
+
+function readAuthLockOwner(lockPath: string): AuthLockOwner | undefined {
+  let raw: string;
+  try {
+    raw = readFileSync(join(lockPath, AUTH_LOCK_OWNER_FILENAME), "utf8");
+  } catch (error) {
+    if (isNotFound(error)) {
+      return undefined;
+    }
+    throw error;
+  }
+
+  try {
+    const value = JSON.parse(raw) as Partial<AuthLockOwner>;
+    if (
+      !Number.isInteger(value.pid) ||
+      (value.pid ?? 0) <= 0 ||
+      typeof value.token !== "string" ||
+      value.token.length === 0 ||
+      typeof value.createdAt !== "number" ||
+      !Number.isFinite(value.createdAt)
+    ) {
+      return undefined;
+    }
+    return value as AuthLockOwner;
+  } catch {
+    return undefined;
   }
 }
 
@@ -133,4 +348,42 @@ function validateAuthStorageData(value: unknown): {
 
 function invalidAuthStorage(): { data: AuthStorageData; invalidReason: string } {
   return { data: { providers: {} }, invalidReason: invalidAuthStorageFormatReason };
+}
+
+function isOwnedByCurrentUser(uid: number): boolean {
+  return typeof process.getuid !== "function" || uid === process.getuid();
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return !(
+      error instanceof Error &&
+      "code" in error &&
+      (error.code === "ESRCH" || error.code === "EINVAL")
+    );
+  }
+}
+
+function sleepSync(ms: number): void {
+  const signal = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+  Atomics.wait(signal, 0, 0, ms);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isNotFound(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+function isAlreadyExists(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "EEXIST";
 }

--- a/src/core/auth/auth_storage.ts
+++ b/src/core/auth/auth_storage.ts
@@ -226,34 +226,39 @@ function acquireAuthLock(lockPath: string): AuthLockOwner {
     token: randomUUID(),
     createdAt: Date.now(),
   };
+  const candidatePath = `${lockPath}.candidate.${owner.token}`;
   const startedAt = Date.now();
 
-  while (true) {
-    try {
-      mkdirSync(lockPath, { mode: PRIVATE_DIRECTORY_MODE });
+  try {
+    mkdirSync(candidatePath, { mode: PRIVATE_DIRECTORY_MODE });
+    chmodSync(candidatePath, PRIVATE_DIRECTORY_MODE);
+    const ownerPath = join(candidatePath, AUTH_LOCK_OWNER_FILENAME);
+    writeFileSync(ownerPath, JSON.stringify(owner), {
+      encoding: "utf8",
+      flag: "wx",
+      mode: PRIVATE_FILE_MODE,
+    });
+    chmodSync(ownerPath, PRIVATE_FILE_MODE);
+
+    while (true) {
       try {
-        writeFileSync(join(lockPath, AUTH_LOCK_OWNER_FILENAME), JSON.stringify(owner), {
-          encoding: "utf8",
-          flag: "wx",
-          mode: PRIVATE_FILE_MODE,
-        });
+        renameSync(candidatePath, lockPath);
+        return owner;
       } catch (error) {
-        rmSync(lockPath, { recursive: true, force: true });
-        throw error;
+        if (!isLockExists(error)) {
+          throw error;
+        }
+        if (recoverStaleAuthLock(lockPath)) {
+          continue;
+        }
+        if (Date.now() - startedAt >= AUTH_LOCK_TIMEOUT_MS) {
+          throw new Error("timed out waiting for auth storage lock");
+        }
+        sleepSync(AUTH_LOCK_RETRY_MS);
       }
-      return owner;
-    } catch (error) {
-      if (!isAlreadyExists(error)) {
-        throw error;
-      }
-      if (recoverStaleAuthLock(lockPath)) {
-        continue;
-      }
-      if (Date.now() - startedAt >= AUTH_LOCK_TIMEOUT_MS) {
-        throw new Error("timed out waiting for auth storage lock");
-      }
-      sleepSync(AUTH_LOCK_RETRY_MS);
     }
+  } finally {
+    rmSync(candidatePath, { recursive: true, force: true });
   }
 }
 
@@ -384,6 +389,10 @@ function isNotFound(error: unknown): boolean {
   return error instanceof Error && "code" in error && error.code === "ENOENT";
 }
 
-function isAlreadyExists(error: unknown): boolean {
-  return error instanceof Error && "code" in error && error.code === "EEXIST";
+function isLockExists(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error.code === "EEXIST" || error.code === "ENOTEMPTY")
+  );
 }

--- a/src/core/auth/credential_store.ts
+++ b/src/core/auth/credential_store.ts
@@ -41,23 +41,38 @@ export class TauCredentialStore implements CredentialStore {
       return current?.credential;
     }
 
-    this.options.authStorage.update((data) => {
-      if (!data.providers[providerId]) {
-        data.providers[providerId] = { accounts: [] };
+    const accountId =
+      current?.accountId ?? getCredentialAccountId(next) ?? getDefaultAccountId(providerId);
+    const expected = current
+      ? storedAccountFromCredential(current.credential, current.accountId)
+      : undefined;
+    const nextAccount = storedAccountFromCredential(next, accountId);
+    const stored = this.options.authStorage.update((data): StoredAccount | undefined => {
+      const provider = data.providers[providerId];
+      const existing = provider?.accounts.find((entry) => entry.accountId === accountId);
+      if (expected) {
+        if (!existing) {
+          return undefined;
+        }
+        if (!hasSameStoredCredentialGeneration(existing, expected)) {
+          return existing;
+        }
+      } else if (existing) {
+        return existing;
       }
-      const provider = data.providers[providerId]!;
-      const accountId =
-        current?.accountId ?? getCredentialAccountId(next) ?? getDefaultAccountId(providerId);
-      const account = storedAccountFromCredential(next, accountId);
-      const existingIndex = provider.accounts.findIndex((entry) => entry.accountId === accountId);
+
+      const target = provider ?? { accounts: [] };
+      data.providers[providerId] = target;
+      const existingIndex = target.accounts.findIndex((entry) => entry.accountId === accountId);
       if (existingIndex >= 0) {
-        provider.accounts[existingIndex] = account;
+        target.accounts[existingIndex] = nextAccount;
       } else {
-        provider.accounts = [account];
+        target.accounts.push(nextAccount);
       }
+      return nextAccount;
     });
 
-    return next;
+    return stored ? credentialFromStoredAccount(stored) : undefined;
   }
 
   async delete(providerId: string): Promise<void> {
@@ -165,6 +180,26 @@ function credentialFromStoredAccount(account: StoredAccount): Credential {
     ...(account.enterpriseUrl ? { enterpriseUrl: account.enterpriseUrl } : {}),
     ...(account.projectId ? { projectId: account.projectId } : {}),
   };
+}
+
+function hasSameStoredCredentialGeneration(a: StoredAccount, b: StoredAccount): boolean {
+  if (a.type !== b.type || a.accountId !== b.accountId) {
+    return false;
+  }
+  if (a.type === "api_key" && b.type === "api_key") {
+    return a.key === b.key;
+  }
+  if (a.type !== "oauth" || b.type !== "oauth") {
+    return false;
+  }
+  return (
+    a.providerAccountId === b.providerAccountId &&
+    a.access === b.access &&
+    a.refresh === b.refresh &&
+    a.expires === b.expires &&
+    a.enterpriseUrl === b.enterpriseUrl &&
+    a.projectId === b.projectId
+  );
 }
 
 function storedAccountFromCredential(credential: Credential, accountId: string): StoredAccount {

--- a/src/core/auth/providers/openai_codex.ts
+++ b/src/core/auth/providers/openai_codex.ts
@@ -85,15 +85,21 @@ export class OpenAICodexAdapter implements AuthProviderAdapter {
     const accounts = getAccounts(authStorage);
     if (accounts.length === 0) return [];
 
-    return Promise.all(
-      accounts.map(async (account) => {
+    const accountInfo = await Promise.all(
+      accounts.map(async (account): Promise<AuthAccountInfo | undefined> => {
         const refreshedAccount = await this.refreshAccountIdentity(authStorage, account);
+        if (!refreshedAccount) {
+          return undefined;
+        }
         const usage = await this.getUsageSnapshot(authStorage, refreshedAccount, {
           forceRefresh: true,
         });
-        const currentAccount =
-          getAccounts(authStorage).find((entry) => entry.accountId === account.accountId) ??
-          refreshedAccount;
+        const currentAccount = getAccounts(authStorage).find(
+          (entry) => entry.accountId === account.accountId,
+        );
+        if (!currentAccount) {
+          return undefined;
+        }
         const identity = decodeIdentity(currentAccount.access);
         return {
           provider: PROVIDER_ID,
@@ -104,6 +110,7 @@ export class OpenAICodexAdapter implements AuthProviderAdapter {
         } satisfies AuthAccountInfo;
       }),
     );
+    return accountInfo.filter((account): account is AuthAccountInfo => account !== undefined);
   }
 
   async selectAccount(authStorage: AuthStorage): Promise<AuthProviderSelection | undefined> {
@@ -169,10 +176,13 @@ export class OpenAICodexAdapter implements AuthProviderAdapter {
     });
     if (!result) return undefined;
 
-    if (shouldUpdateAccount(account, result.newCredentials)) {
-      updateStoredOAuthAccount(authStorage, account.accountId, (current) =>
-        mergeUpdatedCredentials(current, result.newCredentials),
-      );
+    const updateResult = updateStoredOAuthAccount(authStorage, account, (current) =>
+      shouldUpdateAccount(current, result.newCredentials)
+        ? mergeUpdatedCredentials(current, result.newCredentials)
+        : current,
+    );
+    if (updateResult.status !== "updated") {
+      return undefined;
     }
 
     return result.apiKey;
@@ -229,23 +239,18 @@ export class OpenAICodexAdapter implements AuthProviderAdapter {
   private async refreshAccountIdentity(
     authStorage: AuthStorage,
     account: CodexAccount,
-  ): Promise<CodexAccount> {
+  ): Promise<CodexAccount | undefined> {
     try {
       const refreshedCredentials = await refreshOpenAICodexToken(account.refresh);
-      const refreshedAccount = mergeUpdatedCredentials(account, refreshedCredentials);
-      if (shouldUpdateAccount(account, refreshedCredentials)) {
-        updateStoredOAuthAccount(authStorage, account.accountId, (current) =>
-          mergeUpdatedCredentials(current, refreshedCredentials),
-        );
-      }
-      return (
-        getAccounts(authStorage).find((entry) => entry.accountId === account.accountId) ??
-        refreshedAccount
+      const updateResult = updateStoredOAuthAccount(authStorage, account, (current) =>
+        shouldUpdateAccount(current, refreshedCredentials)
+          ? mergeUpdatedCredentials(current, refreshedCredentials)
+          : current,
       );
+      return updateResult.status === "missing" ? undefined : updateResult.account;
     } catch {
-      return (
-        getAccounts(authStorage).find((entry) => entry.accountId === account.accountId) ?? account
-      );
+      authStorage.reload();
+      return getAccounts(authStorage).find((entry) => entry.accountId === account.accountId);
     }
   }
 
@@ -260,7 +265,7 @@ export class OpenAICodexAdapter implements AuthProviderAdapter {
     },
   ): Promise<AuthAccountUsage | undefined> {
     const now = nowSeconds();
-    let usage = account.usage;
+    const usage = account.usage;
     const shouldRefresh =
       Boolean(options?.forceRefresh) ||
       (Boolean(options?.refreshIfMissing) && !usage) ||
@@ -277,12 +282,14 @@ export class OpenAICodexAdapter implements AuthProviderAdapter {
       const refreshedUsage = await fetchUsage(apiKey, refreshedAccount.providerAccountId);
       if (!refreshedUsage) return usage;
 
-      usage = refreshedUsage;
-      updateStoredOAuthAccount(authStorage, account.accountId, (current) => ({
+      const updateResult = updateStoredOAuthAccount(authStorage, refreshedAccount, (current) => ({
         ...current,
         usage: refreshedUsage,
       }));
-      return usage;
+      if (updateResult.status === "missing") {
+        return undefined;
+      }
+      return updateResult.status === "changed" ? updateResult.account.usage : refreshedUsage;
     } catch (error) {
       if (error instanceof UnexpectedUsageWindowError) {
         throw error;
@@ -534,22 +541,45 @@ function hasActivePrimaryWindow(usage: AuthAccountUsage | undefined, now: number
   return Boolean(primary && primary.resetAt > now);
 }
 
+type StoredOAuthAccountUpdateResult =
+  | { status: "missing" }
+  | { status: "changed"; account: CodexAccount }
+  | { status: "updated"; account: CodexAccount };
+
 function updateStoredOAuthAccount(
   authStorage: AuthStorage,
-  accountId: string,
+  expected: CodexAccount,
   update: (account: CodexAccount) => CodexAccount,
-): void {
-  authStorage.update((data) => {
+): StoredOAuthAccountUpdateResult {
+  return authStorage.update((data): StoredOAuthAccountUpdateResult => {
     const accounts = ensureProvider(data, PROVIDER_ID).accounts;
     const index = accounts.findIndex(
-      (entry) => entry.type === "oauth" && entry.accountId === accountId,
+      (entry) => entry.type === "oauth" && entry.accountId === expected.accountId,
     );
-    if (index < 0) return;
+    if (index < 0) return { status: "missing" };
 
     const account = accounts[index];
-    if (account?.type !== "oauth") return;
-    accounts[index] = update(account);
+    if (account?.type !== "oauth") return { status: "missing" };
+    if (!hasSameCredentialGeneration(account, expected)) {
+      return { status: "changed", account };
+    }
+
+    const updated = update(account);
+    accounts[index] = updated;
+    return { status: "updated", account: updated };
   });
+}
+
+function hasSameCredentialGeneration(a: CodexAccount, b: CodexAccount): boolean {
+  return (
+    a.accountId === b.accountId &&
+    a.providerAccountId === b.providerAccountId &&
+    a.access === b.access &&
+    a.refresh === b.refresh &&
+    a.expires === b.expires &&
+    a.enterpriseUrl === b.enterpriseUrl &&
+    a.projectId === b.projectId
+  );
 }
 
 function clampPercent(value: unknown): number {

--- a/src/store/file_session_store.ts
+++ b/src/store/file_session_store.ts
@@ -219,34 +219,39 @@ async function acquireSnapshotLock(
     token: randomUUID(),
     createdAt: Date.now(),
   };
+  const candidatePath = `${lockPath}.candidate.${owner.token}`;
   const startedAt = Date.now();
 
-  while (true) {
-    try {
-      await mkdir(lockPath, { mode: PRIVATE_DIRECTORY_MODE });
+  try {
+    await mkdir(candidatePath, { mode: PRIVATE_DIRECTORY_MODE });
+    await chmod(candidatePath, PRIVATE_DIRECTORY_MODE);
+    const ownerPath = join(candidatePath, SNAPSHOT_LOCK_OWNER_FILENAME);
+    await writeFile(ownerPath, JSON.stringify(owner), {
+      encoding: "utf8",
+      flag: "wx",
+      mode: PRIVATE_FILE_MODE,
+    });
+    await chmod(ownerPath, PRIVATE_FILE_MODE);
+
+    while (true) {
       try {
-        await writeFile(join(lockPath, SNAPSHOT_LOCK_OWNER_FILENAME), JSON.stringify(owner), {
-          encoding: "utf8",
-          flag: "wx",
-          mode: PRIVATE_FILE_MODE,
-        });
+        await rename(candidatePath, lockPath);
+        return owner;
       } catch (error) {
-        await rm(lockPath, { recursive: true, force: true });
-        throw error;
+        if (!isLockExists(error)) {
+          throw error;
+        }
+        if (await recoverStaleSnapshotLock(lockPath)) {
+          continue;
+        }
+        if (Date.now() - startedAt >= SNAPSHOT_LOCK_TIMEOUT_MS) {
+          throw new Error(`timed out waiting for stored session snapshot lock: ${sessionId}`);
+        }
+        await sleep(SNAPSHOT_LOCK_RETRY_MS);
       }
-      return owner;
-    } catch (error) {
-      if (!isAlreadyExists(error)) {
-        throw error;
-      }
-      if (await recoverStaleSnapshotLock(lockPath)) {
-        continue;
-      }
-      if (Date.now() - startedAt >= SNAPSHOT_LOCK_TIMEOUT_MS) {
-        throw new Error(`timed out waiting for stored session snapshot lock: ${sessionId}`);
-      }
-      await sleep(SNAPSHOT_LOCK_RETRY_MS);
     }
+  } finally {
+    await rm(candidatePath, { recursive: true, force: true });
   }
 }
 
@@ -397,8 +402,12 @@ function isNotFound(error: unknown): boolean {
   return error instanceof Error && "code" in error && error.code === "ENOENT";
 }
 
-function isAlreadyExists(error: unknown): boolean {
-  return error instanceof Error && "code" in error && error.code === "EEXIST";
+function isLockExists(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error.code === "EEXIST" || error.code === "ENOTEMPTY")
+  );
 }
 
 function sleep(ms: number): Promise<void> {

--- a/src/store/file_session_store.ts
+++ b/src/store/file_session_store.ts
@@ -1,5 +1,16 @@
 import { randomUUID } from "node:crypto";
-import { mkdir, readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import type { Stats } from "node:fs";
+import {
+  chmod,
+  lstat,
+  mkdir,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
 import type { SessionProtocolSnapshot } from "../protocol/session_protocol.js";
@@ -16,9 +27,21 @@ export type FileSessionStoreOptions = {
   directory: string;
 };
 
+type SnapshotLockOwner = {
+  pid: number;
+  token: string;
+  createdAt: number;
+};
+
 const SNAPSHOT_FILE_EXTENSION = ".json";
+const SNAPSHOT_TEMP_FILE_PATTERN =
+  /^([A-Za-z0-9_-]+\.json)\.(\d+)\.(\d+)\.([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.tmp$/;
+const SNAPSHOT_LOCK_OWNER_FILENAME = "owner.json";
 const SNAPSHOT_LOCK_TIMEOUT_MS = 30_000;
 const SNAPSHOT_LOCK_RETRY_MS = 10;
+const SNAPSHOT_INCOMPLETE_LOCK_STALE_MS = 1_000;
+const PRIVATE_DIRECTORY_MODE = 0o700;
+const PRIVATE_FILE_MODE = 0o600;
 
 export function getDefaultSessionStoreDirectory(homeDir?: string): string {
   return join(homeDir ?? homedir(), ".config", "tau", "sessions");
@@ -26,6 +49,7 @@ export function getDefaultSessionStoreDirectory(homeDir?: string): string {
 
 export class FileSessionStore implements SessionStore {
   private readonly directory: string;
+  private initialization?: Promise<void>;
 
   constructor(options: FileSessionStoreOptions) {
     this.directory = options.directory;
@@ -42,31 +66,32 @@ export class FileSessionStore implements SessionStore {
 
       const finalPath = this.snapshotPath(validated.sessionId);
       const tempPath = `${finalPath}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`;
-      await writeFile(tempPath, `${JSON.stringify(validated)}\n`, "utf8");
-      await rename(tempPath, finalPath);
+      try {
+        await writeFile(tempPath, `${JSON.stringify(validated)}\n`, {
+          encoding: "utf8",
+          flag: "wx",
+          mode: PRIVATE_FILE_MODE,
+        });
+        await rename(tempPath, finalPath);
+        await chmod(finalPath, PRIVATE_FILE_MODE);
+      } finally {
+        await rm(tempPath, { force: true });
+      }
     });
   }
 
   async loadSession(sessionId: string): Promise<SessionProtocolSnapshot | undefined> {
-    let raw: string;
-    try {
-      raw = await readFile(this.snapshotPath(sessionId), "utf8");
-    } catch (error) {
-      if (isNotFound(error)) {
-        return undefined;
-      }
-      throw error;
-    }
-
-    return parseStoredSnapshot(sessionId, raw);
+    await this.ensureInitialized();
+    return await this.loadSessionUnlocked(sessionId);
   }
 
   async listSessionSnapshots(): Promise<SessionProtocolSnapshot[]> {
+    await this.ensureInitialized();
     const filenames = await this.snapshotFilenames();
     const snapshots: SessionProtocolSnapshot[] = [];
     for (const filename of filenames) {
       const sessionId = sessionIdFromSnapshotFilename(filename);
-      const snapshot = await this.loadSession(sessionId);
+      const snapshot = await this.loadSessionUnlocked(sessionId);
       if (snapshot) {
         snapshots.push(snapshot);
       }
@@ -79,15 +104,49 @@ export class FileSessionStore implements SessionStore {
       const current = await this.loadSessionUnlocked(sessionId);
       assertExpectedSessionRevision(sessionId, options.expectedRevision, current);
       await rm(this.snapshotPath(sessionId), { force: true });
+      await this.cleanupSessionTemporaryFiles(sessionId);
     });
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    await this.ensureDirectoryPermissions();
+    if (!this.initialization) {
+      this.initialization = this.initialize().catch((error) => {
+        this.initialization = undefined;
+        throw error;
+      });
+    }
+    await this.initialization;
+  }
+
+  private async initialize(): Promise<void> {
+    const entries = await readdir(this.directory);
+    const sessionIds = new Set<string>();
+    for (const entry of entries) {
+      const sessionId = sessionIdFromSnapshotTempFilename(entry);
+      if (sessionId !== undefined) {
+        sessionIds.add(sessionId);
+      }
+    }
+
+    for (const sessionId of sessionIds) {
+      await this.withSnapshotLockRaw(sessionId, () => this.cleanupSessionTemporaryFiles(sessionId));
+    }
+  }
+
+  private async ensureDirectoryPermissions(): Promise<void> {
+    await mkdir(this.directory, { recursive: true, mode: PRIVATE_DIRECTORY_MODE });
+    await chmod(this.directory, PRIVATE_DIRECTORY_MODE);
   }
 
   private async loadSessionUnlocked(
     sessionId: string,
   ): Promise<SessionProtocolSnapshot | undefined> {
+    const path = this.snapshotPath(sessionId);
     let raw: string;
     try {
-      raw = await readFile(this.snapshotPath(sessionId), "utf8");
+      await chmod(path, PRIVATE_FILE_MODE);
+      raw = await readFile(path, "utf8");
     } catch (error) {
       if (isNotFound(error)) {
         return undefined;
@@ -99,19 +158,8 @@ export class FileSessionStore implements SessionStore {
   }
 
   private async snapshotFilenames(): Promise<string[]> {
-    let entries: string[];
-    try {
-      entries = await readdir(this.directory);
-    } catch (error) {
-      if (isNotFound(error)) {
-        return [];
-      }
-      throw error;
-    }
-
-    return entries
-      .filter((entry) => entry.endsWith(SNAPSHOT_FILE_EXTENSION))
-      .sort((a, b) => a.localeCompare(b));
+    const entries = await readdir(this.directory);
+    return entries.filter((entry) => isSnapshotFilename(entry)).sort((a, b) => a.localeCompare(b));
   }
 
   private snapshotPath(sessionId: string): string {
@@ -122,31 +170,161 @@ export class FileSessionStore implements SessionStore {
     return `${this.snapshotPath(sessionId)}.lock`;
   }
 
-  private async withSnapshotLock<T>(sessionId: string, handler: () => Promise<T>): Promise<T> {
-    await mkdir(this.directory, { recursive: true });
-    const lockPath = this.snapshotLockPath(sessionId);
-    const startedAt = Date.now();
-
-    while (true) {
-      try {
-        await mkdir(lockPath);
-        break;
-      } catch (error) {
-        if (!isAlreadyExists(error)) {
-          throw error;
-        }
-        if (Date.now() - startedAt > SNAPSHOT_LOCK_TIMEOUT_MS) {
-          throw new Error(`timed out waiting for stored session snapshot lock: ${sessionId}`);
-        }
-        await sleep(SNAPSHOT_LOCK_RETRY_MS);
+  private async cleanupSessionTemporaryFiles(sessionId: string): Promise<void> {
+    const expectedSnapshotFilename = snapshotFilename(sessionId);
+    const entries = await readdir(this.directory);
+    for (const entry of entries) {
+      const match = SNAPSHOT_TEMP_FILE_PATTERN.exec(entry);
+      if (!match || match[1] !== expectedSnapshotFilename) {
+        continue;
       }
+      const path = join(this.directory, entry);
+      const metadata = await lstat(path).catch((error) => {
+        if (isNotFound(error)) return undefined;
+        throw error;
+      });
+      if (!metadata?.isFile() || !isOwnedByCurrentUser(metadata.uid)) {
+        continue;
+      }
+      await rm(path, { force: true });
     }
+  }
 
+  private async withSnapshotLock<T>(sessionId: string, handler: () => Promise<T>): Promise<T> {
+    await this.ensureInitialized();
+    return await this.withSnapshotLockRaw(sessionId, async () => {
+      await this.cleanupSessionTemporaryFiles(sessionId);
+      return await handler();
+    });
+  }
+
+  private async withSnapshotLockRaw<T>(sessionId: string, handler: () => Promise<T>): Promise<T> {
+    await this.ensureDirectoryPermissions();
+    const lockPath = this.snapshotLockPath(sessionId);
+    const owner = await acquireSnapshotLock(lockPath, sessionId);
     try {
       return await handler();
     } finally {
-      await rm(lockPath, { recursive: true, force: true });
+      await releaseSnapshotLock(lockPath, owner);
     }
+  }
+}
+
+async function acquireSnapshotLock(
+  lockPath: string,
+  sessionId: string,
+): Promise<SnapshotLockOwner> {
+  const owner: SnapshotLockOwner = {
+    pid: process.pid,
+    token: randomUUID(),
+    createdAt: Date.now(),
+  };
+  const startedAt = Date.now();
+
+  while (true) {
+    try {
+      await mkdir(lockPath, { mode: PRIVATE_DIRECTORY_MODE });
+      try {
+        await writeFile(join(lockPath, SNAPSHOT_LOCK_OWNER_FILENAME), JSON.stringify(owner), {
+          encoding: "utf8",
+          flag: "wx",
+          mode: PRIVATE_FILE_MODE,
+        });
+      } catch (error) {
+        await rm(lockPath, { recursive: true, force: true });
+        throw error;
+      }
+      return owner;
+    } catch (error) {
+      if (!isAlreadyExists(error)) {
+        throw error;
+      }
+      if (await recoverStaleSnapshotLock(lockPath)) {
+        continue;
+      }
+      if (Date.now() - startedAt >= SNAPSHOT_LOCK_TIMEOUT_MS) {
+        throw new Error(`timed out waiting for stored session snapshot lock: ${sessionId}`);
+      }
+      await sleep(SNAPSHOT_LOCK_RETRY_MS);
+    }
+  }
+}
+
+async function recoverStaleSnapshotLock(lockPath: string): Promise<boolean> {
+  const owner = await readSnapshotLockOwner(lockPath);
+  if (owner) {
+    if (isProcessAlive(owner.pid)) {
+      return false;
+    }
+    return await quarantineStaleSnapshotLock(lockPath);
+  }
+
+  let lockStat: Stats;
+  try {
+    lockStat = await stat(lockPath);
+  } catch (error) {
+    if (isNotFound(error)) {
+      return true;
+    }
+    throw error;
+  }
+  if (Date.now() - lockStat.mtimeMs < SNAPSHOT_INCOMPLETE_LOCK_STALE_MS) {
+    return false;
+  }
+  return await quarantineStaleSnapshotLock(lockPath);
+}
+
+async function quarantineStaleSnapshotLock(lockPath: string): Promise<boolean> {
+  const stalePath = `${lockPath}.stale.${randomUUID()}`;
+  try {
+    await rename(lockPath, stalePath);
+  } catch (error) {
+    if (isNotFound(error)) {
+      return true;
+    }
+    throw error;
+  }
+  await rm(stalePath, { recursive: true, force: true });
+  return true;
+}
+
+async function releaseSnapshotLock(
+  lockPath: string,
+  expectedOwner: SnapshotLockOwner,
+): Promise<void> {
+  const owner = await readSnapshotLockOwner(lockPath);
+  if (owner?.token !== expectedOwner.token) {
+    return;
+  }
+  await rm(lockPath, { recursive: true, force: true });
+}
+
+async function readSnapshotLockOwner(lockPath: string): Promise<SnapshotLockOwner | undefined> {
+  let raw: string;
+  try {
+    raw = await readFile(join(lockPath, SNAPSHOT_LOCK_OWNER_FILENAME), "utf8");
+  } catch (error) {
+    if (isNotFound(error)) {
+      return undefined;
+    }
+    throw error;
+  }
+
+  try {
+    const value = JSON.parse(raw) as Partial<SnapshotLockOwner>;
+    if (
+      !Number.isInteger(value.pid) ||
+      (value.pid ?? 0) <= 0 ||
+      typeof value.token !== "string" ||
+      value.token.length === 0 ||
+      typeof value.createdAt !== "number" ||
+      !Number.isFinite(value.createdAt)
+    ) {
+      return undefined;
+    }
+    return value as SnapshotLockOwner;
+  } catch {
+    return undefined;
   }
 }
 
@@ -172,6 +350,14 @@ function parseStoredSnapshot(sessionId: string, raw: string): SessionProtocolSna
   return snapshot.value;
 }
 
+function isSnapshotFilename(filename: string): boolean {
+  if (!filename.endsWith(SNAPSHOT_FILE_EXTENSION)) {
+    return false;
+  }
+  const sessionId = sessionIdFromSnapshotFilename(filename);
+  return snapshotFilename(sessionId) === filename;
+}
+
 function snapshotFilename(sessionId: string): string {
   return `${Buffer.from(sessionId, "utf8").toString("base64url")}${SNAPSHOT_FILE_EXTENSION}`;
 }
@@ -179,6 +365,32 @@ function snapshotFilename(sessionId: string): string {
 function sessionIdFromSnapshotFilename(filename: string): string {
   const encoded = basename(filename, SNAPSHOT_FILE_EXTENSION);
   return Buffer.from(encoded, "base64url").toString("utf8");
+}
+
+function sessionIdFromSnapshotTempFilename(filename: string): string | undefined {
+  const match = SNAPSHOT_TEMP_FILE_PATTERN.exec(filename);
+  if (!match?.[1]) {
+    return undefined;
+  }
+  const sessionId = sessionIdFromSnapshotFilename(match[1]);
+  return snapshotFilename(sessionId) === match[1] ? sessionId : undefined;
+}
+
+function isOwnedByCurrentUser(uid: number): boolean {
+  return typeof process.getuid !== "function" || uid === process.getuid();
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return !(
+      error instanceof Error &&
+      "code" in error &&
+      (error.code === "ESRCH" || error.code === "EINVAL")
+    );
+  }
 }
 
 function isNotFound(error: unknown): boolean {

--- a/test/auth_storage.test.js
+++ b/test/auth_storage.test.js
@@ -1,4 +1,14 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -49,6 +59,16 @@ function createTempAuthPath() {
     authPath: join(dir, "auth.json"),
     cleanup: () => rmSync(dir, { recursive: true, force: true }),
   };
+}
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
 }
 
 beforeEach(() => {
@@ -110,9 +130,300 @@ describe("AuthStorage", () => {
       fx.cleanup();
     }
   });
+
+  it("enforces owner-only permissions before reading auth storage", () => {
+    const fx = createTempAuthPath();
+    try {
+      writeFileSync(fx.authPath, JSON.stringify({ providers: {} }), { mode: 0o644 });
+      chmodSync(fx.dir, 0o755);
+      chmodSync(fx.authPath, 0o644);
+
+      const storage = new AuthStorage(fx.authPath);
+
+      expect(storage.getInvalidReason()).toBeUndefined();
+      expect(statSync(fx.dir).mode & 0o777).toBe(0o700);
+      expect(statSync(fx.authPath).mode & 0o777).toBe(0o600);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("rejects auth storage not owned by the current user before reading it", () => {
+    const fx = createTempAuthPath();
+    const getuid = vi.spyOn(process, "getuid").mockReturnValue(process.getuid() + 1);
+    try {
+      writeFileSync(fx.authPath, JSON.stringify({ providers: {} }), { mode: 0o600 });
+
+      const storage = new AuthStorage(fx.authPath);
+
+      expect(storage.getInvalidReason()).toContain(
+        "auth storage directory is not owned by the current user",
+      );
+    } finally {
+      getuid.mockRestore();
+      fx.cleanup();
+    }
+  });
+
+  it("rejects symlinked auth storage before reading it", () => {
+    const fx = createTempAuthPath();
+    try {
+      const targetPath = join(fx.dir, "target.json");
+      writeFileSync(targetPath, JSON.stringify({ providers: {} }), { mode: 0o600 });
+      symlinkSync(targetPath, fx.authPath);
+
+      const storage = new AuthStorage(fx.authPath);
+
+      expect(storage.getInvalidReason()).toContain("auth storage file is not a regular file");
+      expect(lstatSync(fx.authPath).isSymbolicLink()).toBe(true);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("cleans stale auth temporaries during initialization and mutation", () => {
+    const fx = createTempAuthPath();
+    try {
+      const startupTemp = join(fx.dir, "auth.json.00000000-0000-4000-8000-000000000001.tmp");
+      writeFileSync(startupTemp, "stale", { mode: 0o600 });
+      const storage = new AuthStorage(fx.authPath);
+      expect(() => lstatSync(startupTemp)).toThrow(expect.objectContaining({ code: "ENOENT" }));
+
+      const mutationTemp = join(fx.dir, "auth.json.00000000-0000-4000-8000-000000000002.tmp");
+      writeFileSync(mutationTemp, "stale", { mode: 0o600 });
+      storage.update((data) => {
+        data.providers = {};
+      });
+      expect(() => lstatSync(mutationTemp)).toThrow(expect.objectContaining({ code: "ENOENT" }));
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("recovers an auth lock owned by a process that no longer exists", () => {
+    const fx = createTempAuthPath();
+    try {
+      const lockPath = `${fx.authPath}.lock`;
+      mkdirSync(lockPath);
+      writeFileSync(
+        join(lockPath, "owner.json"),
+        JSON.stringify({ pid: 2_147_483_647, token: "stale-owner", createdAt: 1 }),
+        { mode: 0o600 },
+      );
+
+      const storage = new AuthStorage(fx.authPath);
+      storage.update((data) => {
+        data.providers = {};
+      });
+
+      expect(storage.getInvalidReason()).toBeUndefined();
+      expect(() => lstatSync(lockPath)).toThrow(expect.objectContaining({ code: "ENOENT" }));
+    } finally {
+      fx.cleanup();
+    }
+  });
 });
 
 describe("AuthManager and TauCredentialStore", () => {
+  it("does not restore an account removed during an in-flight refresh", async () => {
+    const fx = createTempAuthPath();
+    try {
+      const originalAccess = createAccessToken({
+        accountId: "acct-race",
+        email: "user@example.com",
+        plan: "plus",
+      });
+      const refreshedAccess = createAccessToken({
+        accountId: "acct-race",
+        email: "user@example.com",
+        plan: "pro",
+      });
+      writeFileSync(
+        fx.authPath,
+        JSON.stringify({
+          providers: {
+            "openai-codex": {
+              accounts: [
+                {
+                  type: "oauth",
+                  accountId: "acct-race",
+                  providerAccountId: "acct-race",
+                  access: originalAccess,
+                  refresh: "refresh-race",
+                  expires: 1,
+                },
+              ],
+            },
+          },
+        }),
+        { mode: 0o600 },
+      );
+      const refreshStarted = deferred();
+      const releaseRefresh = deferred();
+      refreshOpenAICodexToken.mockImplementation(async () => {
+        refreshStarted.resolve();
+        return await releaseRefresh.promise;
+      });
+
+      const listingStorage = new AuthStorage(fx.authPath);
+      const listing = new AuthManager(listingStorage).listProviderAccounts();
+      await refreshStarted.promise;
+
+      const logoutStorage = new AuthStorage(fx.authPath);
+      new AuthManager(logoutStorage).removeAccount("openai-codex", "acct-race");
+      releaseRefresh.resolve({
+        access: refreshedAccess,
+        refresh: "refresh-race-next",
+        expires: Number.MAX_SAFE_INTEGER,
+        accountId: "acct-race",
+      });
+
+      await expect(listing).resolves.toEqual([]);
+      const saved = JSON.parse(readFileSync(fx.authPath, "utf8"));
+      expect(saved.providers["openai-codex"].accounts).toEqual([]);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("does not let credential-store refresh restore a deleted account", async () => {
+    const fx = createTempAuthPath();
+    try {
+      writeFileSync(
+        fx.authPath,
+        JSON.stringify({
+          providers: {
+            "openai-codex": {
+              accounts: [
+                {
+                  type: "oauth",
+                  accountId: "acct-modify-race",
+                  providerAccountId: "acct-modify-race",
+                  access: "access-original",
+                  refresh: "refresh-original",
+                  expires: 1,
+                },
+              ],
+            },
+          },
+        }),
+        { mode: 0o600 },
+      );
+      getOAuthApiKey.mockImplementation(async (_provider, providers) => ({
+        apiKey: providers["openai-codex"].access,
+        newCredentials: providers["openai-codex"],
+      }));
+      const refreshStarted = deferred();
+      const releaseRefresh = deferred();
+      const store = new TauCredentialStore({
+        authStorage: new AuthStorage(fx.authPath),
+        getConfig: () => ({}),
+      });
+      const refresh = store.modify("openai-codex", async (current) => {
+        refreshStarted.resolve();
+        await releaseRefresh.promise;
+        return {
+          ...current,
+          access: "access-refreshed",
+          refresh: "refresh-refreshed",
+          expires: 100,
+        };
+      });
+      await refreshStarted.promise;
+
+      const logoutStorage = new AuthStorage(fx.authPath);
+      new AuthManager(logoutStorage).removeAccount("openai-codex", "acct-modify-race");
+      releaseRefresh.resolve();
+
+      await expect(refresh).resolves.toBeUndefined();
+      const saved = JSON.parse(readFileSync(fx.authPath, "utf8"));
+      expect(saved.providers["openai-codex"].accounts).toEqual([]);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("does not let a later parallel refresh overwrite a newer credential generation", async () => {
+    const fx = createTempAuthPath();
+    try {
+      writeFileSync(
+        fx.authPath,
+        JSON.stringify({
+          providers: {
+            "openai-codex": {
+              accounts: [
+                {
+                  type: "oauth",
+                  accountId: "acct-parallel",
+                  providerAccountId: "acct-parallel",
+                  access: "access-original",
+                  refresh: "refresh-original",
+                  expires: 1,
+                },
+              ],
+            },
+          },
+        }),
+        { mode: 0o600 },
+      );
+      const bothRefreshesStarted = deferred();
+      const refreshes = [deferred(), deferred()];
+      let refreshCallCount = 0;
+      getOAuthApiKey.mockImplementation(async () => {
+        const callIndex = refreshCallCount++;
+        if (refreshCallCount === 2) {
+          bothRefreshesStarted.resolve();
+        }
+        return await refreshes[callIndex].promise;
+      });
+
+      const firstRead = new TauCredentialStore({
+        authStorage: new AuthStorage(fx.authPath),
+        getConfig: () => ({}),
+      }).read("openai-codex");
+      const secondRead = new TauCredentialStore({
+        authStorage: new AuthStorage(fx.authPath),
+        getConfig: () => ({}),
+      }).read("openai-codex");
+      await bothRefreshesStarted.promise;
+
+      refreshes[0].resolve({
+        apiKey: "api-newer",
+        newCredentials: {
+          access: "access-newer",
+          refresh: "refresh-newer",
+          expires: 100,
+          accountId: "acct-parallel",
+        },
+      });
+      await expect(firstRead).resolves.toMatchObject({
+        type: "oauth",
+        access: "access-newer",
+        refresh: "refresh-newer",
+      });
+
+      refreshes[1].resolve({
+        apiKey: "api-stale",
+        newCredentials: {
+          access: "access-stale",
+          refresh: "refresh-stale",
+          expires: 200,
+          accountId: "acct-parallel",
+        },
+      });
+      await expect(secondRead).resolves.toBeUndefined();
+
+      const saved = JSON.parse(readFileSync(fx.authPath, "utf8"));
+      expect(saved.providers["openai-codex"].accounts[0]).toMatchObject({
+        access: "access-newer",
+        refresh: "refresh-newer",
+        expires: 100,
+      });
+    } finally {
+      fx.cleanup();
+    }
+  });
+
   it("refreshes codex account identity before listing plans", async () => {
     const fx = createTempAuthPath();
     try {

--- a/test/auth_storage.test.js
+++ b/test/auth_storage.test.js
@@ -131,14 +131,23 @@ describe("AuthStorage", () => {
     }
   });
 
-  it("enforces owner-only permissions before reading auth storage", () => {
+  it("enforces owner-only permissions under a restrictive umask", () => {
     const fx = createTempAuthPath();
     try {
       writeFileSync(fx.authPath, JSON.stringify({ providers: {} }), { mode: 0o644 });
       chmodSync(fx.dir, 0o755);
       chmodSync(fx.authPath, 0o644);
 
-      const storage = new AuthStorage(fx.authPath);
+      const previousUmask = process.umask(0o777);
+      let storage;
+      try {
+        storage = new AuthStorage(fx.authPath);
+        storage.update((data) => {
+          data.providers = {};
+        });
+      } finally {
+        process.umask(previousUmask);
+      }
 
       expect(storage.getInvalidReason()).toBeUndefined();
       expect(statSync(fx.dir).mode & 0o777).toBe(0o700);

--- a/test/file_session_store.test.js
+++ b/test/file_session_store.test.js
@@ -1,4 +1,4 @@
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { access, chmod, mkdir, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -140,6 +140,72 @@ describe("FileSessionStore", () => {
       await expect(
         store.deleteSession("session-1", { expectedRevision: 2 }),
       ).resolves.toBeUndefined();
+    });
+  });
+
+  it("recovers a lock owned by a process that no longer exists", async () => {
+    await withTempStore(async (store, directory) => {
+      const lockPath = join(directory, "c2Vzc2lvbi0x.json.lock");
+      await mkdir(lockPath, { recursive: true });
+      await writeFile(
+        join(lockPath, "owner.json"),
+        JSON.stringify({ pid: 2_147_483_647, token: "stale-owner", createdAt: 1 }),
+        "utf8",
+      );
+
+      await expect(
+        store.commitSessionSnapshot(createSnapshot("session-1", "recovered")),
+      ).resolves.toBeUndefined();
+      await expect(access(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(store.loadSession("session-1")).resolves.toEqual(
+        createSnapshot("session-1", "recovered"),
+      );
+    });
+  });
+
+  it("uses owner-only permissions for snapshot directories and files", async () => {
+    await withTempStore(async (store, directory) => {
+      const previousUmask = process.umask(0o022);
+      try {
+        await store.commitSessionSnapshot(createSnapshot("session-1", "private"));
+      } finally {
+        process.umask(previousUmask);
+      }
+
+      expect((await stat(directory)).mode & 0o777).toBe(0o700);
+      expect((await stat(join(directory, "c2Vzc2lvbi0x.json"))).mode & 0o777).toBe(0o600);
+
+      await chmod(directory, 0o755);
+      await chmod(join(directory, "c2Vzc2lvbi0x.json"), 0o644);
+      await store.loadSession("session-1");
+
+      expect((await stat(directory)).mode & 0o777).toBe(0o700);
+      expect((await stat(join(directory, "c2Vzc2lvbi0x.json"))).mode & 0o777).toBe(0o600);
+    });
+  });
+
+  it("cleans store-owned snapshot temporaries on startup and deletion", async () => {
+    await withTempStore(async (_store, directory) => {
+      await mkdir(directory, { recursive: true });
+      const startupTemp = join(
+        directory,
+        "c2Vzc2lvbi0x.json.100.100.00000000-0000-4000-8000-000000000001.tmp",
+      );
+      await writeFile(startupTemp, "stale", { mode: 0o600 });
+
+      const store = new FileSessionStore({ directory });
+      await store.listSessionSnapshots();
+      await expect(access(startupTemp)).rejects.toMatchObject({ code: "ENOENT" });
+
+      await store.commitSessionSnapshot(createSnapshot("session-1", "private"));
+      const deletionTemp = join(
+        directory,
+        "c2Vzc2lvbi0x.json.100.200.00000000-0000-4000-8000-000000000002.tmp",
+      );
+      await writeFile(deletionTemp, "stale", { mode: 0o600 });
+
+      await store.deleteSession("session-1");
+      await expect(access(deletionTemp)).rejects.toMatchObject({ code: "ENOENT" });
     });
   });
 });

--- a/test/file_session_store.test.js
+++ b/test/file_session_store.test.js
@@ -165,7 +165,7 @@ describe("FileSessionStore", () => {
 
   it("uses owner-only permissions for snapshot directories and files", async () => {
     await withTempStore(async (store, directory) => {
-      const previousUmask = process.umask(0o022);
+      const previousUmask = process.umask(0o777);
       try {
         await store.commitSessionSnapshot(createSnapshot("session-1", "private"));
       } finally {


### PR DESCRIPTION
## why

Session snapshots and authentication data lacked a complete crash and concurrency contract. Snapshot locks could survive a dead process forever, storage permissions depended on the caller's umask, atomic-write temporaries retained deleted secrets and history, and a delayed credential refresh could overwrite a completed logout.

## what

Adds recoverable owner-identified locks for session snapshots and auth storage, including dead-process detection, race-safe stale-lock quarantine, ownership tokens, and bounded acquisition. Session and auth directories and files are enforced as `0700` and `0600`, with auth symlink and foreign-owner rejection before secret reads.

Atomic writes now use exclusive owner-only temporary files and clean them on ordinary failure. Strictly recognized stale temporaries are reaped under the relevant lock during initialization and deletion or mutation.

## details

Auth mutations reload under the interprocess lock before applying changes. Delayed OAuth and credential-store updates carry the account generation they started from, so logout or a newer refresh wins instead of being overwritten. Tests cover dead lock owners, permissive umasks, stale temporary cleanup, unsafe auth paths, refresh-versus-logout races, and parallel credential refreshes.
