### PR TITLE
preserve direct bash output across snapshot refreshes

### DIFF
--- a/src/tui/chat_view.ts
+++ b/src/tui/chat_view.ts
@@ -11,7 +11,7 @@ import type { ToolUiEvent, ToolUiText } from "../core/tools/registry.js";
 import type { ReasoningEffort } from "../core/types.js";
 import type { SessionProtocolPendingUserMessage } from "../protocol/session_protocol.js";
 import { createAppTerminal } from "./terminal.js";
-import { ToolUiRouter } from "./tool_ui_router.js";
+import { type ToolUiEventOrigin, ToolUiRouter } from "./tool_ui_router.js";
 import { ChatContainerComponent } from "./ui/chat_container.js";
 import type { AssistantMessageModel, ChatMessageModel } from "./ui/chat_message_model.js";
 import { CustomEditor } from "./ui/custom_editor.js";
@@ -86,7 +86,7 @@ export interface ChatView {
   updateStatus(status: ChatViewStatus): void;
   startWorkingIcon(): void;
   stopWorkingIcon(): void;
-  handleToolUiEvent(event: ToolUiEvent): void;
+  handleToolUiEvent(event: ToolUiEvent, origin: ToolUiEventOrigin): void;
   handleSubagentEvent(event: SubagentUiEvent): void;
   resetToolUiSession(): void;
   reconcileToolUiSession(toolCallIds: readonly string[]): void;
@@ -275,8 +275,8 @@ export class TuiChatView implements ChatView {
     this.footer.stop();
   }
 
-  handleToolUiEvent(event: ToolUiEvent): void {
-    this.toolUiRouter.handle(event);
+  handleToolUiEvent(event: ToolUiEvent, origin: ToolUiEventOrigin): void {
+    this.toolUiRouter.handle(event, origin);
   }
 
   handleSubagentEvent(event: SubagentUiEvent): void {

--- a/src/tui/session_chat_controller.ts
+++ b/src/tui/session_chat_controller.ts
@@ -562,12 +562,15 @@ export class SessionChatController {
     this.isStreaming = true;
     this.startTurnTimer();
     this.view.startWorkingIcon();
-    this.view.handleToolUiEvent({
-      type: "bash_started",
-      toolCallId,
-      command,
-      headerTarget,
-    });
+    this.view.handleToolUiEvent(
+      {
+        type: "bash_started",
+        toolCallId,
+        command,
+        headerTarget,
+      },
+      "local",
+    );
     this.refreshStatus();
 
     try {
@@ -590,26 +593,32 @@ export class SessionChatController {
         this.hiddenHistoryEntryIds.add(result.userHistoryEntryId);
         this.renderedMessageIds.push(result.userHistoryEntryId);
       }
-      this.view.handleToolUiEvent({
-        type: "bash_execution",
-        toolCallId,
-        command: result.command,
-        headerTarget,
-        exitCode: result.exitCode,
-        truncationInfo: result.truncationInfo,
-        uiText: result.uiText,
-        durationMs: result.durationMs,
-        labelOverride: options.labelOverride,
-      });
+      this.view.handleToolUiEvent(
+        {
+          type: "bash_execution",
+          toolCallId,
+          command: result.command,
+          headerTarget,
+          exitCode: result.exitCode,
+          truncationInfo: result.truncationInfo,
+          uiText: result.uiText,
+          durationMs: result.durationMs,
+          labelOverride: options.labelOverride,
+        },
+        "local",
+      );
       await this.syncFromSessionSnapshot();
     } catch (error) {
-      this.view.handleToolUiEvent({
-        type: "bash_blocked",
-        toolCallId,
-        command,
-        headerTarget,
-        reason: (error as Error).message || "bash failed",
-      });
+      this.view.handleToolUiEvent(
+        {
+          type: "bash_blocked",
+          toolCallId,
+          command,
+          headerTarget,
+          reason: (error as Error).message || "bash failed",
+        },
+        "local",
+      );
       await this.syncFromSessionSnapshot();
     } finally {
       this.isStreaming = false;
@@ -1283,7 +1292,7 @@ export class SessionChatController {
     this.observedSessionRevision = Math.max(this.observedSessionRevision, this.snapshot.revision);
 
     for (const event of nextEvents.slice(previousEvents.length)) {
-      this.view.handleToolUiEvent(event);
+      this.view.handleToolUiEvent(event, "session");
     }
     this.refreshStatus();
     return true;
@@ -1415,7 +1424,7 @@ export class SessionChatController {
   private syncSnapshotToolAndAgentUi(snapshot: SessionProtocolSnapshot): void {
     this.view.reconcileToolUiSession(Object.keys(snapshot.tools));
     for (const event of getToolUiEventsInModelOrder(snapshot)) {
-      this.view.handleToolUiEvent(event);
+      this.view.handleToolUiEvent(event, "session");
     }
 
     for (const agent of Object.values(snapshot.agents)) {

--- a/src/tui/tool_ui_router.ts
+++ b/src/tui/tool_ui_router.ts
@@ -36,6 +36,8 @@ type ToolUiEventWithToolCallId = Extract<ToolUiEvent, { toolCallId: string }>;
 type ToolPrunedEvent = Extract<ToolUiEvent, { type: "tool_pruned" }>;
 type NonPrunedToolUiEvent = Exclude<ToolUiEventWithToolCallId, ToolPrunedEvent>;
 
+export type ToolUiEventOrigin = "session" | "local";
+
 type ToolUiEventType = ToolUiEvent["type"];
 type BashTerminalEventType = "bash_execution" | "bash_aborted" | "bash_blocked";
 type SubagentTerminalEventType =
@@ -74,6 +76,7 @@ export class ToolUiRouter {
   private runningBashComponents: Map<string, RunningBashComponent> = new Map();
   private runningSubagentTools: Map<string, RunningSubagentTool> = new Map();
   private latestToolEventsById: Map<string, ToolUiEventWithToolCallId> = new Map();
+  private sessionToolCallIds: Set<string> = new Set();
 
   constructor(options: { chatContainer: ChatContainerComponent; requestRender: () => void }) {
     this.chatContainer = options.chatContainer;
@@ -84,12 +87,19 @@ export class ToolUiRouter {
     this.runningBashComponents.clear();
     this.runningSubagentTools.clear();
     this.latestToolEventsById.clear();
+    this.sessionToolCallIds.clear();
   }
 
   reconcileSession(toolCallIds: readonly string[]): void {
     const currentIds = new Set(toolCallIds);
-    const staleIds = [...this.latestToolEventsById.keys()].filter((id) => !currentIds.has(id));
-    this.resetSession();
+    const staleIds = [...this.sessionToolCallIds].filter((id) => !currentIds.has(id));
+    for (const id of this.sessionToolCallIds) {
+      this.runningBashComponents.delete(id);
+      this.runningSubagentTools.delete(id);
+      this.latestToolEventsById.delete(id);
+    }
+    this.sessionToolCallIds.clear();
+
     if (staleIds.length > 0) {
       this.chatContainer.removeMessages(staleIds);
       this.requestRender();
@@ -122,7 +132,7 @@ export class ToolUiRouter {
     this.requestRender();
   }
 
-  handle(uiEvent: ToolUiEvent): void {
+  handle(uiEvent: ToolUiEvent, origin: ToolUiEventOrigin): void {
     if (uiEvent.type === "tool_pruned") {
       const updated = this.applyPrunedMutation(uiEvent);
       if (updated) {
@@ -131,6 +141,9 @@ export class ToolUiRouter {
       return;
     }
 
+    if (origin === "session") {
+      this.sessionToolCallIds.add(uiEvent.toolCallId);
+    }
     this.upsertToolMessage(uiEvent);
     this.updateRunningToolState(uiEvent);
     this.requestRender();

--- a/test/session_chat_controller.test.js
+++ b/test/session_chat_controller.test.js
@@ -542,6 +542,7 @@ class FakeView {
   removed = [];
   systems = [];
   toolEvents = [];
+  toolEventOrigins = [];
   rewindPickerShows = [];
   rewindPickerHideCount = 0;
   removeMessagesFromCalls = [];
@@ -602,8 +603,9 @@ class FakeView {
   stopWorkingIcon() {
     this.workingIconStops += 1;
   }
-  handleToolUiEvent(event) {
+  handleToolUiEvent(event, origin) {
     this.toolEvents.push(event);
+    this.toolEventOrigins.push(origin);
   }
   subagentEvents = [];
   handleSubagentEvent(event) {
@@ -2402,6 +2404,7 @@ describe("SessionChatController", () => {
       "tool_call_queued",
       "bash_execution",
     ]);
+    expect(view.toolEventOrigins).toEqual(["session", "session"]);
     await controller.dispose();
   });
 
@@ -2494,6 +2497,7 @@ describe("SessionChatController", () => {
 
     expect(view.resetToolUiSession).toHaveBeenCalledTimes(resetCount);
     expect(view.toolEvents).toEqual([queuedEvent, startedEvent]);
+    expect(view.toolEventOrigins).toEqual(["session", "session"]);
     expect(view.status.footer.sessionCost).toBe("$0.42");
     expect(controller.snapshot.tools["tool-a"].status).toBe("running");
     await controller.dispose();
@@ -2744,6 +2748,7 @@ describe("SessionChatController", () => {
         }),
       ]),
     );
+    expect(view.toolEventOrigins).toEqual(["local", "local"]);
     expect(view.messages).not.toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -2782,6 +2787,7 @@ describe("SessionChatController", () => {
         }),
       ]),
     );
+    expect(view.toolEventOrigins).toEqual(["local", "local"]);
   });
 
   it("routes session maintenance commands through the session protocol", async () => {

--- a/test/tool_ui_router.test.js
+++ b/test/tool_ui_router.test.js
@@ -45,6 +45,8 @@ function createHarness() {
 
   return {
     router,
+    handleSession: (event) => router.handle(event, "session"),
+    handleLocal: (event) => router.handle(event, "local"),
     added,
     replaced,
     removed,
@@ -103,13 +105,13 @@ describe("ToolUiRouter prune mutations", () => {
   it("patches existing tool cards by toolCallId and preserves the base event type", () => {
     const harness = createHarness();
 
-    harness.router.handle({
+    harness.handleSession({
       type: "bash_started",
       toolCallId: "bash-1",
       command: "echo hello",
     });
 
-    harness.router.handle({
+    harness.handleSession({
       type: "bash_execution",
       toolCallId: "bash-1",
       command: "echo hello",
@@ -135,7 +137,7 @@ describe("ToolUiRouter prune mutations", () => {
 
     const prunedContent =
       "[Tool result pruned] bash output removed (12 tokens). Re-run the command if needed.";
-    harness.router.handle({
+    harness.handleSession({
       type: "tool_pruned",
       toolCallId: "bash-1",
       content: prunedContent,
@@ -152,7 +154,7 @@ describe("ToolUiRouter prune mutations", () => {
   it("adds one-shot tool cards with ids and renders pruned content without tones", () => {
     const harness = createHarness();
 
-    harness.router.handle({
+    harness.handleSession({
       type: "write_success",
       toolCallId: "write-1",
       path: "notes.txt",
@@ -167,7 +169,7 @@ describe("ToolUiRouter prune mutations", () => {
 
     expect(harness.added.at(-1)).toMatchObject({ id: "write-1" });
 
-    harness.router.handle({
+    harness.handleSession({
       type: "tool_pruned",
       toolCallId: "write-1",
       content: "- old\n+ new",
@@ -184,7 +186,7 @@ describe("ToolUiRouter prune mutations", () => {
   it("patches blocked events that do not expose uiText", () => {
     const harness = createHarness();
 
-    harness.router.handle({
+    harness.handleSession({
       type: "bash_blocked",
       toolCallId: "bash-2",
       command: "echo hi",
@@ -193,7 +195,7 @@ describe("ToolUiRouter prune mutations", () => {
 
     const prunedContent =
       "[Tool result pruned] bash output removed (20 tokens). Re-run the command if needed.";
-    harness.router.handle({
+    harness.handleSession({
       type: "tool_pruned",
       toolCallId: "bash-2",
       content: prunedContent,
@@ -208,7 +210,7 @@ describe("ToolUiRouter prune mutations", () => {
   it("falls back to adding when cached tool ids are no longer present", () => {
     const harness = createHarness();
 
-    harness.router.handle({
+    harness.handleSession({
       type: "write_success",
       toolCallId: "write-1",
       path: "notes.txt",
@@ -223,7 +225,7 @@ describe("ToolUiRouter prune mutations", () => {
 
     harness.removeMessage("write-1");
 
-    harness.router.handle({
+    harness.handleSession({
       type: "write_success",
       toolCallId: "write-1",
       path: "notes.txt",
@@ -243,15 +245,21 @@ describe("ToolUiRouter prune mutations", () => {
 });
 
 describe("ToolUiRouter snapshot reconciliation", () => {
-  it("removes tool cards that are no longer present in the snapshot", () => {
+  it("rebuilds session cards while preserving local cards", () => {
     const harness = createHarness();
-    harness.router.handle({
+    harness.handleLocal({
+      type: "bash_started",
+      toolCallId: "local-call",
+      command: "pwd",
+      headerTarget: "pwd",
+    });
+    harness.handleSession({
       type: "tool_call_streaming",
       toolCallId: "stale-call",
       toolName: "write",
       headerTarget: "write",
     });
-    harness.router.handle({
+    harness.handleSession({
       type: "tool_call_streaming",
       toolCallId: "current-call",
       toolName: "bash",
@@ -261,18 +269,25 @@ describe("ToolUiRouter snapshot reconciliation", () => {
     harness.router.reconcileSession(["current-call"]);
 
     expect(harness.removed).toEqual(["stale-call"]);
-    expect(getLatestEventsMap(harness.router).size).toBe(0);
-    harness.router.handle({
+    expect([...getLatestEventsMap(harness.router).keys()]).toEqual(["local-call"]);
+    expect(getRunningBashMap(harness.router).has("local-call")).toBe(true);
+
+    harness.handleSession({
       type: "tool_call_queued",
       toolCallId: "current-call",
       toolName: "bash",
       headerTarget: "bash",
     });
+    harness.handleLocal(bashExecutionEvent("local-call", "pwd"));
+
     expect(harness.added.filter((entry) => entry.id === "current-call")).toHaveLength(1);
-    expect(harness.replaced.at(-1)).toMatchObject({
-      id: "current-call",
-      model: { event: { type: "tool_call_queued" } },
+    expect(findLatestReplacedEvent(harness.replaced, "current-call")).toMatchObject({
+      type: "tool_call_queued",
     });
+    expect(findLatestReplacedEvent(harness.replaced, "local-call")).toMatchObject({
+      type: "bash_execution",
+    });
+    expect(getRunningBashMap(harness.router).has("local-call")).toBe(false);
   });
 });
 
@@ -280,24 +295,24 @@ describe("ToolUiRouter lifecycle tracking", () => {
   it("tracks and untracks bash for execution and blocked lifecycles", () => {
     const harness = createHarness();
 
-    harness.router.handle({
+    harness.handleSession({
       type: "bash_started",
       toolCallId: "bash-exec",
       command: "echo one",
     });
     expect(getRunningBashMap(harness.router).has("bash-exec")).toBe(true);
 
-    harness.router.handle(bashExecutionEvent("bash-exec", "echo one"));
+    harness.handleSession(bashExecutionEvent("bash-exec", "echo one"));
     expect(getRunningBashMap(harness.router).has("bash-exec")).toBe(false);
 
-    harness.router.handle({
+    harness.handleSession({
       type: "bash_started",
       toolCallId: "bash-blocked",
       command: "echo two",
     });
     expect(getRunningBashMap(harness.router).has("bash-blocked")).toBe(true);
 
-    harness.router.handle({
+    harness.handleSession({
       type: "bash_blocked",
       toolCallId: "bash-blocked",
       command: "echo two",
@@ -421,16 +436,16 @@ describe("ToolUiRouter lifecycle tracking", () => {
     ];
 
     for (const entry of cases) {
-      harness.router.handle(entry.started);
+      harness.handleSession(entry.started);
       expect(getRunningSubagentMap(harness.router).has(entry.started.toolCallId)).toBe(true);
 
-      harness.router.handle(entry.terminal);
+      harness.handleSession(entry.terminal);
       expect(getRunningSubagentMap(harness.router).has(entry.started.toolCallId)).toBe(false);
 
-      harness.router.handle(entry.blockedStarted);
+      harness.handleSession(entry.blockedStarted);
       expect(getRunningSubagentMap(harness.router).has(entry.blockedStarted.toolCallId)).toBe(true);
 
-      harness.router.handle(entry.blocked);
+      harness.handleSession(entry.blocked);
       expect(getRunningSubagentMap(harness.router).has(entry.blockedStarted.toolCallId)).toBe(
         false,
       );
@@ -440,12 +455,12 @@ describe("ToolUiRouter lifecycle tracking", () => {
   it("finalizes pending bash and subagent entries with aborted reason", () => {
     const harness = createHarness();
 
-    harness.router.handle({
+    harness.handleSession({
       type: "bash_started",
       toolCallId: "bash-pending",
       command: "echo pending",
     });
-    harness.router.handle({
+    harness.handleSession({
       type: "spawn_agent_started",
       toolCallId: "spawn-pending",
       name: "default",
@@ -467,12 +482,12 @@ describe("ToolUiRouter lifecycle tracking", () => {
   it("finalizes pending bash and subagent entries with interrupted reason", () => {
     const harness = createHarness();
 
-    harness.router.handle({
+    harness.handleSession({
       type: "bash_started",
       toolCallId: "bash-pending-int",
       command: "echo pending int",
     });
-    harness.router.handle({
+    harness.handleSession({
       type: "wait_for_agents_started",
       toolCallId: "wait-pending-int",
       agentIds: ["agent-1", "agent-2"],
@@ -493,12 +508,12 @@ describe("ToolUiRouter lifecycle tracking", () => {
   it("clears transient maps and resetSession clears all cached tool state", () => {
     const harness = createHarness();
 
-    harness.router.handle({
+    harness.handleSession({
       type: "bash_started",
       toolCallId: "bash-1",
       command: "echo one",
     });
-    harness.router.handle({
+    harness.handleSession({
       type: "send_input_to_agent_started",
       toolCallId: "send-1",
       agentId: "agent-1",


### PR DESCRIPTION
## why

Snapshot reconciliation introduced for streamed tool-call cleanup treated every rendered tool card as session-owned. Direct `!` and `!!` commands render TUI-local bash cards with no matching `snapshot.tools` entry, so the refresh after execution immediately removed their output.

## what

I made tool UI ownership explicit across the controller, view, and router. Snapshot facet events are routed as session-owned, while all direct-bash lifecycle events are routed as local. Reconciliation now clears and removes only session-owned card state, preserving local cards and their lifecycle across snapshot refreshes.

I added mixed-ownership router coverage for stale and current session cards alongside a local bash card, plus controller assertions that snapshot events and both direct-command modes use the correct ownership.

## details

Direct commands remain outside `snapshot.tools`: `!` still records its hidden model-visible history entry, while `!!` remains non-persisted. Full local UI session resets continue to clear both ownership classes. This follows the implementation agreed in the issue discussion, with no remaining questions or compatibility assumptions.

fixes #323
