### PR TITLE
improve telegram poll error logs

### DIFF
--- a/src/core/telegram/adapter.ts
+++ b/src/core/telegram/adapter.ts
@@ -874,6 +874,50 @@ const TelegramGetUpdatesResultSchema = z.array(TelegramUpdateSchema);
 const TelegramGetFileResultSchema = z.object({ file_path: z.string() });
 const TelegramGetMeResultSchema = telegramObject({ username: z.string() });
 const TelegramAckResultSchema = z.literal(true);
+const MAX_TELEGRAM_ERROR_DETAIL_LENGTH = 500;
+
+function getErrorCode(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null || !("code" in error)) {
+    return undefined;
+  }
+
+  return typeof error.code === "string" ? error.code : undefined;
+}
+
+function formatTelegramNetworkError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  const cause = error instanceof Error ? error.cause : undefined;
+  const causeMessage = cause instanceof Error ? cause.message : undefined;
+  const codes = Array.from(
+    new Set([getErrorCode(error), getErrorCode(cause)].filter((code) => code !== undefined)),
+  );
+  const detail = causeMessage && causeMessage !== message ? `${message}: ${causeMessage}` : message;
+  return `${detail}${codes.length > 0 ? ` (${codes.join(", ")})` : ""}`;
+}
+
+function truncateTelegramErrorDetail(detail: string): string {
+  if (detail.length <= MAX_TELEGRAM_ERROR_DETAIL_LENGTH) {
+    return detail;
+  }
+
+  return `${detail.slice(0, MAX_TELEGRAM_ERROR_DETAIL_LENGTH)}…`;
+}
+
+async function readTelegramHttpErrorDetail(response: Response): Promise<string> {
+  const responseText = (await response.text()).trim();
+  if (!responseText) {
+    return "";
+  }
+
+  try {
+    const parsed = TelegramEnvelopeSchema.safeParse(JSON.parse(responseText));
+    if (parsed.success && parsed.data.description?.trim()) {
+      return truncateTelegramErrorDetail(parsed.data.description.trim());
+    }
+  } catch {}
+
+  return truncateTelegramErrorDetail(responseText);
+}
 
 function createTelegramApi(botToken: string): TelegramApi {
   const apiUrl = `https://api.telegram.org/bot${botToken}`;
@@ -883,17 +927,26 @@ function createTelegramApi(botToken: string): TelegramApi {
     payload: Record<string, unknown>,
     resultSchema: z.ZodType<Result>,
   ): Promise<Result> {
-    const response = await fetch(`${apiUrl}/${method}`, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-      },
-      body: JSON.stringify(payload),
-    });
+    let response: Response;
+    try {
+      response = await fetch(`${apiUrl}/${method}`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+    } catch (error) {
+      throw new Error(
+        `telegram ${method} network request failed: ${formatTelegramNetworkError(error)}`,
+      );
+    }
 
     if (!response.ok) {
-      const detail = (await response.text()).trim();
-      throw new Error(detail || `telegram ${method} failed: HTTP ${response.status}`);
+      const detail = await readTelegramHttpErrorDetail(response);
+      throw new Error(
+        `telegram ${method} failed: HTTP ${response.status}${detail ? `: ${detail}` : ""}`,
+      );
     }
 
     let raw: unknown;
@@ -911,7 +964,7 @@ function createTelegramApi(botToken: string): TelegramApi {
 
     if (!envelope.ok) {
       const detail = envelope.description?.trim() ?? "";
-      throw new Error(detail || `telegram ${method} request failed`);
+      throw new Error(`telegram ${method} request failed${detail ? `: ${detail}` : ""}`);
     }
 
     return parseOrThrow(

--- a/src/core/telegram/runtime.ts
+++ b/src/core/telegram/runtime.ts
@@ -43,9 +43,26 @@ type RuntimeResources = {
   sessionManager: TelegramSessionManager;
 };
 
+type RuntimeLogEntry = {
+  level: string;
+  message: string;
+  data?: unknown;
+};
+
 const defaultDeps: TelegramRuntimeDependencies = {
   startTelegramAdapter: startTelegramAdapter,
 };
+
+function formatRuntimeLog(scope: string, entry: RuntimeLogEntry): string {
+  const cause =
+    typeof entry.data === "object" &&
+    entry.data !== null &&
+    "cause" in entry.data &&
+    typeof entry.data.cause === "string"
+      ? entry.data.cause.trim()
+      : "";
+  return `[${scope}:${entry.level}] ${entry.message}${cause ? `: ${cause}` : ""}`;
+}
 
 async function closeRuntimeResources(resources: Partial<RuntimeResources>): Promise<void> {
   await Promise.allSettled([
@@ -88,7 +105,7 @@ export async function startTelegramRuntime(
     systemMessage: options.config.systemMessage,
     persistencePath: resolveTelegramSessionStatePath(options.config.workspaceRoot),
     onLog: (entry) => {
-      options.onLog?.(`[telegram:${entry.level}] ${entry.message}`);
+      options.onLog?.(formatRuntimeLog("telegram", entry));
     },
     createClient: options.createSessionClient,
   });
@@ -132,7 +149,7 @@ export async function startTelegramRuntime(
         sessionManager,
         projectPreferences,
         onLog: (entry) => {
-          options.onLog?.(`[telegram:${botId}:${entry.level}] ${entry.message}`);
+          options.onLog?.(formatRuntimeLog(`telegram:${botId}`, entry));
         },
       });
 

--- a/src/core/telegram/runtime.ts
+++ b/src/core/telegram/runtime.ts
@@ -49,18 +49,32 @@ type RuntimeLogEntry = {
   data?: unknown;
 };
 
+const MAX_RUNTIME_LOG_CAUSE_LENGTH = 500;
+
 const defaultDeps: TelegramRuntimeDependencies = {
   startTelegramAdapter: startTelegramAdapter,
 };
 
+function formatRuntimeLogCause(data: unknown): string {
+  if (
+    typeof data !== "object" ||
+    data === null ||
+    !("cause" in data) ||
+    typeof data.cause !== "string"
+  ) {
+    return "";
+  }
+
+  const cause = data.cause.trim().replace(/\s+/g, " ");
+  if (cause.length <= MAX_RUNTIME_LOG_CAUSE_LENGTH) {
+    return cause;
+  }
+
+  return `${cause.slice(0, MAX_RUNTIME_LOG_CAUSE_LENGTH - 1)}…`;
+}
+
 function formatRuntimeLog(scope: string, entry: RuntimeLogEntry): string {
-  const cause =
-    typeof entry.data === "object" &&
-    entry.data !== null &&
-    "cause" in entry.data &&
-    typeof entry.data.cause === "string"
-      ? entry.data.cause.trim()
-      : "";
+  const cause = formatRuntimeLogCause(entry.data);
   return `[${scope}:${entry.level}] ${entry.message}${cause ? `: ${cause}` : ""}`;
 }
 

--- a/test/telegram_adapter.test.js
+++ b/test/telegram_adapter.test.js
@@ -1965,6 +1965,47 @@ describe("telegram adapter", () => {
         entry.message === "telegram poll failed" &&
         String(entry.data?.cause).includes("telegram getUpdates returned"),
     },
+    {
+      name: "Telegram rejects getUpdates with a conflict",
+      handlers: {
+        setMyCommands: async () => createJsonResponse({ ok: true, result: true }),
+        getUpdates: async ({ call }) =>
+          call === 1
+            ? createJsonResponse(
+                {
+                  ok: false,
+                  error_code: 409,
+                  description: "Conflict: terminated by other getUpdates request",
+                },
+                409,
+              )
+            : pendingTelegramCall(),
+      },
+      expectWarning: (entry) =>
+        entry.level === "warn" &&
+        entry.message === "telegram poll failed" &&
+        entry.data?.cause ===
+          "telegram getUpdates failed: HTTP 409: Conflict: terminated by other getUpdates request",
+    },
+    {
+      name: "getUpdates encounters a network failure",
+      handlers: {
+        setMyCommands: async () => createJsonResponse({ ok: true, result: true }),
+        getUpdates: async ({ call }) => {
+          if (call !== 1) {
+            return pendingTelegramCall();
+          }
+
+          const cause = Object.assign(new Error("socket disconnected"), { code: "ECONNRESET" });
+          throw new TypeError("fetch failed", { cause });
+        },
+      },
+      expectWarning: (entry) =>
+        entry.level === "warn" &&
+        entry.message === "telegram poll failed" &&
+        entry.data?.cause ===
+          "telegram getUpdates network request failed: fetch failed: socket disconnected (ECONNRESET)",
+    },
   ])("logs a clear warning when $name", async ({ handlers, expectWarning }) => {
     const managerHarness = createSessionManagerHarness();
     const logs = [];

--- a/test/telegram_runtime.test.js
+++ b/test/telegram_runtime.test.js
@@ -60,7 +60,8 @@ describe("telegram runtime", () => {
           expect(Object.keys(options.projects)).toEqual(["alpha"]);
           options.onLog?.({
             level: "warn",
-            message: "adapter ready",
+            message: "telegram poll failed",
+            data: { cause: "telegram getUpdates failed: HTTP 409: Conflict" },
           });
           return telegramHandle;
         }),
@@ -69,7 +70,7 @@ describe("telegram runtime", () => {
 
     expect(events).toEqual(["start-telegram:token-1:bot-one"]);
     expect(logs).toEqual([
-      "[telegram:bot-one:warn] adapter ready",
+      "[telegram:bot-one:warn] telegram poll failed: telegram getUpdates failed: HTTP 409: Conflict",
       "tau telegram adapter enabled (bot-one)",
     ]);
 

--- a/test/telegram_runtime.test.js
+++ b/test/telegram_runtime.test.js
@@ -80,6 +80,38 @@ describe("telegram runtime", () => {
     expect(events.slice(-1)).toEqual(["close-telegram:bot-one"]);
   });
 
+  it("keeps runtime log causes single-line and bounded", async () => {
+    const logs = [];
+    const runtime = await startTelegramRuntime({
+      config: createTelegramConfig({
+        bots: { "bot-one": { botToken: "token-1" } },
+      }),
+      createSessionClient: vi.fn(),
+      onLog: (line) => {
+        logs.push(line);
+      },
+      deps: {
+        startTelegramAdapter: vi.fn(async (options) => {
+          options.onLog?.({
+            level: "warn",
+            message: "telegram poll failed",
+            data: { cause: `gateway failure\r\n${"x".repeat(600)}` },
+          });
+          return { close: vi.fn(async () => {}) };
+        }),
+      },
+    });
+
+    const warning = logs[0];
+    expect(warning).not.toMatch(/[\r\n]/);
+    expect(warning).toMatch(
+      /^\[telegram:bot-one:warn\] telegram poll failed: gateway failure x+…$/,
+    );
+    expect(warning.length).toBe("[telegram:bot-one:warn] telegram poll failed: ".length + 500);
+
+    await runtime.close();
+  });
+
   it("persists project preferences across runtime restarts", async () => {
     const ownerId = "telegram:bot-one:chat:42";
     const config = createTelegramConfig({


### PR DESCRIPTION
## why

Telegram polling warnings currently discard the structured failure cause at the runtime boundary, leaving every API, response, and network failure as the same `telegram poll failed` line. This makes recurring failures difficult to diagnose and can require code-level investigation to distinguish a duplicate poller from a transient connection problem.

## what

Preserve concise failure causes in Telegram runtime output and make API request errors identify the Telegram method, HTTP status and description, or nested network error code. Unexpected response details are bounded so warnings remain single-line and low-noise.

The adapter coverage now includes Telegram conflict responses and nested network failures, while runtime coverage verifies that structured causes reach the rendered log line.
