### PR TITLE
upgrade pi packages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,7 +289,7 @@ In TUI mode, `--debug` respects `--persona` and `--no-agent-context-files`, so y
 - `tau serve [--host <host>] [--port <port>] [--auth-token <token>]` - Host session protocol over WebSocket (`TAU_WS_AUTH_TOKEN` can provide the token)
 - `tau attach [--session <id> | --new --cwd <path>] [--auth-token <token>] ws://host:port` - Run the terminal UI against a WebSocket session host
 - `tau attach [--session <id> | --new --cwd <path>] -- <command...>` - Run the terminal UI against a session-protocol command, for example `ssh vps 'tau rpc'`; without `--session` or `--new`, attach lists hosted sessions and prompts for a selection, and new sessions require a host-local execution cwd
-- `tau auth login codex` - OAuth login for ChatGPT Plus/Pro; stores `~/.config/tau/auth.json`
+- `tau auth login codex` - Browser or device-code OAuth login for ChatGPT Plus/Pro; stores `~/.config/tau/auth.json`
 - `tau auth list` - List authenticated accounts and usage windows
 - `tau auth logout codex --account <email>` - Remove stored OAuth credentials
 - `tau usage` - Summarize usage logs from `~/.config/tau/logs/`

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ to use the OpenAI Codex subscription provider (`openai-codex`), run:
 tau auth login codex
 ```
 
-this prints a login URL and starts a local callback server on `127.0.0.1:1455`. complete the login in your browser and tau will store tokens in `~/.config/tau/auth.json`. if port `1455` is already in use, or the browser callback fails, tau will prompt you to paste the redirect URL/code. if you see token refresh errors later, run the login command again to re-authenticate.
+this prompts you to choose browser or device-code login. browser login prints a URL and starts a local callback server on `127.0.0.1:1455`; if the callback fails, tau prompts you to paste the redirect URL/code. device-code login prints a verification URL and code instead. tau stores tokens in `~/.config/tau/auth.json`. if you see token refresh errors later, run the login command again to re-authenticate.
 
 to list authenticated accounts and usage:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@markusylisiurunen/tau",
       "version": "0.3.22",
       "dependencies": {
-        "@earendil-works/pi-ai": "0.80.6",
-        "@earendil-works/pi-tui": "0.80.6",
+        "@earendil-works/pi-ai": "0.80.10",
+        "@earendil-works/pi-tui": "0.80.10",
         "@fly/sprites": "^0.0.1",
         "chalk": "^5.6.2",
         "file-type": "^21.3.4",
@@ -658,9 +658,9 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.6.tgz",
-      "integrity": "sha512-7xfLk8sANBp+bpPEbjoOZTbPxsa+++b1JXAoSJsNa3vbs9AHHEclmvg54XLQcxH+fuwaeti/g2jeIfJ+mVYLpA==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.10.tgz",
+      "integrity": "sha512-Moe/H8c87yacDGK9dPbWphZNjVsrb3nTrIHycOQJAkFEnY9PYxOOd74+ny44kATfPU9Dm7aTHefar3pZF+UKUA==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -689,9 +689,9 @@
       "license": "MIT"
     },
     "node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.6.tgz",
-      "integrity": "sha512-bSuzS4EVSqEPj/Qr/p9eqCESfKsGuDNbl77EGci8Iaqqt/C/XCBZL1MjXaxSWW1NsT5afjp/Cb0NTPzOLv/aPA==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.10.tgz",
+      "integrity": "sha512-c2JO29PbhKPEQ6fgHQKAl0WhwuFqzWfzspMmP+8B5tpDuP+0mvarRbKKg8gq4b+pQx/QX+6aVS4ko7deoyjQjg==",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "0.80.6",
-    "@earendil-works/pi-tui": "0.80.6",
+    "@earendil-works/pi-ai": "0.80.10",
+    "@earendil-works/pi-tui": "0.80.10",
     "@fly/sprites": "^0.0.1",
     "chalk": "^5.6.2",
     "file-type": "^21.3.4",

--- a/src/core/auth/auth_manager.ts
+++ b/src/core/auth/auth_manager.ts
@@ -1,4 +1,4 @@
-import type { OAuthCredentials } from "@earendil-works/pi-ai";
+import type { OAuthCredential } from "@earendil-works/pi-ai";
 import type { AuthStorage } from "./auth_storage.js";
 import type { AuthProviderAdapter } from "./provider_adapter.js";
 import { OpenAICodexAdapter } from "./providers/openai_codex.js";
@@ -53,7 +53,7 @@ export class AuthManager {
     return results;
   }
 
-  addOAuthAccount(providerId: string, credentials: OAuthCredentials): void {
+  addOAuthAccount(providerId: string, credentials: OAuthCredential): void {
     const adapter = this.adapters.get(providerId);
     if (!adapter) {
       throw new Error(`unsupported auth provider "${providerId}"`);

--- a/src/core/auth/cli.ts
+++ b/src/core/auth/cli.ts
@@ -1,21 +1,16 @@
-import type { OAuthCredentials, OAuthPrompt, OAuthProvider } from "@earendil-works/pi-ai";
-import { loginOpenAICodex } from "@earendil-works/pi-ai/oauth";
+import type { AuthInteraction, AuthPrompt, OAuthCredential } from "@earendil-works/pi-ai";
+import { openaiCodexProvider } from "@earendil-works/pi-ai/providers/openai-codex";
 import { Chalk } from "chalk";
-import { CODEX_ORIGINATOR } from "../utils/codex.js";
 import { AuthManager } from "./auth_manager.js";
 import type { AuthStorage } from "./auth_storage.js";
 
 export type AuthLog = (message: string) => void;
-export type AuthPromptFn = (prompt: OAuthPrompt) => Promise<string>;
+export type AuthPromptFn = (prompt: AuthPrompt) => Promise<string>;
 
-export type AuthLoginHandler = (callbacks: {
-  onAuth: (info: { url: string; instructions?: string }) => void;
-  onPrompt: (prompt: OAuthPrompt) => Promise<string>;
-  onProgress?: (message: string) => void;
-}) => Promise<OAuthCredentials>;
+export type AuthLoginHandler = (interaction: AuthInteraction) => Promise<OAuthCredential>;
 
 export type OAuthProviderSpec = {
-  id: OAuthProvider;
+  id: string;
   cliId: string;
   label: string;
 };
@@ -30,14 +25,13 @@ export const SUPPORTED_OAUTH_PROVIDERS: OAuthProviderSpec[] = [
   { id: "openai-codex", cliId: "codex", label: "OpenAI Codex (ChatGPT Plus/Pro)" },
 ];
 
-const DEFAULT_LOGIN_HANDLERS: Partial<Record<OAuthProvider, AuthLoginHandler>> = {
-  "openai-codex": (callbacks) =>
-    loginOpenAICodex({
-      onAuth: callbacks.onAuth,
-      onPrompt: callbacks.onPrompt,
-      onProgress: callbacks.onProgress,
-      originator: CODEX_ORIGINATOR,
-    }),
+const openaiCodexOAuth = openaiCodexProvider().auth.oauth;
+if (!openaiCodexOAuth) {
+  throw new Error("OpenAI Codex provider is missing OAuth support");
+}
+
+const DEFAULT_LOGIN_HANDLERS: Partial<Record<string, AuthLoginHandler>> = {
+  "openai-codex": (interaction) => openaiCodexOAuth.login(interaction),
 };
 
 const chalk = new Chalk({ level: process.stdout.isTTY ? 2 : 0 });
@@ -138,11 +132,14 @@ async function promptForProvider(
   prompt: AuthPromptFn,
   log: AuthLog,
   providers: OAuthProviderSpec[],
-): Promise<OAuthProvider> {
+): Promise<string> {
   log("select a provider:\n");
   log(formatProviderList(providers));
   log("");
-  const selection = await prompt({ message: `enter number (1-${providers.length}):` });
+  const selection = await prompt({
+    type: "text",
+    message: `enter number (1-${providers.length}):`,
+  });
   const index = Number.parseInt(selection, 10) - 1;
   if (!Number.isFinite(index) || index < 0 || index >= providers.length) {
     throw new Error("invalid selection.");
@@ -153,7 +150,7 @@ async function promptForProvider(
 function resolveProvider(
   providerArg: string | undefined,
   providers: OAuthProviderSpec[],
-): OAuthProvider | undefined {
+): string | undefined {
   if (!providerArg) return undefined;
   const normalized = normalizeProvider(providerArg);
   const resolved = providers.find(
@@ -173,7 +170,7 @@ export async function runLoginCommand(options: {
   prompt: AuthPromptFn;
   log?: AuthLog;
   providers?: OAuthProviderSpec[];
-  loginHandlers?: Partial<Record<OAuthProvider, AuthLoginHandler>>;
+  loginHandlers?: Partial<Record<string, AuthLoginHandler>>;
 }): Promise<void> {
   const log = options.log ?? console.log;
   const providers = options.providers ?? SUPPORTED_OAUTH_PROVIDERS;
@@ -183,9 +180,7 @@ export async function runLoginCommand(options: {
     provider = await promptForProvider(options.prompt, log, providers);
   }
 
-  const handlers = { ...DEFAULT_LOGIN_HANDLERS, ...options.loginHandlers } as Partial<
-    Record<OAuthProvider, AuthLoginHandler>
-  >;
+  const handlers = { ...DEFAULT_LOGIN_HANDLERS, ...options.loginHandlers };
   const handler = handlers[provider];
 
   if (!handler) {
@@ -195,26 +190,33 @@ export async function runLoginCommand(options: {
 
   log(`logging in to ${provider}...`);
 
-  const credentials = (await handler({
-    onAuth: (info) => {
-      log("");
-      if (provider === "openai-codex") {
+  const credentials = await handler({
+    prompt: options.prompt,
+    notify: (event) => {
+      if (event.type === "auth_url") {
+        log("");
         log("copy this url into your browser to complete login:");
-      } else {
-        log("open this url in your browser:");
-      }
-      log(info.url);
-      if (info.instructions) {
-        log(info.instructions);
-      }
-      if (provider === "openai-codex") {
+        log(event.url);
+        if (event.instructions) {
+          log(event.instructions);
+        }
         log("if the browser callback fails, you'll be prompted to paste the redirect url/code.");
+        log("");
+        return;
       }
-      log("");
+
+      if (event.type === "device_code") {
+        log("");
+        log("open this url in your browser:");
+        log(event.verificationUri);
+        log(`enter code: ${event.userCode}`);
+        log("");
+        return;
+      }
+
+      log(event.message);
     },
-    onPrompt: async (prompt) => options.prompt(prompt),
-    onProgress: (message) => log(message),
-  })) as OAuthCredentials;
+  });
 
   const authManager = new AuthManager(options.authStorage);
   authManager.addOAuthAccount(provider, credentials);

--- a/src/core/auth/credential_store.ts
+++ b/src/core/auth/credential_store.ts
@@ -1,4 +1,4 @@
-import type { Credential, CredentialStore } from "@earendil-works/pi-ai";
+import type { Credential, CredentialInfo, CredentialStore } from "@earendil-works/pi-ai";
 import type { Config } from "../config/schema.js";
 import { getApiKeyForProvider } from "../config/schema.js";
 import { resolveProviderApiKey } from "../models/catalog.js";
@@ -29,6 +29,21 @@ export class TauCredentialStore implements CredentialStore {
     }
 
     return this.readConfiguredCredential(providerId);
+  }
+
+  async list(): Promise<readonly CredentialInfo[]> {
+    this.options.authStorage.reload();
+    const invalidReason = this.options.authStorage.getInvalidReason();
+    if (invalidReason) {
+      throw new Error(invalidReason);
+    }
+
+    return Object.entries(this.options.authStorage.getData().providers).flatMap(
+      ([providerId, provider]) => {
+        const account = provider.accounts[0];
+        return account ? [{ providerId, type: account.type }] : [];
+      },
+    );
   }
 
   async modify(

--- a/src/core/auth/provider_adapter.ts
+++ b/src/core/auth/provider_adapter.ts
@@ -1,4 +1,4 @@
-import type { OAuthCredentials } from "@earendil-works/pi-ai";
+import type { OAuthCredential } from "@earendil-works/pi-ai";
 import type { AuthStorage } from "./auth_storage.js";
 import type { AuthAccountInfo } from "./types.js";
 
@@ -10,8 +10,8 @@ export type AuthProviderSelection = {
 export interface AuthProviderAdapter {
   id: string;
   label: string;
-  validateOAuthCredentials?: (credentials: OAuthCredentials) => void;
-  addOAuthAccount: (authStorage: AuthStorage, credentials: OAuthCredentials) => void;
+  validateOAuthCredentials?: (credentials: OAuthCredential) => void;
+  addOAuthAccount: (authStorage: AuthStorage, credentials: OAuthCredential) => void;
   removeAccount: (authStorage: AuthStorage, accountId: string) => boolean;
   listAccountInfo: (authStorage: AuthStorage) => Promise<AuthAccountInfo[]>;
   selectAccount: (authStorage: AuthStorage) => Promise<AuthProviderSelection | undefined>;

--- a/src/core/auth/providers/openai_codex.ts
+++ b/src/core/auth/providers/openai_codex.ts
@@ -1,5 +1,5 @@
-import type { OAuthCredentials, OAuthProvider } from "@earendil-works/pi-ai";
-import { getOAuthApiKey, refreshOpenAICodexToken } from "@earendil-works/pi-ai/oauth";
+import type { OAuthCredential } from "@earendil-works/pi-ai";
+import { openaiCodexProvider } from "@earendil-works/pi-ai/providers/openai-codex";
 import type { AuthStorage } from "../auth_storage.js";
 import { decodeJwtPayload } from "../jwt.js";
 import type { AuthProviderAdapter, AuthProviderSelection } from "../provider_adapter.js";
@@ -16,6 +16,15 @@ const PROVIDER_LABEL = "OpenAI Codex";
 const USAGE_ENDPOINT = "https://chatgpt.com/backend-api/wham/usage";
 const FORCED_ACCOUNT_ENV = "TAU_CODEX_ACCOUNT";
 const ALLOWED_USAGE_WINDOW_SECONDS = new Set([5 * 60 * 60, 7 * 24 * 60 * 60]);
+const openaiCodexOAuth = getOpenAICodexOAuth();
+
+function getOpenAICodexOAuth() {
+  const oauth = openaiCodexProvider().auth.oauth;
+  if (!oauth) {
+    throw new Error("OpenAI Codex provider is missing OAuth support");
+  }
+  return oauth;
+}
 
 class UnexpectedUsageWindowError extends Error {
   constructor(name: "primary" | "secondary", windowSeconds: number) {
@@ -34,11 +43,11 @@ export class OpenAICodexAdapter implements AuthProviderAdapter {
   readonly id = PROVIDER_ID;
   readonly label = PROVIDER_LABEL;
 
-  validateOAuthCredentials(credentials: OAuthCredentials): void {
+  validateOAuthCredentials(credentials: OAuthCredential): void {
     assertCodexClaims(credentials);
   }
 
-  addOAuthAccount(authStorage: AuthStorage, credentials: OAuthCredentials): void {
+  addOAuthAccount(authStorage: AuthStorage, credentials: OAuthCredential): void {
     const claims = assertCodexClaims(credentials);
     const accountId = claims.accountId;
     const account: CodexAccount = {
@@ -171,21 +180,21 @@ export class OpenAICodexAdapter implements AuthProviderAdapter {
     const account = getAccounts(authStorage).find((entry) => entry.accountId === accountId);
     if (!account) return undefined;
 
-    const result = await getOAuthApiKey(PROVIDER_ID as OAuthProvider, {
-      [PROVIDER_ID]: toOAuthCredentials(account),
-    });
-    if (!result) return undefined;
+    let credential = toOAuthCredential(account);
+    if (Date.now() >= credential.expires) {
+      credential = await openaiCodexOAuth.refresh(credential);
+    }
 
     const updateResult = updateStoredOAuthAccount(authStorage, account, (current) =>
-      shouldUpdateAccount(current, result.newCredentials)
-        ? mergeUpdatedCredentials(current, result.newCredentials)
+      shouldUpdateAccount(current, credential)
+        ? mergeUpdatedCredentials(current, credential)
         : current,
     );
     if (updateResult.status !== "updated") {
       return undefined;
     }
 
-    return result.apiKey;
+    return (await openaiCodexOAuth.toAuth(toOAuthCredential(updateResult.account))).apiKey;
   }
 
   getForcedAccountId(authStorage: AuthStorage): string | undefined {
@@ -241,7 +250,7 @@ export class OpenAICodexAdapter implements AuthProviderAdapter {
     account: CodexAccount,
   ): Promise<CodexAccount | undefined> {
     try {
-      const refreshedCredentials = await refreshOpenAICodexToken(account.refresh);
+      const refreshedCredentials = await openaiCodexOAuth.refresh(toOAuthCredential(account));
       const updateResult = updateStoredOAuthAccount(authStorage, account, (current) =>
         shouldUpdateAccount(current, refreshedCredentials)
           ? mergeUpdatedCredentials(current, refreshedCredentials)
@@ -349,8 +358,9 @@ function readForcedAccountIdentifier(): { raw: string; identifier: string } | un
   return identifier ? { raw, identifier } : undefined;
 }
 
-function toOAuthCredentials(account: CodexAccount): OAuthCredentials {
-  const credentials: OAuthCredentials = {
+function toOAuthCredential(account: CodexAccount): OAuthCredential {
+  const credential: OAuthCredential = {
+    type: "oauth",
     refresh: account.refresh,
     access: account.access,
     expires: account.expires,
@@ -358,12 +368,12 @@ function toOAuthCredentials(account: CodexAccount): OAuthCredentials {
     projectId: account.projectId,
   };
   if (account.providerAccountId) {
-    credentials.accountId = account.providerAccountId;
+    credential.accountId = account.providerAccountId;
   }
-  return credentials;
+  return credential;
 }
 
-function assertCodexClaims(credentials: OAuthCredentials): {
+function assertCodexClaims(credentials: OAuthCredential): {
   accountId: string;
   email: string;
   plan: string;
@@ -592,7 +602,7 @@ function normalizeNumber(value: unknown): number {
   return typeof value === "number" && !Number.isNaN(value) ? Math.round(value) : 0;
 }
 
-function shouldUpdateAccount(current: CodexAccount, updated: OAuthCredentials): boolean {
+function shouldUpdateAccount(current: CodexAccount, updated: OAuthCredential): boolean {
   const updatedAccountId = normalizeString(updated.accountId);
   const updatedEnterpriseUrl = normalizeString(updated.enterpriseUrl);
   const updatedProjectId = normalizeString(updated.projectId);
@@ -606,7 +616,7 @@ function shouldUpdateAccount(current: CodexAccount, updated: OAuthCredentials): 
   );
 }
 
-function mergeUpdatedCredentials(account: CodexAccount, updated: OAuthCredentials): CodexAccount {
+function mergeUpdatedCredentials(account: CodexAccount, updated: OAuthCredential): CodexAccount {
   return {
     ...account,
     access: updated.access,

--- a/src/main.ts
+++ b/src/main.ts
@@ -643,11 +643,25 @@ if (argv[0] === "auth") {
   const authPath = getAuthPath();
   const authStorage = new AuthStorage(authPath);
   const rl = createInterface({ input: process.stdin, output: process.stdout });
-  const prompt: AuthPromptFn = (question) =>
-    new Promise((resolve) => {
-      const suffix = question.placeholder ? ` (${question.placeholder})` : "";
-      rl.question(`${question.message}${suffix} `, resolve);
-    });
+  const ask = (question: string): Promise<string> =>
+    new Promise((resolve) => rl.question(question, resolve));
+  const prompt: AuthPromptFn = async (question) => {
+    if (question.type === "select") {
+      console.log(question.message);
+      question.options.forEach((option, index) => {
+        console.log(`  ${index + 1}. ${option.label}`);
+      });
+      const answer = await ask(`enter number (1-${question.options.length}): `);
+      const option = question.options[Number.parseInt(answer, 10) - 1];
+      if (!option) {
+        throw new Error("invalid selection.");
+      }
+      return option.id;
+    }
+
+    const suffix = question.placeholder ? ` (${question.placeholder})` : "";
+    return ask(`${question.message}${suffix} `);
+  };
 
   try {
     if (command.type === "login") {

--- a/test/auth_cli.test.js
+++ b/test/auth_cli.test.js
@@ -73,6 +73,7 @@ describe("auth cli", () => {
       const authStorage = new AuthStorage(fx.authPath);
       const accountId = "acct-123";
       const credentials = {
+        type: "oauth",
         access: createAccessToken({
           accountId,
           email: "user@example.com",
@@ -135,10 +136,14 @@ describe("auth cli", () => {
         },
         log: () => {},
         loginHandlers: {
-          "openai-codex": async (callbacks) => {
-            const input = await callbacks.onPrompt({ message: "Paste code:" });
+          "openai-codex": async (interaction) => {
+            const input = await interaction.prompt({
+              type: "manual_code",
+              message: "Paste code:",
+            });
             const accountId = `acct-${input}`;
             return {
+              type: "oauth",
               access: createAccessToken({
                 accountId,
                 email: `user+${input}@example.com`,

--- a/test/auth_storage.test.js
+++ b/test/auth_storage.test.js
@@ -13,16 +13,23 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@earendil-works/pi-ai/oauth", async (importOriginal) => {
-  const actual = await importOriginal();
-  return {
-    ...actual,
-    getOAuthApiKey: vi.fn(),
-    refreshOpenAICodexToken: vi.fn(),
-  };
-});
+const { codexLogin, codexRefresh, codexToAuth } = vi.hoisted(() => ({
+  codexLogin: vi.fn(),
+  codexRefresh: vi.fn(),
+  codexToAuth: vi.fn(),
+}));
 
-const { getOAuthApiKey, refreshOpenAICodexToken } = await import("@earendil-works/pi-ai/oauth");
+vi.mock("@earendil-works/pi-ai/providers/openai-codex", () => ({
+  openaiCodexProvider: () => ({
+    auth: {
+      oauth: {
+        login: codexLogin,
+        refresh: codexRefresh,
+        toAuth: codexToAuth,
+      },
+    },
+  }),
+}));
 
 import { AuthManager } from "../dist/core/auth/auth_manager.js";
 import { AuthStorage } from "../dist/core/auth/auth_storage.js";
@@ -72,7 +79,11 @@ function deferred() {
 }
 
 beforeEach(() => {
-  vi.clearAllMocks();
+  codexLogin.mockReset();
+  codexRefresh.mockReset().mockImplementation(async (credential) => credential);
+  codexToAuth.mockReset().mockImplementation(async (credential) => ({
+    apiKey: credential.access,
+  }));
 });
 
 afterEach(() => {
@@ -269,7 +280,7 @@ describe("AuthManager and TauCredentialStore", () => {
       );
       const refreshStarted = deferred();
       const releaseRefresh = deferred();
-      refreshOpenAICodexToken.mockImplementation(async () => {
+      codexRefresh.mockImplementation(async () => {
         refreshStarted.resolve();
         return await releaseRefresh.promise;
       });
@@ -281,6 +292,7 @@ describe("AuthManager and TauCredentialStore", () => {
       const logoutStorage = new AuthStorage(fx.authPath);
       new AuthManager(logoutStorage).removeAccount("openai-codex", "acct-race");
       releaseRefresh.resolve({
+        type: "oauth",
         access: refreshedAccess,
         refresh: "refresh-race-next",
         expires: Number.MAX_SAFE_INTEGER,
@@ -318,10 +330,6 @@ describe("AuthManager and TauCredentialStore", () => {
         }),
         { mode: 0o600 },
       );
-      getOAuthApiKey.mockImplementation(async (_provider, providers) => ({
-        apiKey: providers["openai-codex"].access,
-        newCredentials: providers["openai-codex"],
-      }));
       const refreshStarted = deferred();
       const releaseRefresh = deferred();
       const store = new TauCredentialStore({
@@ -378,7 +386,7 @@ describe("AuthManager and TauCredentialStore", () => {
       const bothRefreshesStarted = deferred();
       const refreshes = [deferred(), deferred()];
       let refreshCallCount = 0;
-      getOAuthApiKey.mockImplementation(async () => {
+      codexRefresh.mockImplementation(async () => {
         const callIndex = refreshCallCount++;
         if (refreshCallCount === 2) {
           bothRefreshesStarted.resolve();
@@ -397,13 +405,11 @@ describe("AuthManager and TauCredentialStore", () => {
       await bothRefreshesStarted.promise;
 
       refreshes[0].resolve({
-        apiKey: "api-newer",
-        newCredentials: {
-          access: "access-newer",
-          refresh: "refresh-newer",
-          expires: 100,
-          accountId: "acct-parallel",
-        },
+        type: "oauth",
+        access: "access-newer",
+        refresh: "refresh-newer",
+        expires: 100,
+        accountId: "acct-parallel",
       });
       await expect(firstRead).resolves.toMatchObject({
         type: "oauth",
@@ -412,13 +418,11 @@ describe("AuthManager and TauCredentialStore", () => {
       });
 
       refreshes[1].resolve({
-        apiKey: "api-stale",
-        newCredentials: {
-          access: "access-stale",
-          refresh: "refresh-stale",
-          expires: 200,
-          accountId: "acct-parallel",
-        },
+        type: "oauth",
+        access: "access-stale",
+        refresh: "refresh-stale",
+        expires: 200,
+        accountId: "acct-parallel",
       });
       await expect(secondRead).resolves.toBeUndefined();
 
@@ -470,16 +474,13 @@ describe("AuthManager and TauCredentialStore", () => {
         ),
       );
 
-      refreshOpenAICodexToken.mockResolvedValue({
+      codexRefresh.mockResolvedValue({
+        type: "oauth",
         access: refreshedAccess,
         refresh: "refresh-plan-next",
         expires: Number.MAX_SAFE_INTEGER,
         accountId: "acct-plan",
       });
-      getOAuthApiKey.mockImplementation(async (_provider, providers) => ({
-        apiKey: providers["openai-codex"].access,
-        newCredentials: providers["openai-codex"],
-      }));
       vi.stubGlobal(
         "fetch",
         vi.fn(async () => ({
@@ -566,13 +567,9 @@ describe("AuthManager and TauCredentialStore", () => {
         ),
       );
 
-      getOAuthApiKey.mockImplementation(async (_provider, providers) => {
-        const account = providers["openai-codex"];
-        return {
-          apiKey: account.refresh === "refresh-exhausted" ? "api-exhausted" : "api-next",
-          newCredentials: account,
-        };
-      });
+      codexToAuth.mockImplementation(async (credential) => ({
+        apiKey: credential.refresh === "refresh-exhausted" ? "api-exhausted" : "api-next",
+      }));
 
       vi.stubGlobal(
         "fetch",
@@ -606,6 +603,55 @@ describe("AuthManager and TauCredentialStore", () => {
 
       expect(credential?.type).toBe("oauth");
       expect(credential?.refresh).toBe("refresh-next");
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("lists stored credential metadata without resolving credentials", async () => {
+    const fx = createTempAuthPath();
+    try {
+      writeFileSync(
+        fx.authPath,
+        JSON.stringify({
+          providers: {
+            "openai-codex": {
+              accounts: [
+                {
+                  type: "oauth",
+                  accountId: "acct-list",
+                  access: "access-list",
+                  refresh: "refresh-list",
+                  expires: 0,
+                },
+              ],
+            },
+            anthropic: {
+              accounts: [
+                {
+                  type: "api_key",
+                  accountId: "anthropic:default",
+                  key: "secret-key",
+                },
+              ],
+            },
+            empty: { accounts: [] },
+          },
+        }),
+        { mode: 0o600 },
+      );
+
+      const store = new TauCredentialStore({
+        authStorage: new AuthStorage(fx.authPath),
+        getConfig: () => ({}),
+      });
+
+      await expect(store.list()).resolves.toEqual([
+        { providerId: "openai-codex", type: "oauth" },
+        { providerId: "anthropic", type: "api_key" },
+      ]);
+      expect(codexRefresh).not.toHaveBeenCalled();
+      expect(codexToAuth).not.toHaveBeenCalled();
     } finally {
       fx.cleanup();
     }
@@ -712,11 +758,6 @@ describe("AuthManager and TauCredentialStore", () => {
         ),
       );
 
-      getOAuthApiKey.mockImplementation(async (_provider, providers) => ({
-        apiKey: providers["openai-codex"].access,
-        newCredentials: providers["openai-codex"],
-      }));
-
       let sessionId = "session-1";
       const storage = new AuthStorage(fx.authPath);
       const store = new TauCredentialStore({
@@ -803,10 +844,6 @@ describe("AuthManager and TauCredentialStore", () => {
         ),
       );
 
-      getOAuthApiKey.mockImplementation(async (_provider, providers) => ({
-        apiKey: providers["openai-codex"].access,
-        newCredentials: providers["openai-codex"],
-      }));
       vi.stubGlobal(
         "fetch",
         vi.fn(async (_url, init) => {
@@ -882,16 +919,6 @@ describe("AuthManager and TauCredentialStore", () => {
           2,
         ),
       );
-
-      getOAuthApiKey.mockResolvedValue({
-        apiKey: "new-access",
-        newCredentials: {
-          access: "old-access",
-          refresh: "old-refresh",
-          expires: 0,
-          accountId: "provider-old",
-        },
-      });
 
       vi.stubGlobal(
         "fetch",


### PR DESCRIPTION
## why

Tau was pinned to pi-ai and pi-tui 0.80.6. The 0.80.10 releases include model/runtime fixes and terminal handling improvements, while pi-ai 0.80.8 replaces the legacy global OAuth helpers with provider-owned authentication contracts.

## what

Upgrade pi-ai and pi-tui to 0.80.10 and migrate Tau's Codex authentication integration to the provider-owned login, refresh, and auth derivation APIs. Implement credential metadata enumeration, support the canonical browser and device-code login interaction, update the auth tests, and document the login choices.
