### PR TITLE
fix model overlay precedence

### DIFF
--- a/src/core/models/catalog.ts
+++ b/src/core/models/catalog.ts
@@ -429,6 +429,7 @@ export function loadModelResolver(options: {
   }
 
   const providerPatches = new Map<string, ModelPatch>();
+  const modelPatches = new Map<string, ModelPatch[]>();
   const errors: string[] = [];
 
   for (const level of levels) {
@@ -455,48 +456,39 @@ export function loadModelResolver(options: {
 
       const providerPatch = createProviderPatch(providerConfig);
       if (Object.keys(providerPatch).length > 0) {
-        const mergedProviderPatch = mergeProviderPatch(
-          providerPatches.get(providerName),
-          providerPatch,
+        providerPatches.set(
+          providerName,
+          mergeProviderPatch(providerPatches.get(providerName), providerPatch),
         );
-        providerPatches.set(providerName, mergedProviderPatch);
-
-        for (const [key, candidate] of modelsByKey.entries()) {
-          if (candidate.provider !== providerName) {
-            continue;
-          }
-
-          modelsByKey.set(key, applyModelPatch(candidate, mergedProviderPatch));
-        }
       }
 
       for (const modelConfig of providerConfig.models ?? []) {
         const key = modelKey(providerName, modelConfig.id);
-        const providerPatchForModel = providerPatches.get(providerName);
-        const existing =
-          modelsByKey.get(key) ??
-          createSyntheticModel(providerName, modelConfig.id, providerTemplates);
-
-        if (!existing) {
-          errors.push(
-            `${level.modelsPath}: provider '${providerName}' does not have bundled defaults to derive model '${modelConfig.id}'.`,
-          );
-          continue;
+        if (!modelsByKey.has(key)) {
+          const synthetic = createSyntheticModel(providerName, modelConfig.id, providerTemplates);
+          if (!synthetic) {
+            errors.push(
+              `${level.modelsPath}: provider '${providerName}' does not have bundled defaults to derive model '${modelConfig.id}'.`,
+            );
+            continue;
+          }
+          modelsByKey.set(key, synthetic);
         }
 
-        const withProviderDefaults = providerPatchForModel
-          ? applyModelPatch(existing, providerPatchForModel)
-          : existing;
-        const next = applyModelPatch(withProviderDefaults, createModelPatch(modelConfig));
-
-        modelsByKey.set(key, {
-          ...next,
-          id: modelConfig.id,
-          name: next.name || modelConfig.id,
-          provider: providerName,
-        });
+        const patches = modelPatches.get(key) ?? [];
+        patches.push(createModelPatch(modelConfig));
+        modelPatches.set(key, patches);
       }
     }
+  }
+
+  for (const [key, baseModel] of modelsByKey.entries()) {
+    const providerPatch = providerPatches.get(baseModel.provider);
+    let resolved = providerPatch ? applyModelPatch(baseModel, providerPatch) : baseModel;
+    for (const modelPatch of modelPatches.get(key) ?? []) {
+      resolved = applyModelPatch(resolved, modelPatch);
+    }
+    modelsByKey.set(key, resolved);
   }
 
   const resolveConfiguredModel: ModelResolver = (providerRaw, modelIdRaw) => {

--- a/test/model_catalog.test.js
+++ b/test/model_catalog.test.js
@@ -138,9 +138,16 @@ describe("model catalog", () => {
           {
             providers: {
               openai: {
+                headers: {
+                  "x-route": "global-provider",
+                },
                 models: [
                   {
                     id: "gpt-5.9-custom",
+                    baseUrl: "https://model.example/v1",
+                    headers: {
+                      "x-route": "global-model",
+                    },
                     contextWindow: 100000,
                     maxTokens: 1000,
                   },
@@ -159,6 +166,11 @@ describe("model catalog", () => {
           {
             providers: {
               openai: {
+                baseUrl: "https://project-provider.example/v1",
+                headers: {
+                  "x-route": "project-provider",
+                  "x-tenant": "project",
+                },
                 models: [
                   {
                     id: "gpt-5.9-custom",
@@ -203,6 +215,11 @@ describe("model catalog", () => {
       expect(resolver.errors).toEqual([]);
       const model = resolver.resolveModel("openai", "gpt-5.9-custom");
       expect(model).toBeTruthy();
+      expect(model.baseUrl).toBe("https://model.example/v1");
+      expect(model.headers).toEqual({
+        "x-route": "global-model",
+        "x-tenant": "project",
+      });
       expect(model.contextWindow).toBe(200000);
       expect(model.maxTokens).toBe(1000);
       expect(model.cost.tiers).toEqual([


### PR DESCRIPTION
## why

Model-specific configuration is documented to override provider defaults, but later provider overlays were reapplied to already resolved models. An unrelated project provider patch could therefore overwrite a more specific model header, base URL, or API selected at an earlier configuration level.

## what

Accumulates provider patches and ordered per-model patches separately while loading configuration. Each final model is now resolved once from its base by applying the complete provider patch first, followed by every model-specific patch in configuration-level order.

Regression coverage verifies that a project provider overlay can add a header while preserving global model-specific header and base-URL overrides.

## details

This addresses Nook finding 48. After this PR merges, re-read `finding/48`, preserve its current review fields, append implementation and verification notes, and mark it resolved in Nook KV.
