### PR TITLE
validate auth command arguments

### DIFF
--- a/src/core/auth/cli.ts
+++ b/src/core/auth/cli.ts
@@ -20,6 +20,12 @@ export type OAuthProviderSpec = {
   label: string;
 };
 
+export type AuthCliCommand =
+  | { type: "help" }
+  | { type: "login"; providerArg?: string }
+  | { type: "list" }
+  | { type: "logout"; providerArg?: string; accountId: string };
+
 export const SUPPORTED_OAUTH_PROVIDERS: OAuthProviderSpec[] = [
   { id: "openai-codex", cliId: "codex", label: "OpenAI Codex (ChatGPT Plus/Pro)" },
 ];
@@ -36,6 +42,87 @@ const DEFAULT_LOGIN_HANDLERS: Partial<Record<OAuthProvider, AuthLoginHandler>> =
 
 const chalk = new Chalk({ level: process.stdout.isTTY ? 2 : 0 });
 const BAR_WIDTH = 10;
+
+export function parseAuthCliArgs(args: string[]): AuthCliCommand {
+  const [subcommand, ...subcommandArgs] = args;
+
+  if (subcommand === "--help" || subcommand === "-h") {
+    if (subcommandArgs.length > 0) {
+      throw new Error(`unexpected auth argument "${subcommandArgs[0]}"`);
+    }
+    return { type: "help" };
+  }
+
+  if (subcommand === "login") {
+    const [providerArg, ...extraArgs] = subcommandArgs;
+    if (providerArg?.startsWith("-")) {
+      throw new Error(`unknown auth login option "${providerArg}"`);
+    }
+    if (extraArgs.length > 0) {
+      const extra = extraArgs[0];
+      throw new Error(
+        extra?.startsWith("-")
+          ? `unknown auth login option "${extra}"`
+          : `unexpected auth login argument "${extra}"`,
+      );
+    }
+    return { type: "login", ...(providerArg ? { providerArg } : {}) };
+  }
+
+  if (subcommand === "list") {
+    const extra = subcommandArgs[0];
+    if (extra !== undefined) {
+      throw new Error(
+        extra.startsWith("-")
+          ? `unknown auth list option "${extra}"`
+          : `unexpected auth list argument "${extra}"`,
+      );
+    }
+    return { type: "list" };
+  }
+
+  if (subcommand === "logout") {
+    let index = 0;
+    let providerArg: string | undefined;
+    if (subcommandArgs[index] && !subcommandArgs[index]!.startsWith("-")) {
+      providerArg = subcommandArgs[index];
+      index += 1;
+    }
+
+    let accountId: string | undefined;
+    while (index < subcommandArgs.length) {
+      const argument = subcommandArgs[index]!;
+      if (argument !== "--account") {
+        throw new Error(
+          argument.startsWith("-")
+            ? `unknown auth logout option "${argument}"`
+            : `unexpected auth logout argument "${argument}"`,
+        );
+      }
+      if (accountId !== undefined) {
+        throw new Error('duplicate auth logout option "--account"');
+      }
+
+      const value = subcommandArgs[index + 1];
+      if (!value || value.startsWith("--")) {
+        throw new Error('missing value for auth logout option "--account"');
+      }
+      accountId = value;
+      index += 2;
+    }
+
+    if (!accountId) {
+      throw new Error("missing --account <id> for logout");
+    }
+    return {
+      type: "logout",
+      ...(providerArg ? { providerArg } : {}),
+      accountId,
+    };
+  }
+
+  throw new Error(`unknown auth subcommand "${subcommand ?? ""}"`);
+}
 
 function normalizeProvider(value: string): string {
   return value.trim().toLowerCase();

--- a/src/core/auth/index.ts
+++ b/src/core/auth/index.ts
@@ -2,8 +2,15 @@ export { AuthManager } from "./auth_manager.js";
 export { formatCodexAuthError } from "./auth_messages.js";
 export { getAuthPath } from "./auth_paths.js";
 export { AuthStorage } from "./auth_storage.js";
-export type { AuthLog, AuthLoginHandler, AuthPromptFn, OAuthProviderSpec } from "./cli.js";
+export type {
+  AuthCliCommand,
+  AuthLog,
+  AuthLoginHandler,
+  AuthPromptFn,
+  OAuthProviderSpec,
+} from "./cli.js";
 export {
+  parseAuthCliArgs,
   runListCommand,
   runLoginCommand,
   runLogoutCommand,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,9 +1,16 @@
-export type { AuthLog, AuthLoginHandler, AuthPromptFn, OAuthProviderSpec } from "./auth/index.js";
+export type {
+  AuthCliCommand,
+  AuthLog,
+  AuthLoginHandler,
+  AuthPromptFn,
+  OAuthProviderSpec,
+} from "./auth/index.js";
 export {
   AuthManager,
   AuthStorage,
   formatCodexAuthError,
   getAuthPath,
+  parseAuthCliArgs,
   runListCommand,
   runLoginCommand,
   runLogoutCommand,

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
 import type { RuntimeConfigResult } from "./core/config/index.js";
 import type {
+  AuthCliCommand,
   AuthPromptFn,
   CliOptions,
   Config,
@@ -28,6 +29,7 @@ import {
   loadRuntimeBootstrap,
   loadRuntimeConfig,
   NookCliError,
+  parseAuthCliArgs,
   parseCliArgs,
   parsePersonaString,
   printDebugInfo,
@@ -624,15 +626,19 @@ let themes: ThemeDefinition[] = [];
 let runtimeBootstrap: RuntimeBootstrap | undefined;
 
 if (argv[0] === "auth") {
-  if (argv.includes("--help") || argv.includes("-h")) {
+  let command: AuthCliCommand;
+  try {
+    command = parseAuthCliArgs(argv.slice(1));
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error((err as Error).message);
+    process.exit(1);
+  }
+
+  if (command.type === "help") {
     printAuthHelp();
     process.exit(0);
   }
-
-  const subcommand = argv[1];
-  const providerArg = argv[2];
-  const accountIndex = argv.indexOf("--account");
-  const accountId = accountIndex >= 0 ? argv[accountIndex + 1] : undefined;
 
   const authPath = getAuthPath();
   const authStorage = new AuthStorage(authPath);
@@ -644,25 +650,23 @@ if (argv[0] === "auth") {
     });
 
   try {
-    if (subcommand === "login") {
+    if (command.type === "login") {
       await runLoginCommand({
-        providerArg,
+        providerArg: command.providerArg,
         authStorage,
         authPath,
         prompt,
       });
-    } else if (subcommand === "logout") {
+    } else if (command.type === "logout") {
       await runLogoutCommand({
-        providerArg,
-        accountId,
+        providerArg: command.providerArg,
+        accountId: command.accountId,
         authStorage,
         authPath,
         prompt,
       });
-    } else if (subcommand === "list") {
-      await runListCommand({ authStorage });
     } else {
-      throw new Error(`unknown auth subcommand "${subcommand ?? ""}"`);
+      await runListCommand({ authStorage });
     }
     process.exit(0);
   } catch (err) {

--- a/test/auth_cli.test.js
+++ b/test/auth_cli.test.js
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { AuthStorage } from "../dist/core/auth/auth_storage.js";
-import { runLoginCommand, runLogoutCommand } from "../dist/core/auth/cli.js";
+import { parseAuthCliArgs, runLoginCommand, runLogoutCommand } from "../dist/core/auth/cli.js";
 
 function toBase64Url(value) {
   return Buffer.from(value, "utf-8")
@@ -40,6 +40,33 @@ function createTempAuthPath() {
 }
 
 describe("auth cli", () => {
+  it("parses complete auth subcommands", () => {
+    expect(parseAuthCliArgs(["login", "codex"])).toEqual({
+      type: "login",
+      providerArg: "codex",
+    });
+    expect(parseAuthCliArgs(["list"])).toEqual({ type: "list" });
+    expect(parseAuthCliArgs(["logout", "codex", "--account", "user@example.com"])).toEqual({
+      type: "logout",
+      providerArg: "codex",
+      accountId: "user@example.com",
+    });
+  });
+
+  it.each([
+    [["list", "--bogus"], 'unknown auth list option "--bogus"'],
+    [["list", "extra"], 'unexpected auth list argument "extra"'],
+    [["login", "codex", "extra"], 'unexpected auth login argument "extra"'],
+    [["logout", "codex", "--account", "wanted", "--force"], 'unknown auth logout option "--force"'],
+    [
+      ["logout", "codex", "--account", "first", "--account", "second"],
+      'duplicate auth logout option "--account"',
+    ],
+    [["logout", "codex", "--account"], 'missing value for auth logout option "--account"'],
+  ])("rejects invalid arguments %#", (args, message) => {
+    expect(() => parseAuthCliArgs(args)).toThrow(message);
+  });
+
   it("stores credentials on login and removes them on logout", async () => {
     const fx = createTempAuthPath();
     try {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,5 +1,7 @@
 import { spawnSync } from "node:child_process";
-import { resolve } from "node:path";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { parseCliArgs } from "../dist/core/cli.js";
 
@@ -33,6 +35,23 @@ describe("cli", () => {
     expect(() => parseCliArgs(["--persona", "demo:ultra"])).toThrow(
       "invalid reasoning level 'ultra'",
     );
+  });
+
+  it("rejects invalid auth arguments before creating credential storage", () => {
+    const home = mkdtempSync(join(tmpdir(), "tau-auth-cli-home-"));
+    try {
+      const mainPath = resolve(process.cwd(), "dist/main.js");
+      const result = spawnSync(process.execPath, [mainPath, "auth", "list", "--bogus"], {
+        encoding: "utf8",
+        env: { ...process.env, HOME: home },
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('unknown auth list option "--bogus"');
+      expect(existsSync(join(home, ".config", "tau"))).toBe(false);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
   });
 
   it.each(["rpc", "serve"])("rejects --debug in %s mode", (mode) => {


### PR DESCRIPTION
## why

`tau auth` selected fixed argument positions and ignored unknown flags, trailing positionals, and duplicate account selectors. That allowed malformed commands, including destructive logout commands, to proceed while silently discarding user input.

## what

Adds a strict per-subcommand auth parser for login, list, logout, and help. Unsupported options, surplus positionals, missing account values, and duplicate `--account` selectors now fail before authentication storage is initialized. The main entry point dispatches only the parser's canonical command shapes.

Regression coverage exercises valid command shapes, invalid and duplicate arguments, and verifies a rejected command does not create credential storage.

## details

This addresses Nook finding 34. After this PR merges, re-read `finding/34`, preserve its current review fields, append implementation and verification notes, and mark it resolved in Nook KV.
