### PR TITLE
bound stdio transport diagnostics

### DIFF
--- a/src/transport/stdio_session_transport.ts
+++ b/src/transport/stdio_session_transport.ts
@@ -40,6 +40,22 @@ type ProcessExitInfo = {
 export type SessionProtocolSpawnedProcess = ChildProcessWithoutNullStreams;
 
 const CLOSE_TIMEOUT_MS = 2_000;
+const STDERR_DIAGNOSTIC_MAX_BYTES = 64 * 1024;
+const STDERR_TRUNCATION_MARKER = "[stderr truncated; showing tail]\n";
+const STDERR_TRUNCATION_MARKER_BYTES = Buffer.byteLength(STDERR_TRUNCATION_MARKER, "utf8");
+
+function truncateUtf8Tail(value: string, maxBytes: number): string {
+  const buffer = Buffer.from(value, "utf8");
+  if (buffer.byteLength <= maxBytes) {
+    return value;
+  }
+
+  let start = buffer.byteLength - maxBytes;
+  while (start < buffer.byteLength && (buffer[start]! & 0xc0) === 0x80) {
+    start += 1;
+  }
+  return buffer.subarray(start).toString("utf8");
+}
 
 export class StdioSessionProtocolTransport implements SessionProtocolTransport {
   private readonly process;
@@ -55,6 +71,7 @@ export class StdioSessionProtocolTransport implements SessionProtocolTransport {
   private readyValue?: SessionProtocolReadyMessage;
   private readonly stdoutBuffer = new LineBuffer();
   private stderrBuffer = "";
+  private stderrTruncated = false;
   private connectPromise?: Promise<void>;
   private closePromise?: Promise<void>;
   private isConnected = false;
@@ -254,13 +271,20 @@ export class StdioSessionProtocolTransport implements SessionProtocolTransport {
   };
 
   private readonly handleStderrData = (chunk: string | Buffer): void => {
-    this.stderrBuffer += chunk.toString();
+    const next = `${this.stderrBuffer}${chunk.toString()}`;
+    const maxTailBytes = STDERR_DIAGNOSTIC_MAX_BYTES - STDERR_TRUNCATION_MARKER_BYTES;
+    if (this.stderrTruncated || Buffer.byteLength(next, "utf8") > STDERR_DIAGNOSTIC_MAX_BYTES) {
+      this.stderrBuffer = truncateUtf8Tail(next, maxTailBytes);
+      this.stderrTruncated = true;
+      return;
+    }
+    this.stderrBuffer = next;
   };
 
   private readonly handleProcessError = (error: Error): void => {
     this.failTransport(
       new TauProcessError("tau rpc process transport failure", {
-        stderr: this.stderrBuffer,
+        stderr: this.getStderrDiagnostic(),
         cause: error,
       }),
     );
@@ -302,9 +326,15 @@ export class StdioSessionProtocolTransport implements SessionProtocolTransport {
       new TauProcessError(message, {
         exitCode: exit.code,
         signal: exit.signal,
-        stderr: this.stderrBuffer,
+        stderr: this.getStderrDiagnostic(),
       }),
     );
+  }
+
+  private getStderrDiagnostic(): string {
+    return this.stderrTruncated
+      ? `${STDERR_TRUNCATION_MARKER}${this.stderrBuffer}`
+      : this.stderrBuffer;
   }
 
   private handleSessionProtocolLine(line: string): void {

--- a/test/sdk_client.test.js
+++ b/test/sdk_client.test.js
@@ -1395,6 +1395,31 @@ describe("sdk_client", () => {
     await expect(session.interrupt()).rejects.toBeInstanceOf(TauTransportError);
   });
 
+  it("retains a bounded stderr tail when the rpc subprocess exits", async () => {
+    const child = new FakeChildProcess();
+    const { client } = await createConnectedClient(child);
+    const session = await client.sessions.observe("session-1");
+    await expect(session.snapshot()).resolves.toEqual(createSnapshot("session-1"));
+
+    const snapshotPromise = session.snapshot();
+    await waitForRequest(child, (request) => request.method === "session.snapshot");
+
+    child.writeStderr("discarded-head\n");
+    child.writeStderr("é".repeat(35_000));
+    child.writeStderr("\nretained-tail\n");
+    child.exit(9, null);
+
+    const error = await snapshotPromise.catch((cause) => cause);
+    expect(error).toBeInstanceOf(TauProcessError);
+    expect(error.stderr.startsWith("[stderr truncated; showing tail]\n")).toBe(true);
+    expect(error.stderr.endsWith("\nretained-tail\n")).toBe(true);
+    expect(error.stderr).not.toContain("discarded-head");
+    expect(error.stderr).not.toContain("�");
+    expect(Buffer.byteLength(error.stderr, "utf8")).toBeLessThanOrEqual(64 * 1024);
+
+    await client.close();
+  });
+
   it("close is idempotent", async () => {
     const child = new FakeChildProcess();
     const { client } = await createConnectedClient(child);


### PR DESCRIPTION
## why

The stdio session transport retained every byte written by an SSH or RPC peer to stderr for the full connection lifetime. Long-lived diagnostic output could therefore grow transport memory without a bound and was copied wholesale into terminal process errors.

## what

Keeps only a UTF-8-safe 64 KiB stderr diagnostic tail. Terminal process errors include an explicit truncation marker when older diagnostics were discarded, while short stderr output remains unchanged.

Regression coverage verifies the retained error is byte-bounded, preserves the newest diagnostics, discards the oldest output, marks truncation, and does not split a UTF-8 code point.

## details

This addresses Nook finding 58. After this PR merges, re-read `finding/58`, preserve its current review fields, append implementation and verification notes, and mark it resolved in Nook KV.
