### PR TITLE
show real targets for queued tool calls

### DIFF
--- a/src/core/session/runner.ts
+++ b/src/core/session/runner.ts
@@ -288,14 +288,18 @@ function prepareToolCall(
   return { type: "ready", toolCall, definition };
 }
 
-function createToolQueuedEvent(toolCall: ToolCall): CoreToolUiEvent {
+function createToolQueuedEvent(
+  prepared: Extract<PreparedToolCall, { type: "ready" }>,
+  context: ToolDispatchContext,
+): CoreToolUiEvent {
+  const { toolCall, definition } = prepared;
   return {
     type: "tool_ui",
     uiEvent: {
       type: "tool_call_queued",
       toolCallId: toolCall.id,
       toolName: toolCall.name,
-      headerTarget: toolCall.name,
+      headerTarget: definition.getDisplayTarget(toolCall, context),
     },
   };
 }
@@ -320,7 +324,9 @@ export class SequentialToolCallRunner implements AsyncIterable<ToolRunnerEvent> 
   enqueue(toolCall: ToolCall): CoreToolUiEvent | undefined {
     const prepared = prepareToolCall(toolCall, this.options);
     this.enqueuePrepared(prepared);
-    return prepared.type === "ready" ? createToolQueuedEvent(toolCall) : undefined;
+    return prepared.type === "ready"
+      ? createToolQueuedEvent(prepared, this.options.dispatchContext)
+      : undefined;
   }
 
   enqueueRejected(toolCall: ToolCall, message: string): void {
@@ -462,7 +468,7 @@ export async function* runToolCalls(
       break;
     }
     if (prepared.type === "ready") {
-      yield createToolQueuedEvent(prepared.toolCall);
+      yield createToolQueuedEvent(prepared, dispatchContext);
     }
   }
 

--- a/src/core/tools/bash.ts
+++ b/src/core/tools/bash.ts
@@ -380,9 +380,18 @@ function parseBashArgs(raw: unknown):
   };
 }
 
+function getBashDisplayTarget(raw: unknown): string {
+  const parsedArgs = parseBashArgs(raw);
+  if (!parsedArgs.ok) {
+    return "(invalid arguments)";
+  }
+  return parsedArgs.data.commandForDisplay.split(/\r?\n/)[0] ?? parsedArgs.data.commandForDisplay;
+}
+
 export function createBashToolDefinition(backend: ToolExecutionBackend): ToolDefinition {
   return {
     schema: BASH_TOOL,
+    getDisplayTarget: (toolCall) => getBashDisplayTarget(toolCall.arguments),
     async dispatch(
       toolCall: ToolCall,
       signal: AbortSignal,
@@ -392,7 +401,7 @@ export function createBashToolDefinition(backend: ToolExecutionBackend): ToolDef
       const commandForDisplay = parsedArgs.ok
         ? parsedArgs.data.commandForDisplay
         : parsedArgs.commandForDisplay;
-      const headerTarget = commandForDisplay.split(/\r?\n/)[0] ?? commandForDisplay;
+      const headerTarget = getBashDisplayTarget(toolCall.arguments);
 
       const blocked = (reason: string): ToolDispatchResult => {
         const toolResult = createToolError(toolCall, reason);

--- a/src/core/tools/edit.ts
+++ b/src/core/tools/edit.ts
@@ -61,6 +61,11 @@ function parseEditArgs(
   return { ok: true, data: parsed.data };
 }
 
+function getEditDisplayTarget(raw: unknown): string {
+  const parsedArgs = parseEditArgs(raw);
+  return parsedArgs.ok ? parsedArgs.data.path : "(invalid arguments)";
+}
+
 function countOccurrences(content: string, search: string): number {
   if (!search) return 0;
   let count = 0;
@@ -123,11 +128,12 @@ function buildEditUiText(args: {
 export function createEditToolDefinition(backend: ToolExecutionBackend): ToolDefinition {
   return {
     schema: EDIT_TOOL,
+    getDisplayTarget: (toolCall) => getEditDisplayTarget(toolCall.arguments),
     async dispatch(toolCall: ToolCall): Promise<ToolDispatch> {
       return createToolDispatch(async () => {
         const parsedArgs = parseEditArgs(toolCall.arguments);
         const path = parsedArgs.ok ? parsedArgs.data.path : "";
-        const headerTarget = path || "(invalid arguments)";
+        const headerTarget = getEditDisplayTarget(toolCall.arguments);
 
         const blocked = (reason: string): ToolDispatchResult => {
           const toolResult = createToolError(toolCall, reason);

--- a/src/core/tools/emit_output.ts
+++ b/src/core/tools/emit_output.ts
@@ -51,6 +51,7 @@ function parseEmitOutputArgs(
 export function createEmitOutputToolDefinition(): ToolDefinition {
   return {
     schema: EMIT_OUTPUT_TOOL,
+    getDisplayTarget: () => TOOL_NAME_EMIT_OUTPUT,
     async dispatch(
       toolCall: ToolCall,
       _signal: AbortSignal,

--- a/src/core/tools/emit_output.ts
+++ b/src/core/tools/emit_output.ts
@@ -51,7 +51,8 @@ function parseEmitOutputArgs(
 export function createEmitOutputToolDefinition(): ToolDefinition {
   return {
     schema: EMIT_OUTPUT_TOOL,
-    getDisplayTarget: () => TOOL_NAME_EMIT_OUTPUT,
+    getDisplayTarget: (toolCall) =>
+      parseEmitOutputArgs(toolCall.arguments).ok ? TOOL_NAME_EMIT_OUTPUT : "(invalid arguments)",
     async dispatch(
       toolCall: ToolCall,
       _signal: AbortSignal,

--- a/src/core/tools/grep.ts
+++ b/src/core/tools/grep.ts
@@ -111,6 +111,11 @@ function parseGrepArgs(raw: unknown): { ok: true; data: GrepArgs } | { ok: false
   return { ok: true, data: parsed.data };
 }
 
+function getGrepDisplayTarget(raw: unknown): string {
+  const parsedArgs = parseGrepArgs(raw);
+  return parsedArgs.ok ? parsedArgs.data.pattern : "(invalid arguments)";
+}
+
 function buildGrepArgs(raw: z.infer<typeof grepArgsSchema>): {
   args: string[];
   paths: string[];
@@ -230,10 +235,11 @@ function buildGrepUiText(args: {
 export function createGrepToolDefinition(backend: ToolExecutionBackend): ToolDefinition {
   return {
     schema: GREP_TOOL,
+    getDisplayTarget: (toolCall) => getGrepDisplayTarget(toolCall.arguments),
     async dispatch(toolCall: ToolCall, signal?: AbortSignal): Promise<ToolDispatch> {
       const parsedArgs = parseGrepArgs(toolCall.arguments);
       const pattern = parsedArgs.ok ? parsedArgs.data.pattern : "";
-      const headerTarget = pattern || "(invalid arguments)";
+      const headerTarget = getGrepDisplayTarget(toolCall.arguments);
 
       const blocked = (reason: string): ToolDispatchResult => {
         const toolResult = createToolError(toolCall, reason);

--- a/src/core/tools/list.ts
+++ b/src/core/tools/list.ts
@@ -66,6 +66,11 @@ function parseListArgs(raw: unknown):
   return { ok: true, data: parsed.data };
 }
 
+function getListDisplayTarget(raw: unknown): string {
+  const parsedArgs = parseListArgs(raw);
+  return parsedArgs.ok ? parsedArgs.data.path : "(invalid arguments)";
+}
+
 function formatListToolResultText(entries: string[]): string {
   return entries.join("\n");
 }
@@ -101,11 +106,12 @@ function buildListUiText(args: {
 export function createListToolDefinition(backend: ToolExecutionBackend): ToolDefinition {
   return {
     schema: LIST_TOOL,
+    getDisplayTarget: (toolCall) => getListDisplayTarget(toolCall.arguments),
     async dispatch(toolCall: ToolCall): Promise<ToolDispatch> {
       return createToolDispatch(async () => {
         const parsedArgs = parseListArgs(toolCall.arguments);
         const path = parsedArgs.ok ? parsedArgs.data.path : "";
-        const headerTarget = path || "(invalid arguments)";
+        const headerTarget = getListDisplayTarget(toolCall.arguments);
 
         const blocked = (reason: string): ToolDispatchResult => {
           const toolResult = createToolError(toolCall, reason);

--- a/src/core/tools/nook.ts
+++ b/src/core/tools/nook.ts
@@ -120,6 +120,15 @@ const nookArgsSchema = z
 
 type NookToolArgs = z.infer<typeof nookArgsSchema>;
 
+function formatNookDisplayTarget(args: NookToolArgs): string {
+  return [args.operation, args.site, args.template, args.key].filter(Boolean).join(" ");
+}
+
+function getNookDisplayTarget(raw: unknown): string {
+  const parsedArgs = nookArgsSchema.safeParse(raw);
+  return parsedArgs.success ? formatNookDisplayTarget(parsedArgs.data) : "(invalid arguments)";
+}
+
 const NOOK_UI_PREVIEW_HEAD_LINES = 3;
 const NOOK_UI_PREVIEW_TAIL_LINES = 3;
 
@@ -169,7 +178,7 @@ function buildUiEvent(
     type: "client_tool_finished",
     toolCallId: toolCall.id,
     toolName: TOOL_NAME_NOOK,
-    headerTarget: TOOL_NAME_NOOK,
+    headerTarget: getNookDisplayTarget(toolCall.arguments),
     status,
     uiText: buildNookUiText(message),
   };
@@ -178,6 +187,7 @@ function buildUiEvent(
 export function createNookToolDefinition(backend: ToolExecutionBackend): ToolDefinition {
   return {
     schema: NOOK_TOOL,
+    getDisplayTarget: (toolCall) => getNookDisplayTarget(toolCall.arguments),
     async dispatch(
       toolCall: ToolCall,
       _signal: AbortSignal,

--- a/src/core/tools/read.ts
+++ b/src/core/tools/read.ts
@@ -69,6 +69,11 @@ function parseReadArgs(raw: unknown):
   return { ok: true, data: parsed.data };
 }
 
+function getReadDisplayTarget(raw: unknown): string {
+  const parsedArgs = parseReadArgs(raw);
+  return parsedArgs.ok ? parsedArgs.data.path : "(invalid arguments)";
+}
+
 function formatRange(startLine: number, endLine: number | undefined): string {
   if (!endLine) {
     return `${startLine}-EOF`;
@@ -136,11 +141,12 @@ function buildReadUiText(args: {
 export function createReadToolDefinition(backend: ToolExecutionBackend): ToolDefinition {
   return {
     schema: READ_TOOL,
+    getDisplayTarget: (toolCall) => getReadDisplayTarget(toolCall.arguments),
     async dispatch(toolCall: ToolCall): Promise<ToolDispatch> {
       return createToolDispatch(async () => {
         const parsedArgs = parseReadArgs(toolCall.arguments);
         const path = parsedArgs.ok ? parsedArgs.data.path : "";
-        const headerTarget = path || "(invalid arguments)";
+        const headerTarget = getReadDisplayTarget(toolCall.arguments);
 
         const blocked = (reason: string): ToolDispatchResult => {
           const toolResult = createToolError(toolCall, reason);

--- a/src/core/tools/registry.ts
+++ b/src/core/tools/registry.ts
@@ -341,6 +341,7 @@ export function isSubagentToolDispatchContext(
 
 export interface ToolDefinition {
   readonly schema: Tool;
+  getDisplayTarget(toolCall: ToolCall, context: ToolDispatchContext): string;
   dispatch(
     toolCall: ToolCall,
     signal: AbortSignal,

--- a/src/core/tools/send_input_to_agent.ts
+++ b/src/core/tools/send_input_to_agent.ts
@@ -56,11 +56,24 @@ function resolveSnapshotTarget(snapshot: SubagentStateSnapshot) {
   return { name: snapshot.name, title: snapshot.title };
 }
 
+function getSendInputDisplayTarget(raw: unknown, context: ToolDispatchContext): string {
+  const parsedArgs = parseToolArgs(sendInputArgsSchema, raw);
+  if (!parsedArgs.ok) {
+    return "(invalid arguments)";
+  }
+  const { id } = parsedArgs.data;
+  if (!isMainToolDispatchContext(context)) {
+    return id;
+  }
+  return context.subagentControlPlane.getSnapshot(id)?.title ?? id;
+}
+
 export function createSendInputToAgentToolDefinition(
   backend: ToolExecutionBackend,
 ): ToolDefinition {
   return {
     schema: SEND_INPUT_TO_AGENT_TOOL,
+    getDisplayTarget: (toolCall, context) => getSendInputDisplayTarget(toolCall.arguments, context),
     async dispatch(
       toolCall: ToolCall,
       signal: AbortSignal,
@@ -68,7 +81,7 @@ export function createSendInputToAgentToolDefinition(
     ): Promise<ToolDispatch> {
       let id = "";
       let prompt = "";
-      let headerTarget = "(invalid arguments)";
+      const headerTarget = getSendInputDisplayTarget(toolCall.arguments, context);
 
       const blocked = (
         reason: string,
@@ -93,7 +106,6 @@ export function createSendInputToAgentToolDefinition(
       }
 
       ({ id, prompt } = parsedArgs.data);
-      headerTarget = id;
 
       if (!isMainToolDispatchContext(context)) {
         return createToolDispatch(() =>

--- a/src/core/tools/spawn_agent.ts
+++ b/src/core/tools/spawn_agent.ts
@@ -102,9 +102,15 @@ function formatAllowedLaunchModels(launchModels: string[]): string {
   return launchModels.map((entry) => `'${entry}'`).join(", ");
 }
 
+function getSpawnAgentDisplayTarget(raw: unknown): string {
+  const parsedArgs = parseToolArgs(spawnArgsSchema, raw);
+  return parsedArgs.ok ? parsedArgs.data.title : "(invalid arguments)";
+}
+
 export function createSpawnAgentToolDefinition(backend: ToolExecutionBackend): ToolDefinition {
   return {
     schema: SPAWN_AGENT_TOOL,
+    getDisplayTarget: (toolCall) => getSpawnAgentDisplayTarget(toolCall.arguments),
     async dispatch(
       toolCall: ToolCall,
       signal: AbortSignal,
@@ -112,7 +118,7 @@ export function createSpawnAgentToolDefinition(backend: ToolExecutionBackend): T
     ): Promise<ToolDispatch> {
       let name = "";
       let title = "";
-      let headerTarget = "(invalid arguments)";
+      const headerTarget = getSpawnAgentDisplayTarget(toolCall.arguments);
 
       const blocked = (reason: string, details?: { name?: string; title?: string }) => {
         const toolResult = createToolError(toolCall, reason);
@@ -135,7 +141,6 @@ export function createSpawnAgentToolDefinition(backend: ToolExecutionBackend): T
       const { prompt, model, workingDirectory } = parsedArgs.data;
       name = parsedArgs.data.name;
       title = parsedArgs.data.title;
-      headerTarget = title;
 
       if (!isMainToolDispatchContext(context)) {
         return createToolDispatch(() =>

--- a/src/core/tools/terminate_agent.ts
+++ b/src/core/tools/terminate_agent.ts
@@ -74,16 +74,22 @@ function getTerminateDurationMs(result: SubagentResult): number | undefined {
   return Math.max(0, finishedAt - result.startedAt);
 }
 
+function getTerminateAgentDisplayTarget(raw: unknown): string {
+  const parsedArgs = parseToolArgs(terminateArgsSchema, raw);
+  return parsedArgs.ok ? parsedArgs.data.id : "(invalid arguments)";
+}
+
 export function createTerminateAgentToolDefinition(): ToolDefinition {
   return {
     schema: TERMINATE_AGENT_TOOL,
+    getDisplayTarget: (toolCall) => getTerminateAgentDisplayTarget(toolCall.arguments),
     async dispatch(
       toolCall: ToolCall,
       signal: AbortSignal,
       context: ToolDispatchContext,
     ): Promise<ToolDispatch> {
       let id = "";
-      let headerTarget = "(invalid arguments)";
+      const headerTarget = getTerminateAgentDisplayTarget(toolCall.arguments);
 
       const blocked = (reason: string): ToolDispatchResult => {
         const toolResult = createToolError(toolCall, reason);
@@ -103,7 +109,6 @@ export function createTerminateAgentToolDefinition(): ToolDefinition {
       }
 
       ({ id } = parsedArgs.data);
-      headerTarget = id;
 
       if (!isMainToolDispatchContext(context)) {
         return createToolDispatch(() =>

--- a/src/core/tools/view_image.ts
+++ b/src/core/tools/view_image.ts
@@ -58,6 +58,11 @@ function parseViewImageArgs(
   return { ok: true, data: parsed.data };
 }
 
+function getViewImageDisplayTarget(raw: unknown): string {
+  const parsedArgs = parseViewImageArgs(raw);
+  return parsedArgs.ok ? parsedArgs.data.path : "(invalid arguments)";
+}
+
 type SupportedImageType = (typeof SUPPORTED_IMAGE_TYPES)[number];
 
 type ImageEncodePlan =
@@ -234,11 +239,12 @@ function buildViewImageUiText(args: { mimeType: string; fullText: string }): Too
 export function createViewImageToolDefinition(backend: ToolExecutionBackend): ToolDefinition {
   return {
     schema: VIEW_IMAGE_TOOL,
+    getDisplayTarget: (toolCall) => getViewImageDisplayTarget(toolCall.arguments),
     async dispatch(toolCall: ToolCall): Promise<ToolDispatch> {
       return createToolDispatch(async () => {
         const parsedArgs = parseViewImageArgs(toolCall.arguments);
         const path = parsedArgs.ok ? parsedArgs.data.path : "";
-        const headerTarget = path || "(invalid arguments)";
+        const headerTarget = getViewImageDisplayTarget(toolCall.arguments);
 
         const blocked = (reason: string): ToolDispatchResult => {
           const toolResult = createToolError(toolCall, reason);

--- a/src/core/tools/wait_for_agents.ts
+++ b/src/core/tools/wait_for_agents.ts
@@ -127,20 +127,27 @@ function getWaitCostTotal(results: SubagentResult[]): number {
   return results.reduce((sum, result) => sum + result.costTotal, 0);
 }
 
+function formatAgentIdsDisplayTarget(ids: string[]): string {
+  const cleaned = ids.map((id) => id.trim()).filter(Boolean);
+  return cleaned.length > 0 ? cleaned.join(", ") : "(invalid arguments)";
+}
+
+function getWaitForAgentsDisplayTarget(raw: unknown): string {
+  const parsedArgs = parseToolArgs(waitArgsSchema, raw);
+  return parsedArgs.ok ? formatAgentIdsDisplayTarget(parsedArgs.data.ids) : "(invalid arguments)";
+}
+
 export function createWaitForAgentsToolDefinition(): ToolDefinition {
   return {
     schema: WAIT_FOR_AGENTS_TOOL,
+    getDisplayTarget: (toolCall) => getWaitForAgentsDisplayTarget(toolCall.arguments),
     async dispatch(
       toolCall: ToolCall,
       signal: AbortSignal,
       context: ToolDispatchContext,
     ): Promise<ToolDispatch> {
       let ids: string[] = [];
-      const formatHeaderTarget = (entries: string[]): string => {
-        const cleaned = entries.map((id) => id.trim()).filter(Boolean);
-        return cleaned.length > 0 ? cleaned.join(", ") : "(invalid arguments)";
-      };
-      let headerTarget = "(invalid arguments)";
+      const headerTarget = getWaitForAgentsDisplayTarget(toolCall.arguments);
 
       const blocked = (reason: string): ToolDispatchResult => {
         const toolResult = createToolError(toolCall, reason);
@@ -160,7 +167,6 @@ export function createWaitForAgentsToolDefinition(): ToolDefinition {
       }
 
       ({ ids } = parsedArgs.data);
-      headerTarget = formatHeaderTarget(ids);
 
       const deduped: string[] = [];
       const seen = new Set<string>();
@@ -170,7 +176,7 @@ export function createWaitForAgentsToolDefinition(): ToolDefinition {
           deduped.push(id);
         }
       }
-      const dedupedTarget = formatHeaderTarget(deduped);
+      const dedupedTarget = formatAgentIdsDisplayTarget(deduped);
 
       if (!isMainToolDispatchContext(context)) {
         return createToolDispatch(() =>

--- a/src/core/tools/wait_for_agents.ts
+++ b/src/core/tools/wait_for_agents.ts
@@ -128,8 +128,7 @@ function getWaitCostTotal(results: SubagentResult[]): number {
 }
 
 function formatAgentIdsDisplayTarget(ids: string[]): string {
-  const cleaned = ids.map((id) => id.trim()).filter(Boolean);
-  return cleaned.length > 0 ? cleaned.join(", ") : "(invalid arguments)";
+  return ids.join(", ");
 }
 
 function getWaitForAgentsDisplayTarget(raw: unknown): string {

--- a/src/core/tools/web_fetch.ts
+++ b/src/core/tools/web_fetch.ts
@@ -129,6 +129,11 @@ function parseArgs(raw: unknown): { ok: true; data: WebFetchArgs } | { ok: false
   return { ok: true, data: parsed.data };
 }
 
+function getWebFetchDisplayTarget(raw: unknown): string {
+  const parsedArgs = parseArgs(raw);
+  return parsedArgs.ok ? parsedArgs.data.url : "(invalid arguments)";
+}
+
 function estimateParallelExtractCostUsd(urlCount: number): number {
   return 0.001 * urlCount;
 }
@@ -199,10 +204,11 @@ function formatExtractResults(response: ExtractResponse): TruncationResult {
 export function createWebFetchToolDefinition(config: Config): ToolDefinition {
   return {
     schema: WEB_FETCH_TOOL,
+    getDisplayTarget: (toolCall) => getWebFetchDisplayTarget(toolCall.arguments),
     async dispatch(toolCall: ToolCall, signal?: AbortSignal): Promise<ToolDispatch> {
       const parsedArgs = parseArgs(toolCall.arguments);
       const url = parsedArgs.ok ? parsedArgs.data.url : "";
-      const headerTarget = url || "(invalid arguments)";
+      const headerTarget = getWebFetchDisplayTarget(toolCall.arguments);
 
       const blocked = (reason: string): ToolDispatchResult => {
         const toolResult = createToolError(toolCall, reason);

--- a/src/core/tools/web_search.ts
+++ b/src/core/tools/web_search.ts
@@ -113,6 +113,11 @@ function parseArgs(raw: unknown): { ok: true; data: WebSearchArgs } | { ok: fals
   return { ok: true, data: parsed.data };
 }
 
+function getWebSearchDisplayTarget(raw: unknown): string {
+  const parsedArgs = parseArgs(raw);
+  return parsedArgs.ok ? parsedArgs.data.objective : "(invalid arguments)";
+}
+
 function estimateParallelSearchCostUsd(
   maxResultsRequested: number | undefined,
   resultsReturned: number | undefined,
@@ -171,10 +176,11 @@ function formatSearchResults(response: ParallelSearchResponse): TruncationResult
 export function createWebSearchToolDefinition(config: Config): ToolDefinition {
   return {
     schema: WEB_SEARCH_TOOL,
+    getDisplayTarget: (toolCall) => getWebSearchDisplayTarget(toolCall.arguments),
     async dispatch(toolCall: ToolCall, signal?: AbortSignal): Promise<ToolDispatch> {
       const parsedArgs = parseArgs(toolCall.arguments);
       const objective = parsedArgs.ok ? parsedArgs.data.objective : "";
-      const headerTarget = objective || "(invalid arguments)";
+      const headerTarget = getWebSearchDisplayTarget(toolCall.arguments);
 
       const blocked = (reason: string): ToolDispatchResult => {
         const toolResult = createToolError(toolCall, reason);

--- a/src/core/tools/write.ts
+++ b/src/core/tools/write.ts
@@ -57,6 +57,11 @@ function parseWriteArgs(
   return { ok: true, data: parsed.data };
 }
 
+function getWriteDisplayTarget(raw: unknown): string {
+  const parsedArgs = parseWriteArgs(raw);
+  return parsedArgs.ok ? parsedArgs.data.path : "(invalid arguments)";
+}
+
 function buildWriteUiText(args: {
   bytes: number;
   lines: number;
@@ -96,11 +101,12 @@ function buildWriteUiText(args: {
 export function createWriteToolDefinition(backend: ToolExecutionBackend): ToolDefinition {
   return {
     schema: WRITE_TOOL,
+    getDisplayTarget: (toolCall) => getWriteDisplayTarget(toolCall.arguments),
     async dispatch(toolCall: ToolCall): Promise<ToolDispatch> {
       return createToolDispatch(async () => {
         const parsedArgs = parseWriteArgs(toolCall.arguments);
         const path = parsedArgs.ok ? parsedArgs.data.path : "";
-        const headerTarget = path || "(invalid arguments)";
+        const headerTarget = getWriteDisplayTarget(toolCall.arguments);
 
         const blocked = (reason: string): ToolDispatchResult => {
           const toolResult = createToolError(toolCall, reason);

--- a/src/host/client_tool_broker.ts
+++ b/src/host/client_tool_broker.ts
@@ -361,6 +361,7 @@ function createClientToolDefinition(
 
   return {
     schema,
+    getDisplayTarget: () => tool.name,
     async dispatch(
       toolCall: ToolCall,
       signal: AbortSignal,

--- a/src/tui/ui/tool_ui_registry.ts
+++ b/src/tui/ui/tool_ui_registry.ts
@@ -292,7 +292,7 @@ export function createToolUiRegistry(): ToolUiRegistry {
 
   registry.register("tool_call_queued", (event, context) => {
     const uiEvent = event as Extract<ToolUiEvent, { type: "tool_call_queued" }>;
-    return buildToolQueuedView(context.theme, uiEvent.toolName);
+    return buildToolQueuedView(context.theme, uiEvent.headerTarget);
   });
 
   registry.register("client_tool_finished", (event, context) => {

--- a/test/client_tool_broker.test.js
+++ b/test/client_tool_broker.test.js
@@ -38,6 +38,7 @@ describe("ClientToolBroker", () => {
     registration.attachSession("session-1");
 
     const definition = broker.getToolDefinitions("session-1")[0];
+    expect(definition.getDisplayTarget(createToolCall({ choice: "a" }), {})).toBe("local_picker");
     const result = await runTool(
       definition,
       createToolCall({ choice: "a" }),

--- a/test/core_runtime.test.js
+++ b/test/core_runtime.test.js
@@ -640,7 +640,11 @@ describe("core session rewind APIs", () => {
 
   it("starts streamed tool calls early while preserving sequential execution", async () => {
     const firstCall = fauxToolCall("first_tool", {}, { id: "first-call" });
-    const secondCall = fauxToolCall("second_tool", {}, { id: "second-call" });
+    const secondCall = fauxToolCall(
+      "second_tool",
+      { displayTarget: "ssh host 'du -h /'" },
+      { id: "second-call" },
+    );
     const toolMessage = fauxAssistantMessage([firstCall, secondCall], {
       stopReason: "toolUse",
     });
@@ -673,6 +677,7 @@ describe("core session rewind APIs", () => {
           additionalProperties: false,
         },
       },
+      getDisplayTarget: (toolCall) => toolCall.arguments.displayTarget ?? toolCall.name,
       dispatch,
     });
     const toolRegistry = new ToolRegistry([
@@ -775,6 +780,14 @@ describe("core session rewind APIs", () => {
 
     await Promise.all([firstStarted, secondQueued]);
     expect(
+      events.find(
+        (event) =>
+          event.type === "tool_ui" &&
+          event.uiEvent.type === "tool_call_queued" &&
+          event.uiEvent.toolCallId === secondCall.id,
+      ),
+    ).toMatchObject({ uiEvent: { headerTarget: "ssh host 'du -h /'" } });
+    expect(
       events
         .filter((event) => event.type === "tool_ui" && event.uiEvent.type === "tool_call_queued")
         .map((event) => event.uiEvent.toolCallId),
@@ -821,6 +834,7 @@ describe("core session rewind APIs", () => {
             additionalProperties: false,
           },
         },
+        getDisplayTarget: (toolCall) => toolCall.name,
         dispatch: async (call) => {
           executedSequences.push(call.arguments.sequence);
           return {
@@ -910,6 +924,7 @@ describe("core session rewind APIs", () => {
           description: "test tool",
           parameters: { type: "object", properties: {}, additionalProperties: false },
         },
+        getDisplayTarget: (toolCall) => toolCall.name,
         dispatch: async (call) => ({
           run: Promise.resolve({
             toolResult: {
@@ -986,6 +1001,7 @@ describe("core session rewind APIs", () => {
             additionalProperties: false,
           },
         },
+        getDisplayTarget: (toolCall) => toolCall.name,
         dispatch: async (call) => {
           executions += 1;
           return {
@@ -1119,6 +1135,7 @@ describe("core session rewind APIs", () => {
             additionalProperties: false,
           },
         },
+        getDisplayTarget: (toolCall) => toolCall.name,
         dispatch: async (call) => {
           executions += 1;
           return {
@@ -1211,6 +1228,7 @@ describe("core session rewind APIs", () => {
             additionalProperties: false,
           },
         },
+        getDisplayTarget: (toolCall) => toolCall.name,
         dispatch: async (call, signal) => {
           executions += 1;
           if (!signal.aborted) {
@@ -1320,6 +1338,7 @@ describe("core session rewind APIs", () => {
             additionalProperties: false,
           },
         },
+        getDisplayTarget: (toolCall) => toolCall.name,
         dispatch: async (call, signal) => {
           markToolStarted();
           await new Promise((resolve) => signal.addEventListener("abort", resolve, { once: true }));
@@ -1387,6 +1406,7 @@ describe("core session rewind APIs", () => {
             additionalProperties: false,
           },
         },
+        getDisplayTarget: (toolCall) => toolCall.name,
         async dispatch(_toolCall, _signal, context) {
           toolContextReasoning.push(context.persona.settings.reasoning);
           session.setReasoning("high");
@@ -1488,6 +1508,7 @@ describe("core session rewind APIs", () => {
               additionalProperties: false,
             },
           },
+          getDisplayTarget: (toolCall) => toolCall.name,
           async dispatch(toolCall, _signal, context) {
             receivedOriginHistoryEntryId = context.originHistoryEntryId;
             return {

--- a/test/core_runtime.test.js
+++ b/test/core_runtime.test.js
@@ -640,11 +640,7 @@ describe("core session rewind APIs", () => {
 
   it("starts streamed tool calls early while preserving sequential execution", async () => {
     const firstCall = fauxToolCall("first_tool", {}, { id: "first-call" });
-    const secondCall = fauxToolCall(
-      "second_tool",
-      { displayTarget: "ssh host 'du -h /'" },
-      { id: "second-call" },
-    );
+    const secondCall = fauxToolCall("second_tool", {}, { id: "second-call" });
     const toolMessage = fauxAssistantMessage([firstCall, secondCall], {
       stopReason: "toolUse",
     });
@@ -667,7 +663,7 @@ describe("core session rewind APIs", () => {
     });
     let secondHasStarted = false;
 
-    const createDefinition = (name, dispatch) => ({
+    const createDefinition = (name, displayTarget, dispatch) => ({
       schema: {
         name,
         description: "test tool",
@@ -677,11 +673,11 @@ describe("core session rewind APIs", () => {
           additionalProperties: false,
         },
       },
-      getDisplayTarget: (toolCall) => toolCall.arguments.displayTarget ?? toolCall.name,
+      getDisplayTarget: () => displayTarget,
       dispatch,
     });
     const toolRegistry = new ToolRegistry([
-      createDefinition("first_tool", async (toolCall) => {
+      createDefinition("first_tool", "first_tool", async (toolCall) => {
         markFirstStarted();
         await firstRun;
         return {
@@ -697,7 +693,7 @@ describe("core session rewind APIs", () => {
           }),
         };
       }),
-      createDefinition("second_tool", async (toolCall) => {
+      createDefinition("second_tool", "ssh host 'du -h /'", async (toolCall) => {
         secondHasStarted = true;
         markSecondStarted();
         return {

--- a/test/session_runner.test.js
+++ b/test/session_runner.test.js
@@ -567,15 +567,9 @@ describe("session runner tool dispatch context", () => {
   });
 
   it("derives queued targets from completed built-in tool arguments", async () => {
-    const signal = new AbortController().signal;
-    const dispatchedCommands = [];
+    const abortController = new AbortController();
     const toolRegistry = new ToolRegistry([
-      createBashToolDefinition({
-        runBash(command) {
-          dispatchedCommands.push(command);
-          return new Promise(() => {});
-        },
-      }),
+      createBashToolDefinition({}),
       createWriteToolDefinition({}),
     ]);
     const dispatchContext = {
@@ -622,37 +616,32 @@ describe("session runner tool dispatch context", () => {
       ],
       toolRegistry,
       enabledTools: toolRegistry.schemas,
-      signal,
+      signal: abortController.signal,
       dispatchContext,
     })[Symbol.asyncIterator]();
+    const queuedEvents = [];
 
-    await expect(iterator.next()).resolves.toMatchObject({
-      value: {
-        uiEvent: { toolCallId: "bash-call", headerTarget: "printf hello" },
-      },
-    });
-    await expect(iterator.next()).resolves.toMatchObject({
-      value: {
-        uiEvent: { toolCallId: "second-bash-call", headerTarget: "ssh host 'du -h /'" },
-      },
-    });
-    await expect(iterator.next()).resolves.toMatchObject({
-      value: {
-        uiEvent: { toolCallId: "write-call", headerTarget: "src/output.ts" },
-      },
-    });
-    await expect(iterator.next()).resolves.toMatchObject({
-      value: {
-        uiEvent: { toolCallId: "invalid-bash-call", headerTarget: "(invalid arguments)" },
-      },
-    });
-    await expect(iterator.next()).resolves.toMatchObject({
-      value: {
-        uiEvent: { type: "bash_started", toolCallId: "bash-call" },
-      },
-    });
-    expect(dispatchedCommands).toEqual(["printf hello\nprintf ignored"]);
-    await iterator.return();
+    for (let index = 0; index < 4; index++) {
+      const next = await iterator.next();
+      queuedEvents.push(next.value);
+    }
+
+    expect(
+      queuedEvents.map((event) => [
+        event.uiEvent.type,
+        event.uiEvent.toolCallId,
+        event.uiEvent.toolName,
+        event.uiEvent.headerTarget,
+      ]),
+    ).toEqual([
+      ["tool_call_queued", "bash-call", "bash", "printf hello"],
+      ["tool_call_queued", "second-bash-call", "bash", "ssh host 'du -h /'"],
+      ["tool_call_queued", "write-call", "write", "src/output.ts"],
+      ["tool_call_queued", "invalid-bash-call", "bash", "(invalid arguments)"],
+    ]);
+
+    abortController.abort();
+    await expect(iterator.next()).resolves.toEqual({ done: true, value: undefined });
   });
 
   it("converts rejected tool runs into tool error results", async () => {

--- a/test/session_runner.test.js
+++ b/test/session_runner.test.js
@@ -10,10 +10,11 @@ import {
   pruneSessionHistory,
 } from "../dist/core/session/pruning.js";
 import { runModelSubturn, runToolCalls } from "../dist/core/session/runner.js";
-import { BASH_DEFAULT_TIMEOUT_MS } from "../dist/core/tools/bash.js";
+import { BASH_DEFAULT_TIMEOUT_MS, createBashToolDefinition } from "../dist/core/tools/bash.js";
 import { scopeToolExecutionBackend } from "../dist/core/tools/execution_backend.js";
 import { ToolRegistry } from "../dist/core/tools/registry.js";
 import { TOOL_NAME_BASH, TOOL_NAME_EDIT } from "../dist/core/tools/tool_names.js";
+import { createWriteToolDefinition } from "../dist/core/tools/write.js";
 import { buildCompactionUserMessage } from "../dist/core/utils/compact.js";
 import { autocompleteProjectPathsWithBackend } from "../dist/core/utils/project_files.js";
 import { prependTauUserMetadata } from "../dist/core/utils/user_metadata.js";
@@ -425,6 +426,7 @@ describe("session runner tool dispatch context", () => {
           additionalProperties: false,
         },
       },
+      getDisplayTarget: () => "sleep 30",
       async dispatch(call) {
         return {
           startedUiEvent: {
@@ -473,6 +475,7 @@ describe("session runner tool dispatch context", () => {
           additionalProperties: false,
         },
       },
+      getDisplayTarget: () => "fast.txt",
       async dispatch(call) {
         fastDispatched = true;
         return {
@@ -524,13 +527,21 @@ describe("session runner tool dispatch context", () => {
     await expect(iterator.next()).resolves.toMatchObject({
       value: {
         type: "tool_ui",
-        uiEvent: { type: "tool_call_queued", toolCallId: "slow-call" },
+        uiEvent: {
+          type: "tool_call_queued",
+          toolCallId: "slow-call",
+          headerTarget: "sleep 30",
+        },
       },
     });
     await expect(iterator.next()).resolves.toMatchObject({
       value: {
         type: "tool_ui",
-        uiEvent: { type: "tool_call_queued", toolCallId: "fast-call" },
+        uiEvent: {
+          type: "tool_call_queued",
+          toolCallId: "fast-call",
+          headerTarget: "fast.txt",
+        },
       },
     });
     await expect(iterator.next()).resolves.toMatchObject({
@@ -555,6 +566,95 @@ describe("session runner tool dispatch context", () => {
     ).toEqual(["bash_execution", "write_success", "tool_result", "tool_result"]);
   });
 
+  it("derives queued targets from completed built-in tool arguments", async () => {
+    const signal = new AbortController().signal;
+    const dispatchedCommands = [];
+    const toolRegistry = new ToolRegistry([
+      createBashToolDefinition({
+        runBash(command) {
+          dispatchedCommands.push(command);
+          return new Promise(() => {});
+        },
+      }),
+      createWriteToolDefinition({}),
+    ]);
+    const dispatchContext = {
+      scope: "subagent",
+      config: {},
+      toolRegistry,
+      authPath: "/tmp/auth.json",
+      originHistoryEntryId: "history-1",
+      cwd: "/repo/subagent",
+      subagentContext: {
+        id: "subagent-1",
+        name: "default",
+        title: "default",
+        originHistoryEntryId: "history-1",
+        controlPlane: { recordEmitOutput: () => {} },
+      },
+    };
+    const iterator = runToolCalls({
+      toolCalls: [
+        {
+          id: "bash-call",
+          type: "toolCall",
+          name: "bash",
+          arguments: { command: "printf hello\nprintf ignored" },
+        },
+        {
+          id: "second-bash-call",
+          type: "toolCall",
+          name: "bash",
+          arguments: { command: "ssh host 'du -h /'" },
+        },
+        {
+          id: "write-call",
+          type: "toolCall",
+          name: "write",
+          arguments: { path: "src/output.ts", content: "content" },
+        },
+        {
+          id: "invalid-bash-call",
+          type: "toolCall",
+          name: "bash",
+          arguments: { command: 42 },
+        },
+      ],
+      toolRegistry,
+      enabledTools: toolRegistry.schemas,
+      signal,
+      dispatchContext,
+    })[Symbol.asyncIterator]();
+
+    await expect(iterator.next()).resolves.toMatchObject({
+      value: {
+        uiEvent: { toolCallId: "bash-call", headerTarget: "printf hello" },
+      },
+    });
+    await expect(iterator.next()).resolves.toMatchObject({
+      value: {
+        uiEvent: { toolCallId: "second-bash-call", headerTarget: "ssh host 'du -h /'" },
+      },
+    });
+    await expect(iterator.next()).resolves.toMatchObject({
+      value: {
+        uiEvent: { toolCallId: "write-call", headerTarget: "src/output.ts" },
+      },
+    });
+    await expect(iterator.next()).resolves.toMatchObject({
+      value: {
+        uiEvent: { toolCallId: "invalid-bash-call", headerTarget: "(invalid arguments)" },
+      },
+    });
+    await expect(iterator.next()).resolves.toMatchObject({
+      value: {
+        uiEvent: { type: "bash_started", toolCallId: "bash-call" },
+      },
+    });
+    expect(dispatchedCommands).toEqual(["printf hello\nprintf ignored"]);
+    await iterator.return();
+  });
+
   it("converts rejected tool runs into tool error results", async () => {
     const signal = new AbortController().signal;
     const toolCall = {
@@ -573,6 +673,7 @@ describe("session runner tool dispatch context", () => {
           additionalProperties: false,
         },
       },
+      getDisplayTarget: () => "fake_tool",
       async dispatch() {
         return { run: Promise.reject(new Error("run failed")) };
       },
@@ -648,6 +749,7 @@ describe("session runner tool dispatch context", () => {
           additionalProperties: false,
         },
       },
+      getDisplayTarget: () => "fake_tool",
       async dispatch(call, dispatchSignal, context) {
         receivedSignal = dispatchSignal;
         receivedContext = context;

--- a/test/tool_ui_registry.test.js
+++ b/test/tool_ui_registry.test.js
@@ -30,10 +30,11 @@ describe("ToolUiRegistry", () => {
       type: "tool_call_queued",
       toolCallId: "q1",
       toolName: "bash",
-      headerTarget: "bash",
+      headerTarget: "printf hello",
     });
     expect(queued).toContain("queued");
-    expect(queued).toContain("bash");
+    expect(queued).toContain("printf hello");
+    expect(queued).not.toContain("bash");
   });
 
   it("renders client tool completion events", () => {


### PR DESCRIPTION
## why

Queued tool cards currently collapse every completed call to its tool name, so sequential bash calls render as `queued bash` even though Tau already has the full command. This also hides useful paths, URLs, objectives, and subagent targets for other tools.

## what

I added a required synchronous display-target method to tool definitions and use it when publishing the existing queued event. Built-in tools derive their target through their existing argument parsers, malformed calls use a stable invalid-arguments target, context-aware subagent calls resolve the current title when available, and client-provided tools explicitly fall back to their tool name.

I also changed the queued renderer to consume the event's `headerTarget` and added regression coverage for a second bash call queued behind active execution, a write path, malformed arguments, the client-tool fallback, and renderer target selection.

## details

I kept this change independent of #318 because that work has not landed yet. It only changes the completed-call queued state, so #318 can still introduce the earlier streaming state and transition the same tool card to this complete target after `toolcall_end`. No protocol shape or additional status is required here.

There are no remaining implementation questions.

fixes #316
