### PR TITLE
add Cowork repository setup

### DIFF
--- a/.cowork/prompts/issue-implement.append.md
+++ b/.cowork/prompts/issue-implement.append.md
@@ -1,0 +1,1 @@
+Inspect @@skill:deslop for additional guidance on evolving abstractions, preserving clean boundaries, and leaving affected code coherent. Apply relevant principles while implementing the issue, but do not perform a separate deslop pass or broaden the workflow into a general cleanup task.

--- a/.cowork/prompts/pull-request-deslop.append.md
+++ b/.cowork/prompts/pull-request-deslop.append.md
@@ -1,0 +1,1 @@
+Use @@skill:deslop for additional cleanup guidance. Apply its principles while preserving the pull request's intended behavior and following the built-in workflow contract, repository instructions, verification requirements, and required pull request comment.

--- a/.cowork/prompts/pull-request-review.append.md
+++ b/.cowork/prompts/pull-request-review.append.md
@@ -1,0 +1,1 @@
+Inspect @@skill:code-review for additional guidance on finding, validating, and prioritizing actionable issues. Apply relevant review principles, but follow the built-in workflow's scope, materiality threshold, inline-comment format, and GitHub publication contract instead of the skill's aggregate output format.

--- a/.cowork/scripts/init
+++ b/.cowork/scripts/init
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+npm ci
+(cd src/diff_tool/app && npm ci)
+npm run build


### PR DESCRIPTION
## why

Cowork workspaces for Tau should start with the repository fully installed and built, and Tau's existing review and cleanup skills should inform the corresponding automated workflows without replacing Cowork's workflow contracts.

## what

Add repository-specific Cowork prompt guidance for issue implementation, pull request review, and pull request cleanup. The guidance activates Tau's existing `deslop` and `code-review` skills while preserving each workflow's scope and publication requirements.

Add an executable workspace initialization script that installs the locked dependencies for both the root package and the built-in diff tool app, then builds Tau before the session starts.
