### PR TITLE
add local session environment overrides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,7 +167,7 @@ Enabled tools execute directly. Persona and subagent tool lists determine tool a
 
 Prompt/context tag style: use dash-case for XML-like tag names in prompt text (for example `<available-skills>`, `<tool-call>`, `<tool-result>`, `<last-assistant-message-verbatim>`). Do not introduce new snake_case tag names.
 
-**Bash limits**: 1MB raw capture (tail of output, stdout/stderr merged in arrival order), 60s timeout. No TTY/stdin (interactive prompts and editors will hang or fail). Environment sanitized by dropping vars that match sensitive key patterns, git is forced non-interactive (no prompt/editor/pager, batch-mode ssh).
+**Bash limits**: 1MB raw capture (tail of output, stdout/stderr merged in arrival order), 60s timeout. No TTY/stdin (interactive prompts and editors will hang or fail). Inherited host environment variables matching sensitive key patterns are dropped; explicit local execution-environment overrides are then applied unchanged. Git is forced non-interactive (no prompt/editor/pager, batch-mode ssh).
 
 **Model context truncation**: Truncation follows a `num_bytes / 6` token heuristic.
 

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -227,12 +227,17 @@ params (required):
 {
   "executionEnvironment": {
     "kind": "local",
-    "cwd": "/repo"
+    "cwd": "/repo",
+    "env": {
+      "GH_CONFIG_DIR": "/srv/cowork/gh"
+    }
   }
 }
 ```
 
-creates a new hosted session in the selected execution environment and returns its identity. Clients call `session.observe` to establish observation and receive the authoritative initial state. Tau resolves config/content from the selected execution environment cwd before creating the runtime, then stores current settings, bootstrap metadata, lightweight catalog metadata, and prompt composition metadata in the snapshot. Prompt bodies and other large execution-environment content are loaded lazily when used. `session.reload` resolves config/content again and replaces the authoritative snapshot. For local execution environments the `cwd` is resolved on the host, not on the client:
+Creates a new hosted session in the selected execution environment and returns its identity. Clients call `session.observe` to establish observation and receive the authoritative initial state. Tau resolves config/content from the selected execution environment cwd before creating the runtime, then stores current settings, bootstrap metadata, lightweight catalog metadata, and prompt composition metadata in the snapshot. Prompt bodies and other large execution-environment content are loaded lazily when used. `session.reload` resolves config/content again and replaces the authoritative snapshot.
+
+For local execution environments, `cwd` is resolved on the host, not on the client. They also accept optional `env` overrides for tool processes. Tau sanitizes the merged environment and persists the overrides in the session snapshot, so clients should pass non-secret configuration rather than tokens or passwords.
 
 Cloudflare Sandbox execution environments use host-configured bridge ids and already-provisioned sandbox ids. The `cwd` is a real path inside that sandbox:
 

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -237,7 +237,7 @@ params (required):
 
 Creates a new hosted session in the selected execution environment and returns its identity. Clients call `session.observe` to establish observation and receive the authoritative initial state. Tau resolves config/content from the selected execution environment cwd before creating the runtime, then stores current settings, bootstrap metadata, lightweight catalog metadata, and prompt composition metadata in the snapshot. Prompt bodies and other large execution-environment content are loaded lazily when used. `session.reload` resolves config/content again and replaces the authoritative snapshot.
 
-For local execution environments, `cwd` is resolved on the host, not on the client. They also accept optional `env` overrides for tool processes. Tau sanitizes the merged environment and persists the overrides in the session snapshot, so clients should pass non-secret configuration rather than tokens or passwords.
+For local execution environments, `cwd` is resolved on the host, not on the client. They also accept optional `env` overrides for tool processes. Tau sanitizes inherited host variables first, then overlays these explicit values unchanged, including sensitive names such as `GH_TOKEN`. All overrides are persisted in the session snapshot, so clients are responsible for protecting the session store when passing secrets.
 
 Cloudflare Sandbox execution environments use host-configured bridge ids and already-provisioned sandbox ids. The `cwd` is a real path inside that sandbox:
 

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -150,11 +150,16 @@ const session = await client.sessions.create({
   executionEnvironment: {
     kind: "local",
     cwd: "/srv/workspaces/repo",
+    env: {
+      GH_CONFIG_DIR: "/srv/cowork/gh",
+    },
   },
 });
 await session.submit("summarize the PR");
 await client.close();
 ```
+
+Local execution environments accept optional `env` overrides for tool processes. The overrides are sanitized with the host environment and persisted in the session snapshot, so use them for non-secret configuration such as credential-store paths rather than tokens or passwords.
 
 When the host config defines a Cloudflare Sandbox bridge, SDK callers can create a session bound to an already-provisioned sandbox:
 

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -159,7 +159,7 @@ await session.submit("summarize the PR");
 await client.close();
 ```
 
-Local execution environments accept optional `env` overrides for tool processes. The overrides are sanitized with the host environment and persisted in the session snapshot, so use them for non-secret configuration such as credential-store paths rather than tokens or passwords.
+Local execution environments accept optional `env` overrides for tool processes. Tau sanitizes inherited host variables first, then overlays these explicit values unchanged, including names such as `GH_TOKEN`. All overrides are persisted in the session snapshot, so clients are responsible for protecting the session store when passing secrets.
 
 When the host config defines a Cloudflare Sandbox bridge, SDK callers can create a session bound to an already-provisioned sandbox:
 

--- a/src/core/tools/execution_backend.ts
+++ b/src/core/tools/execution_backend.ts
@@ -106,8 +106,10 @@ export function createLocalToolExecutionBackend(
   const spawnCapture = deps?.spawn ?? spawnWithCapture;
   const resolvePath = (path: string): string => resolve(cwdProvider(), path);
   const resolveCwd = (cwd?: string): string => (cwd ? resolve(cwdProvider(), cwd) : cwdProvider());
-  const resolveEnvironment = (env?: Record<string, string>): NodeJS.ProcessEnv =>
-    sanitizeEnvironment({ ...envProvider(), ...env });
+  const resolveEnvironment = (env?: Record<string, string>): NodeJS.ProcessEnv => ({
+    ...sanitizeEnvironment(envProvider()),
+    ...env,
+  });
 
   return {
     async dispose() {},

--- a/src/core/tools/execution_backend.ts
+++ b/src/core/tools/execution_backend.ts
@@ -63,7 +63,12 @@ export interface ToolExecutionBackend {
   dispose(): Promise<void>;
   runBash(
     command: string,
-    options?: { timeoutMs?: number; signal?: AbortSignal; cwd?: string },
+    options?: {
+      timeoutMs?: number;
+      signal?: AbortSignal;
+      cwd?: string;
+      env?: Record<string, string>;
+    },
   ): Promise<BashExecutionResult>;
   runNodeScript(
     script: string,
@@ -72,6 +77,7 @@ export interface ToolExecutionBackend {
       timeoutMs?: number;
       signal?: AbortSignal;
       cwd?: string;
+      env?: Record<string, string>;
       maxCaptureBytes?: number | null;
     },
   ): Promise<BashExecutionResult>;
@@ -100,6 +106,8 @@ export function createLocalToolExecutionBackend(
   const spawnCapture = deps?.spawn ?? spawnWithCapture;
   const resolvePath = (path: string): string => resolve(cwdProvider(), path);
   const resolveCwd = (cwd?: string): string => (cwd ? resolve(cwdProvider(), cwd) : cwdProvider());
+  const resolveEnvironment = (env?: Record<string, string>): NodeJS.ProcessEnv =>
+    sanitizeEnvironment({ ...envProvider(), ...env });
 
   return {
     async dispose() {},
@@ -118,7 +126,7 @@ export function createLocalToolExecutionBackend(
         shell: true,
         stdio: ["ignore", "pipe", "pipe"],
         env: {
-          ...sanitizeEnvironment(envProvider()),
+          ...resolveEnvironment(options.env),
           GIT_TERMINAL_PROMPT: "0",
           GIT_EDITOR: "true",
           GIT_SEQUENCE_EDITOR: "true",
@@ -174,7 +182,7 @@ export function createLocalToolExecutionBackend(
 
       const result = await spawnCapture("node", ["-e", script, ...args], {
         stdio: ["ignore", "pipe", "pipe"],
-        env: sanitizeEnvironment(envProvider()),
+        env: resolveEnvironment(options.env),
         detached: true,
         killProcessGroup: true,
         cwd,
@@ -326,10 +334,15 @@ export function createLocalToolExecutionBackend(
 export function scopeToolExecutionBackend(
   backend: ToolExecutionBackend,
   workingDirectory: string,
+  env?: Record<string, string>,
 ): ToolExecutionBackend {
   const resolvePath = (path: string): string => resolve(workingDirectory, path);
   const resolveCwd = (cwd?: string): string =>
     cwd ? resolve(workingDirectory, cwd) : workingDirectory;
+  const mergeEnvironment = (overrides?: Record<string, string>): { env?: Record<string, string> } => {
+    const merged = { ...env, ...overrides };
+    return Object.keys(merged).length > 0 ? { env: merged } : {};
+  };
 
   return {
     dispose() {
@@ -339,12 +352,14 @@ export function scopeToolExecutionBackend(
       return backend.runBash(command, {
         ...options,
         cwd: resolveCwd(options.cwd),
+        ...mergeEnvironment(options.env),
       });
     },
     runNodeScript(script, args = [], options = {}) {
       return backend.runNodeScript(script, args, {
         ...options,
         cwd: resolveCwd(options.cwd),
+        ...mergeEnvironment(options.env),
       });
     },
     readFile(path) {

--- a/src/core/tools/execution_backend.ts
+++ b/src/core/tools/execution_backend.ts
@@ -339,7 +339,9 @@ export function scopeToolExecutionBackend(
   const resolvePath = (path: string): string => resolve(workingDirectory, path);
   const resolveCwd = (cwd?: string): string =>
     cwd ? resolve(workingDirectory, cwd) : workingDirectory;
-  const mergeEnvironment = (overrides?: Record<string, string>): { env?: Record<string, string> } => {
+  const mergeEnvironment = (
+    overrides?: Record<string, string>,
+  ): { env?: Record<string, string> } => {
     const merged = { ...env, ...overrides };
     return Object.keys(merged).length > 0 ? { env: merged } : {};
   };

--- a/src/execution/local_execution_environment.ts
+++ b/src/execution/local_execution_environment.ts
@@ -10,14 +10,21 @@ import { ToolBackendExecutionEnvironment } from "./tool_backend_execution_enviro
 export class LocalExecutionEnvironment extends ToolBackendExecutionEnvironment<SessionProtocolLocalExecutionEnvironmentSnapshot> {
   readonly kind = "local" as const;
 
-  constructor(options: { cwd: string; home: string; backend: ToolExecutionBackend }) {
+  constructor(options: {
+    cwd: string;
+    home: string;
+    env?: Record<string, string>;
+    backend: ToolExecutionBackend;
+  }) {
     super({
       snapshot: {
         kind: "local",
         cwd: options.cwd,
         home: options.home,
+        ...(options.env && Object.keys(options.env).length > 0 ? { env: options.env } : {}),
       },
       backend: options.backend,
+      env: options.env,
     });
   }
 }
@@ -40,7 +47,7 @@ export class LocalExecutionEnvironmentResolver implements ExecutionEnvironmentRe
     if (input.kind !== "local") {
       throw new Error(`unsupported execution environment kind '${input.kind}'`);
     }
-    return this.createLocalEnvironment(input.cwd);
+    return this.createLocalEnvironment(input.cwd, this.home, input.env ?? {});
   }
 
   canRestore(snapshot: SessionProtocolExecutionEnvironmentSnapshot): boolean {
@@ -51,13 +58,18 @@ export class LocalExecutionEnvironmentResolver implements ExecutionEnvironmentRe
     if (snapshot.kind !== "local") {
       throw new Error(`unsupported execution environment kind '${snapshot.kind}'`);
     }
-    return this.createLocalEnvironment(snapshot.cwd, snapshot.home);
+    return this.createLocalEnvironment(snapshot.cwd, snapshot.home, snapshot.env ?? {});
   }
 
-  private createLocalEnvironment(cwd: string, home = this.home): LocalExecutionEnvironment {
+  private createLocalEnvironment(
+    cwd: string,
+    home: string,
+    env: Record<string, string>,
+  ): LocalExecutionEnvironment {
     return new LocalExecutionEnvironment({
       cwd,
       home,
+      env,
       backend: this.toolBackend,
     });
   }

--- a/src/execution/tool_backend_execution_environment.ts
+++ b/src/execution/tool_backend_execution_environment.ts
@@ -35,12 +35,13 @@ export class ToolBackendExecutionEnvironment<TSnapshot extends BackendExecutionS
   constructor(options: {
     snapshot: TSnapshot;
     backend: ToolExecutionBackend;
+    env?: Record<string, string>;
   }) {
     this.environmentSnapshot = options.snapshot;
     this.cwd = options.snapshot.cwd;
     this.home = options.snapshot.home;
     this.backend = options.backend;
-    this.scopedBackend = scopeToolExecutionBackend(options.backend, this.cwd);
+    this.scopedBackend = scopeToolExecutionBackend(options.backend, this.cwd, options.env);
     this.toolRegistry = ToolCatalog.createRegistry(this.scopedBackend);
   }
 

--- a/src/protocol/session_protocol.ts
+++ b/src/protocol/session_protocol.ts
@@ -92,6 +92,7 @@ export type SessionProtocolInitializeParams = {
 export type SessionProtocolLocalExecutionEnvironmentInput = {
   kind: "local";
   cwd: string;
+  env?: Record<string, string>;
 };
 
 export type SessionProtocolCloudflareSandboxExecutionEnvironmentInput = {
@@ -471,6 +472,7 @@ export type SessionProtocolLocalExecutionEnvironmentSnapshot = {
   kind: "local";
   cwd: string;
   home: string;
+  env?: Record<string, string>;
 };
 
 export type SessionProtocolCloudflareSandboxExecutionEnvironmentSnapshot = {
@@ -1197,11 +1199,18 @@ const sessionProtocolClientToolResultParamsSchema = z.discriminatedUnion("ok", [
 ]);
 
 const absolutePathSchema = nonEmptyStringSchema.refine((value) => value.startsWith("/"));
+const environmentVariableNameSchema = z.string().regex(/^[A-Za-z_][A-Za-z0-9_]*$/);
+const environmentVariableValueSchema = z.string().refine((value) => !value.includes("\0"));
+const environmentVariablesSchema = z.record(
+  environmentVariableNameSchema,
+  environmentVariableValueSchema,
+);
 
 const sessionProtocolLocalExecutionEnvironmentInputSchema = z
   .object({
     kind: z.literal("local"),
     cwd: absolutePathSchema,
+    env: environmentVariablesSchema.optional(),
   })
   .strip();
 
@@ -1368,6 +1377,7 @@ const sessionProtocolLocalExecutionEnvironmentSnapshotSchema = z
     kind: z.literal("local"),
     cwd: nonEmptyStringSchema,
     home: nonEmptyStringSchema,
+    env: environmentVariablesSchema.optional(),
   })
   .strip();
 

--- a/test/local_execution_environment.test.js
+++ b/test/local_execution_environment.test.js
@@ -25,25 +25,45 @@ describe("LocalExecutionEnvironment", () => {
     expect(result.truncated).toBe(false);
   });
 
-  it("scopes environment variables to local tool processes", async () => {
+  it("scopes explicit environment variables without filtering sensitive names", async () => {
     const cwd = process.cwd();
     const environment = new LocalExecutionEnvironment({
       cwd,
       home: process.env.HOME ?? cwd,
-      env: { GH_CONFIG_DIR: "/srv/cowork/gh" },
-      backend: createLocalToolExecutionBackend(),
+      env: {
+        GH_CONFIG_DIR: "/srv/cowork/gh",
+        SESSION_TOKEN: "session-secret",
+      },
+      backend: createLocalToolExecutionBackend({
+        env: {
+          cwd: () => cwd,
+          home: () => cwd,
+          platform: () => process.platform,
+          nodeVersion: () => process.version,
+          env: () => ({
+            PATH: process.env.PATH,
+            HOST_TOKEN: "host-secret",
+            VISIBLE_HOST_VALUE: "visible",
+          }),
+        },
+      }),
     });
 
     const result = await environment
       .getToolExecutionBackend()
-      .runBash('printf "%s" "$GH_CONFIG_DIR"');
+      .runBash(
+        `node -e 'process.stdout.write([process.env.HOST_TOKEN ?? "unset", process.env.SESSION_TOKEN, process.env.VISIBLE_HOST_VALUE].join("|"))'`,
+      );
 
-    expect(result.stdout).toBe("/srv/cowork/gh");
+    expect(result.stdout).toBe("unset|session-secret|visible");
     expect(environment.snapshot()).toEqual({
       kind: "local",
       cwd,
       home: process.env.HOME ?? cwd,
-      env: { GH_CONFIG_DIR: "/srv/cowork/gh" },
+      env: {
+        GH_CONFIG_DIR: "/srv/cowork/gh",
+        SESSION_TOKEN: "session-secret",
+      },
     });
   });
 

--- a/test/local_execution_environment.test.js
+++ b/test/local_execution_environment.test.js
@@ -25,6 +25,28 @@ describe("LocalExecutionEnvironment", () => {
     expect(result.truncated).toBe(false);
   });
 
+  it("scopes environment variables to local tool processes", async () => {
+    const cwd = process.cwd();
+    const environment = new LocalExecutionEnvironment({
+      cwd,
+      home: process.env.HOME ?? cwd,
+      env: { GH_CONFIG_DIR: "/srv/cowork/gh" },
+      backend: createLocalToolExecutionBackend(),
+    });
+
+    const result = await environment
+      .getToolExecutionBackend()
+      .runBash('printf "%s" "$GH_CONFIG_DIR"');
+
+    expect(result.stdout).toBe("/srv/cowork/gh");
+    expect(environment.snapshot()).toEqual({
+      kind: "local",
+      cwd,
+      home: process.env.HOME ?? cwd,
+      env: { GH_CONFIG_DIR: "/srv/cowork/gh" },
+    });
+  });
+
   it("resolves runtime bootstrap through the local execution backend", async () => {
     const cwd = process.cwd();
     const environment = new LocalExecutionEnvironment({
@@ -94,12 +116,14 @@ describe("LocalExecutionEnvironment", () => {
       kind: "local",
       cwd: "/repo",
       home: "/stored/home",
+      env: { GH_CONFIG_DIR: "/stored/gh" },
     });
 
     expect(environment.snapshot()).toEqual({
       kind: "local",
       cwd: "/repo",
       home: "/stored/home",
+      env: { GH_CONFIG_DIR: "/stored/gh" },
     });
   });
 

--- a/test/session_protocol.test.js
+++ b/test/session_protocol.test.js
@@ -75,7 +75,13 @@ describe("session_protocol", () => {
         type: "request",
         id: "req-create",
         method: "session.create",
-        params: { executionEnvironment: { kind: "local", cwd: "/repo" } },
+        params: {
+          executionEnvironment: {
+            kind: "local",
+            cwd: "/repo",
+            env: { GH_CONFIG_DIR: "/srv/cowork/gh" },
+          },
+        },
       }),
     );
     expect(create).toEqual({
@@ -85,7 +91,13 @@ describe("session_protocol", () => {
         type: "request",
         id: "req-create",
         method: "session.create",
-        params: { executionEnvironment: { kind: "local", cwd: "/repo" } },
+        params: {
+          executionEnvironment: {
+            kind: "local",
+            cwd: "/repo",
+            env: { GH_CONFIG_DIR: "/srv/cowork/gh" },
+          },
+        },
       },
     });
 
@@ -699,14 +711,22 @@ describe("session_protocol", () => {
     });
     expect(
       validateSessionProtocolParams("session.create", {
-        executionEnvironment: { kind: "local", cwd: "/repo" },
+        executionEnvironment: {
+          kind: "local",
+          cwd: "/repo",
+          env: { GH_CONFIG_DIR: "/srv/cowork/gh" },
+        },
         personaId: "coder",
         reasoning: "high",
       }),
     ).toEqual({
       ok: true,
       value: {
-        executionEnvironment: { kind: "local", cwd: "/repo" },
+        executionEnvironment: {
+          kind: "local",
+          cwd: "/repo",
+          env: { GH_CONFIG_DIR: "/srv/cowork/gh" },
+        },
         personaId: "coder",
         reasoning: "high",
       },

--- a/test/session_runner.test.js
+++ b/test/session_runner.test.js
@@ -976,7 +976,7 @@ describe("session execution backend plumbing", () => {
     const backend = {
       async dispose() {},
       async runBash(command, options = {}) {
-        calls.push(["runBash", command, options.cwd]);
+        calls.push(["runBash", command, options.cwd, options.env]);
         return {
           output: "",
           stdout: "",
@@ -1016,10 +1016,12 @@ describe("session execution backend plumbing", () => {
       },
     };
 
-    const scoped = scopeToolExecutionBackend(backend, "/remote/work");
+    const scoped = scopeToolExecutionBackend(backend, "/remote/work", {
+      GH_CONFIG_DIR: "/srv/cowork/gh",
+    });
 
     await scoped.runBash("pwd");
-    await scoped.runBash("pwd", { cwd: "subdir" });
+    await scoped.runBash("pwd", { cwd: "subdir", env: { EXTRA: "value" } });
     await scoped.readFile("src/a.ts");
     await scoped.readFileBinary("asset.bin");
     await scoped.writeFile("out.txt", "ok");
@@ -1033,8 +1035,13 @@ describe("session execution backend plumbing", () => {
     });
 
     expect(calls).toEqual([
-      ["runBash", "pwd", "/remote/work"],
-      ["runBash", "pwd", "/remote/work/subdir"],
+      ["runBash", "pwd", "/remote/work", { GH_CONFIG_DIR: "/srv/cowork/gh" }],
+      [
+        "runBash",
+        "pwd",
+        "/remote/work/subdir",
+        { GH_CONFIG_DIR: "/srv/cowork/gh", EXTRA: "value" },
+      ],
       ["readFile", "/remote/work/src/a.ts"],
       ["readFileBinary", "/remote/work/asset.bin"],
       ["writeFile", "/remote/work/out.txt", "ok"],


### PR DESCRIPTION
## why

WebSocket SDK clients need to isolate command-line tool configuration per hosted session without changing the environment of `tau serve` or unrelated sessions.

## what

Local execution environments can now carry optional environment overrides. Tau validates and persists those values, merges them into the sanitized environment used by tool processes, and preserves them when sessions are restored.
