### PR TITLE
allow concurrent session side channels

### DIFF
--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -525,7 +525,7 @@ params (required):
 }
 ```
 
-runs a raw shell command through the session execution environment and returns captured output. `output` is stdout and stderr interleaved in arrival order; `stdout` and `stderr` are the split streams. `cwd` and `timeoutMs` are optional. `cwd` is the command working directory, not a confinement boundary; absolute paths are allowed when the execution environment permits them. The command does not add anything to session history; clients that want command output in model context should call `session.record` with their chosen text.
+runs a raw shell command through the session execution environment and returns captured output. `output` is stdout and stderr interleaved in arrival order; `stdout` and `stderr` are the split streams. `cwd` and `timeoutMs` are optional. `cwd` is the command working directory, not a confinement boundary; absolute paths are allowed when the execution environment permits them. Exec requests are independent side channels: multiple commands can run concurrently with each other and with session turns, mutations, samples, or ephemeral agents. They do not enter the session mutation queue, change snapshots, or emit deltas. Workspace races are allowed, so clients must coordinate commands when consistency matters. The command does not add anything to session history; clients that want command output in model context should call `session.record` with their chosen text.
 
 returns:
 
@@ -799,7 +799,7 @@ params (required):
 }
 ```
 
-creates a host-owned ephemeral agent context outside the persisted session timeline. The context inherits the hosted session persona and execution environment, appends the provided instructions, uses the requested tool set, and returns `{ "contextId" }`. These contexts are not persisted in `session.snapshot` and are not recoverable after disconnect or host restart.
+creates a host-owned ephemeral agent context outside the persisted session timeline. The context inherits the hosted session persona and execution environment, appends the provided instructions, uses the requested tool set, and returns `{ "contextId" }`. Ephemeral context creation, submission, and closure run independently of main-session turns and mutations. These contexts are not persisted in `session.snapshot` and are not recoverable after disconnect or host restart.
 
 #### session.ephemeral.submit
 
@@ -963,8 +963,8 @@ error codes:
 - `method_not_found`: unsupported method
 - `invalid_params`: params failed method validation
 - `not_found`: requested session does not exist on this host
-- `busy`: overlapping idle-only `session.submit`/`session.retry`/`session.exec` or activity rejected while a mutating request is in progress
-- `cancelled`: a pending queued/steering request was cancelled or a model sample was interrupted
+- `busy`: overlapping main-session turns, same-thread ephemeral submissions, or activity rejected while a mutating request is in progress
+- `cancelled`: a pending queued/steering request, execution command, or model sample was cancelled
 - `internal_error`: unexpected runtime failure
 
 for lines that cannot produce a valid request id (for example malformed json), `id` is `null`.
@@ -974,14 +974,15 @@ for lines that cannot produce a valid request id (for example malformed json), `
 `runRpcServer` handles incoming lines concurrently with explicit serialization for mutating transitions. this means:
 
 - multiple requests can be accepted before earlier ones complete
-- `session.record`, `session.setReasoning`, `session.setPersona`, `session.reload`, `session.compact`, `session.prune`, `session.rewind`, `session.terminateSubagent`, `session.ephemeral.create`, and `session.ephemeral.close` run through a session-owned mutation queue (arrival order across clients observed to the same live session)
+- `session.record`, `session.setReasoning`, `session.setPersona`, `session.reload`, `session.compact`, `session.prune`, `session.rewind`, and `session.terminateSubagent` run through a session-owned mutation queue (arrival order across clients observed to the same live session)
 - `session.setReasoning` updates settings immediately without interrupting an active turn; active turns keep their captured reasoning and the new setting applies to the next user-message turn
-- only one idle-only `session.submit`, `session.retry`, or `session.exec` can run at once (`busy` otherwise)
-- `session.sample` calls can run concurrently with each other and with normal session work; they never enter the mutation queue
-- `session.queue` can be accepted during active work and runs after the active turn settles
+- only one `session.submit` or `session.retry` turn can run at once (`busy` otherwise)
+- `session.exec` and `session.sample` calls can run concurrently with each other and with normal session work; they never enter the mutation queue
+- `session.ephemeral.create`, `session.ephemeral.submit`, and `session.ephemeral.close` manage independent, non-persisted contexts outside the main-session mutation queue; only overlapping submissions to the same ephemeral thread return `busy`
+- `session.queue` can be accepted during active main-session work and runs after the active turn settles
 - `session.steer` can be accepted during an active turn and runs at the next safe boundary after requesting the active turn to stop
 - `session.cancelPendingMessages` atomically removes pending queue and steering requests without interrupting active work
-- `session.submit`, `session.retry`, and `session.exec` are rejected with `busy` while a queued/running compact or prune mutation exists
+- `session.submit` and `session.retry` are rejected with `busy` while a queued/running main-session mutation exists
 - responses and deltas may still interleave
 
 clients should route responses by `id` and broadcast deltas by `sessionId`, not by arrival order alone.

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -299,7 +299,8 @@ options:
 - `exec(command, options?)`
   - sends `session.exec` with this session id
   - runs a raw command in the session execution environment and returns interleaved `output` plus split `stdout` and `stderr`
-  - does not add output to session history
+  - runs independently and concurrently with session turns, mutations, other execs, samples, and ephemeral agents; callers own workspace coordination
+  - does not add output to session history or mutate the session snapshot
 - `sample({ context, options })`
   - sends `session.sample` with this session id
   - samples the active persona model against only the supplied system prompt, messages, and optional tool schemas
@@ -307,7 +308,7 @@ options:
   - returns a complete assistant message that can be appended directly to a later sampling context
   - does not mutate or persist the session, emit deltas, update session cost, execute returned tool calls, or write a Tau usage-log entry
 - `interrupt()`
-  - sends `session.interrupt` with this session id and cancels active samples as well as other active work
+  - sends `session.interrupt` with this session id and cancels active turns, execs, samples, and maintenance work
 - `snapshot()`
   - sends `session.snapshot` with this session id
   - returns raw recoverable session user text; renderers should use `getTauUserDisplayText()` or `projectTauUserText()` to hide Tau metadata and leading exact `<system>...</system>\n` blocks from user messages before showing them to users
@@ -338,7 +339,7 @@ options:
   - resolves with `{ found: boolean }`
 - `createEphemeralContext({ instructions, tools })`
   - sends `session.ephemeral.create` with this session id
-  - creates non-persisted host-owned agent context and returns `{ contextId }`
+  - creates a non-persisted host-owned agent context independently of main-session turns and mutations, and returns `{ contextId }`
 - `submitEphemeralThread({ contextId, threadId, forkFromThreadId?, message })`
   - sends `session.ephemeral.submit` with this session id
   - runs or continues an ephemeral host-owned agent thread and returns `{ threadId, response }`

--- a/src/host/local_session_host.ts
+++ b/src/host/local_session_host.ts
@@ -456,10 +456,7 @@ export class LocalSessionHost implements TauSessionHost {
     }
 
     for (const session of this.sessions) {
-      session.interruptTurn();
-      session.interruptExecs();
-      session.interruptMaintenance();
-      session.interruptSamples();
+      session.interruptActiveWork();
     }
 
     const settlementResults = await Promise.allSettled(
@@ -542,12 +539,8 @@ class LocalHostedSessionHandle implements LocalHostedSession {
   private runtimeEventQueue: Promise<void> = Promise.resolve();
   private snapshotQueue: Promise<unknown> = Promise.resolve();
   private snapshotGeneration = 0;
-  private readonly execAbortControllers = new Set<AbortController>();
-  private readonly execPromises = new Set<Promise<unknown>>();
-  private readonly maintenanceAbortControllers = new Set<AbortController>();
-  private readonly maintenancePromises = new Set<Promise<unknown>>();
-  private readonly sampleAbortControllers = new Set<AbortController>();
-  private readonly samplePromises = new Set<Promise<unknown>>();
+  private readonly activeWorkAbortControllers = new Set<AbortController>();
+  private readonly activeWorkPromises = new Set<Promise<unknown>>();
   private activeTurnPromise?: Promise<SessionProtocolTurnOutcome>;
   private disposePromise?: Promise<void>;
   private disposing = false;
@@ -681,31 +674,9 @@ class LocalHostedSessionHandle implements LocalHostedSession {
     return this.runtime.interruptTurn();
   }
 
-  interruptExecs(): boolean {
-    let interrupted = false;
-    for (const abortController of this.execAbortControllers) {
-      if (!abortController.signal.aborted) {
-        abortController.abort();
-        interrupted = true;
-      }
-    }
-    return interrupted;
-  }
-
-  interruptMaintenance(): boolean {
-    let interrupted = false;
-    for (const abortController of this.maintenanceAbortControllers) {
-      if (!abortController.signal.aborted) {
-        abortController.abort();
-        interrupted = true;
-      }
-    }
-    return interrupted;
-  }
-
-  interruptSamples(): boolean {
-    let interrupted = false;
-    for (const abortController of this.sampleAbortControllers) {
+  interruptActiveWork(): boolean {
+    let interrupted = this.runtime.interruptTurn();
+    for (const abortController of this.activeWorkAbortControllers) {
       if (!abortController.signal.aborted) {
         abortController.abort();
         interrupted = true;
@@ -717,9 +688,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
   async waitForActiveWork(): Promise<void> {
     await Promise.allSettled([
       ...(this.activeTurnPromise ? [this.activeTurnPromise] : []),
-      ...this.execPromises,
-      ...this.maintenancePromises,
-      ...this.samplePromises,
+      ...this.activeWorkPromises,
     ]);
     await this.runtimeEventQueue;
   }
@@ -740,26 +709,16 @@ class LocalHostedSessionHandle implements LocalHostedSession {
     },
   ): Promise<SessionProtocolExecResult> {
     this.assertActive();
-    const abortController = new AbortController();
-    const signal = options.signal
-      ? AbortSignal.any([options.signal, abortController.signal])
-      : abortController.signal;
-    this.execAbortControllers.add(abortController);
     const backend = this.executionEnvironment.getToolExecutionBackend();
-    const promise = backend.runBash(options.command, {
-      ...(options.cwd !== undefined ? { cwd: options.cwd } : {}),
-      ...(options.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
-      signal,
-    });
-    this.execPromises.add(promise);
-    try {
-      const result = await promise;
+    return await this.runActiveWork(async (signal) => {
+      const result = await backend.runBash(options.command, {
+        ...(options.cwd !== undefined ? { cwd: options.cwd } : {}),
+        ...(options.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
+        signal,
+      });
       signal.throwIfAborted();
       return result;
-    } finally {
-      this.execAbortControllers.delete(abortController);
-      this.execPromises.delete(promise);
-    }
+    }, options.signal);
   }
 
   async sample(
@@ -768,19 +727,12 @@ class LocalHostedSessionHandle implements LocalHostedSession {
     },
   ): Promise<SessionProtocolSampleResult> {
     this.assertActive();
-    const abortController = new AbortController();
-    const signal = options.signal
-      ? AbortSignal.any([options.signal, abortController.signal])
-      : abortController.signal;
-    this.sampleAbortControllers.add(abortController);
-    const promise = this.session.sample({ ...options, signal }).then((message) => ({ message }));
-    this.samplePromises.add(promise);
-    try {
-      return await promise;
-    } finally {
-      this.sampleAbortControllers.delete(abortController);
-      this.samplePromises.delete(promise);
-    }
+    return await this.runActiveWork(
+      async (signal) => ({
+        message: await this.session.sample({ ...options, signal }),
+      }),
+      options.signal,
+    );
   }
 
   async setReasoning(reasoning: ReasoningEffort): Promise<SessionProtocolSettingsUpdateResult> {
@@ -1020,15 +972,25 @@ class LocalHostedSessionHandle implements LocalHostedSession {
 
   private async runMaintenance<T>(operation: (signal: AbortSignal) => Promise<T>): Promise<T> {
     this.assertActive();
+    return await this.runActiveWork(operation);
+  }
+
+  private async runActiveWork<T>(
+    operation: (signal: AbortSignal) => Promise<T>,
+    externalSignal?: AbortSignal,
+  ): Promise<T> {
     const abortController = new AbortController();
-    this.maintenanceAbortControllers.add(abortController);
-    const promise = operation(abortController.signal);
-    this.maintenancePromises.add(promise);
+    const signal = externalSignal
+      ? AbortSignal.any([externalSignal, abortController.signal])
+      : abortController.signal;
+    this.activeWorkAbortControllers.add(abortController);
+    const promise = operation(signal);
+    this.activeWorkPromises.add(promise);
     try {
       return await promise;
     } finally {
-      this.maintenanceAbortControllers.delete(abortController);
-      this.maintenancePromises.delete(promise);
+      this.activeWorkAbortControllers.delete(abortController);
+      this.activeWorkPromises.delete(promise);
     }
   }
 
@@ -1127,10 +1089,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
     }
 
     const errors: unknown[] = [];
-    this.runtime.interruptTurn();
-    this.interruptExecs();
-    this.interruptMaintenance();
-    this.interruptSamples();
+    this.interruptActiveWork();
     try {
       await this.waitForActiveWork();
     } catch (error) {

--- a/src/host/local_session_host.ts
+++ b/src/host/local_session_host.ts
@@ -457,6 +457,7 @@ export class LocalSessionHost implements TauSessionHost {
 
     for (const session of this.sessions) {
       session.interruptTurn();
+      session.interruptExecs();
       session.interruptMaintenance();
       session.interruptSamples();
     }
@@ -541,6 +542,8 @@ class LocalHostedSessionHandle implements LocalHostedSession {
   private runtimeEventQueue: Promise<void> = Promise.resolve();
   private snapshotQueue: Promise<unknown> = Promise.resolve();
   private snapshotGeneration = 0;
+  private readonly execAbortControllers = new Set<AbortController>();
+  private readonly execPromises = new Set<Promise<unknown>>();
   private readonly maintenanceAbortControllers = new Set<AbortController>();
   private readonly maintenancePromises = new Set<Promise<unknown>>();
   private readonly sampleAbortControllers = new Set<AbortController>();
@@ -678,6 +681,17 @@ class LocalHostedSessionHandle implements LocalHostedSession {
     return this.runtime.interruptTurn();
   }
 
+  interruptExecs(): boolean {
+    let interrupted = false;
+    for (const abortController of this.execAbortControllers) {
+      if (!abortController.signal.aborted) {
+        abortController.abort();
+        interrupted = true;
+      }
+    }
+    return interrupted;
+  }
+
   interruptMaintenance(): boolean {
     let interrupted = false;
     for (const abortController of this.maintenanceAbortControllers) {
@@ -703,6 +717,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
   async waitForActiveWork(): Promise<void> {
     await Promise.allSettled([
       ...(this.activeTurnPromise ? [this.activeTurnPromise] : []),
+      ...this.execPromises,
       ...this.maintenancePromises,
       ...this.samplePromises,
     ]);
@@ -725,12 +740,24 @@ class LocalHostedSessionHandle implements LocalHostedSession {
     },
   ): Promise<SessionProtocolExecResult> {
     this.assertActive();
+    const abortController = new AbortController();
+    const signal = options.signal
+      ? AbortSignal.any([options.signal, abortController.signal])
+      : abortController.signal;
+    this.execAbortControllers.add(abortController);
     const backend = this.executionEnvironment.getToolExecutionBackend();
-    return await backend.runBash(options.command, {
+    const promise = backend.runBash(options.command, {
       ...(options.cwd !== undefined ? { cwd: options.cwd } : {}),
       ...(options.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
-      ...(options.signal !== undefined ? { signal: options.signal } : {}),
+      signal,
     });
+    this.execPromises.add(promise);
+    try {
+      return await promise;
+    } finally {
+      this.execAbortControllers.delete(abortController);
+      this.execPromises.delete(promise);
+    }
   }
 
   async sample(
@@ -1099,6 +1126,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
 
     const errors: unknown[] = [];
     this.runtime.interruptTurn();
+    this.interruptExecs();
     this.interruptMaintenance();
     this.interruptSamples();
     try {

--- a/src/host/local_session_host.ts
+++ b/src/host/local_session_host.ts
@@ -753,7 +753,9 @@ class LocalHostedSessionHandle implements LocalHostedSession {
     });
     this.execPromises.add(promise);
     try {
-      return await promise;
+      const result = await promise;
+      signal.throwIfAborted();
+      return result;
     } finally {
       this.execAbortControllers.delete(abortController);
       this.execPromises.delete(promise);

--- a/src/host/session_host.ts
+++ b/src/host/session_host.ts
@@ -50,9 +50,7 @@ export type TauHostedSession = {
   ): Promise<SessionProtocolRecordResult>;
   runTurn(): Promise<SessionProtocolTurnOutcome>;
   interruptTurn(): boolean;
-  interruptExecs(): boolean;
-  interruptMaintenance(): boolean;
-  interruptSamples(): boolean;
+  interruptActiveWork(): boolean;
   waitForActiveWork(): Promise<void>;
   requestTurnBoundaryStop(): boolean;
   cancelTurnBoundaryStop(): boolean;

--- a/src/host/session_host.ts
+++ b/src/host/session_host.ts
@@ -50,6 +50,7 @@ export type TauHostedSession = {
   ): Promise<SessionProtocolRecordResult>;
   runTurn(): Promise<SessionProtocolTurnOutcome>;
   interruptTurn(): boolean;
+  interruptExecs(): boolean;
   interruptMaintenance(): boolean;
   interruptSamples(): boolean;
   waitForActiveWork(): Promise<void>;

--- a/src/host/session_protocol_handler.ts
+++ b/src/host/session_protocol_handler.ts
@@ -36,16 +36,6 @@ type SessionProtocolActiveSubmit = {
   promise: Promise<void>;
 };
 
-type SessionProtocolActiveExec = {
-  abortController: AbortController;
-  promise: Promise<void>;
-};
-
-type SessionProtocolActiveSample = {
-  abortController: AbortController;
-  promise: Promise<void>;
-};
-
 type SessionProtocolPendingRequest<Method extends "session.queue" | "session.steer"> = {
   id: string;
   handler: SessionProtocolHandler;
@@ -165,8 +155,8 @@ export class SessionProtocolHandler {
   private readonly host: TauSessionHost;
   private readonly send: (message: SessionProtocolOutgoingMessage) => void;
   private readonly sessionStates = new Map<string, SessionProtocolHandlerSessionState>();
-  private readonly activeExecs = new Set<SessionProtocolActiveExec>();
-  private readonly activeSamples = new Set<SessionProtocolActiveSample>();
+  private readonly connectionAbortController = new AbortController();
+  private readonly activeSideChannels = new Set<Promise<void>>();
   private initialized = false;
   private clientToolRegistration?: {
     attachSession: (sessionId: string) => void;
@@ -300,27 +290,13 @@ export class SessionProtocolHandler {
     const interruptActiveTurns = mode === "interrupt" || shutdownHost;
 
     const states = [...this.sessionStates.values()];
-    const execPromises = new Set<Promise<void>>();
-    for (const exec of this.activeExecs) {
-      exec.abortController.abort();
-      execPromises.add(exec.promise);
-    }
-    const samplePromises = new Set<Promise<void>>();
-    for (const sample of this.activeSamples) {
-      sample.abortController.abort();
-      samplePromises.add(sample.promise);
-    }
+    const activeSideChannels = [...this.activeSideChannels];
+    this.connectionAbortController.abort();
 
     for (const state of states) {
       this.unsubscribeSessionListeners(state);
-
-      if (interruptActiveTurns && (state.live.activeSubmit || state.session.isTurnRunning)) {
-        state.session.interruptTurn();
-      }
       if (interruptActiveTurns) {
-        state.session.interruptExecs();
-        state.session.interruptMaintenance();
-        state.session.interruptSamples();
+        state.session.interruptActiveWork();
       }
     }
 
@@ -333,7 +309,7 @@ export class SessionProtocolHandler {
         states.map((state) => getSessionMutationQueueState(state.session).queue),
       );
     }
-    await Promise.allSettled([...execPromises, ...samplePromises]);
+    await Promise.allSettled(activeSideChannels);
 
     this.sessionStates.clear();
     this.clientToolRegistration?.unregister();
@@ -581,17 +557,7 @@ export class SessionProtocolHandler {
       return;
     }
 
-    const abortController = new AbortController();
-    const activeExec = {
-      abortController,
-      promise: this.executeExec(state, request, abortController.signal),
-    };
-    this.activeExecs.add(activeExec);
-    try {
-      await activeExec.promise;
-    } finally {
-      this.activeExecs.delete(activeExec);
-    }
+    await this.runSideChannel((signal) => this.executeExec(state, request, signal));
   }
 
   private async handleSample(
@@ -606,17 +572,7 @@ export class SessionProtocolHandler {
       return;
     }
 
-    const abortController = new AbortController();
-    const activeSample = {
-      abortController,
-      promise: this.executeSample(state, request, abortController.signal),
-    };
-    this.activeSamples.add(activeSample);
-    try {
-      await activeSample.promise;
-    } finally {
-      this.activeSamples.delete(activeSample);
-    }
+    await this.runSideChannel((signal) => this.executeSample(state, request, signal));
   }
 
   private async handleRetry(
@@ -1038,6 +994,16 @@ export class SessionProtocolHandler {
     }
   }
 
+  private async runSideChannel(operation: (signal: AbortSignal) => Promise<void>): Promise<void> {
+    const promise = operation(this.connectionAbortController.signal);
+    this.activeSideChannels.add(promise);
+    try {
+      await promise;
+    } finally {
+      this.activeSideChannels.delete(promise);
+    }
+  }
+
   private async executeExec(
     state: SessionProtocolHandlerSessionState,
     request: Extract<SessionProtocolRequestMessage, { method: "session.exec" }>,
@@ -1102,20 +1068,12 @@ export class SessionProtocolHandler {
       return;
     }
 
-    const interruptedTurn = state.session.interruptTurn();
-    const interruptedExecs = state.session.interruptExecs();
-    const interruptedMaintenance = state.session.interruptMaintenance();
-    const interruptedSamples = state.session.interruptSamples();
+    const interrupted = state.session.interruptActiveWork();
     this.rejectPendingSteeringSubmits(state, "session was interrupted");
 
     const result: SessionProtocolResultByMethod["session.interrupt"] = {
-      interrupted:
-        interruptedTurn || interruptedExecs || interruptedMaintenance || interruptedSamples,
-      isTurnRunning:
-        state.session.isTurnRunning ||
-        interruptedExecs ||
-        interruptedMaintenance ||
-        interruptedSamples,
+      interrupted,
+      isTurnRunning: state.session.isTurnRunning || interrupted,
     };
 
     this.sendMessage(createSessionProtocolSuccessResponse(request.id, "session.interrupt", result));
@@ -1486,7 +1444,10 @@ export class SessionProtocolHandler {
     }
 
     const session = await this.host.observeSession(sessionId);
-    return session ? this.registerSession(session) : undefined;
+    if (!session || this.closed) {
+      return undefined;
+    }
+    return this.registerSession(session);
   }
 
   private flushBufferedDeltasAfterSnapshot(

--- a/src/host/session_protocol_handler.ts
+++ b/src/host/session_protocol_handler.ts
@@ -1267,6 +1267,9 @@ export class SessionProtocolHandler {
       this.sendSessionNotFound(request.id, request.params.sessionId);
       return;
     }
+    if (this.closed) {
+      return;
+    }
 
     const result = await state.session.createEphemeralContext({
       instructions: request.params.instructions,

--- a/src/host/session_protocol_handler.ts
+++ b/src/host/session_protocol_handler.ts
@@ -36,8 +36,7 @@ type SessionProtocolActiveSubmit = {
   promise: Promise<void>;
 };
 
-type SessionProtocolActiveBash = {
-  requestId: SessionProtocolRequestId;
+type SessionProtocolActiveExec = {
   abortController: AbortController;
   promise: Promise<void>;
 };
@@ -59,7 +58,6 @@ type SessionProtocolPendingUserMessageRequest =
 
 type SessionProtocolLiveSessionState = {
   activeSubmit?: SessionProtocolActiveSubmit;
-  activeBash?: SessionProtocolActiveBash;
   revision: number;
   pendingSteeringSubmits: Array<SessionProtocolPendingRequest<"session.steer">>;
   pendingQueuedSubmits: Array<SessionProtocolPendingRequest<"session.queue">>;
@@ -159,9 +157,7 @@ type SessionProtocolMutationRequest = Extract<
       | "session.compact"
       | "session.prune"
       | "session.rewind"
-      | "session.terminateSubagent"
-      | "session.ephemeral.create"
-      | "session.ephemeral.close";
+      | "session.terminateSubagent";
   }
 >;
 
@@ -169,6 +165,7 @@ export class SessionProtocolHandler {
   private readonly host: TauSessionHost;
   private readonly send: (message: SessionProtocolOutgoingMessage) => void;
   private readonly sessionStates = new Map<string, SessionProtocolHandlerSessionState>();
+  private readonly activeExecs = new Set<SessionProtocolActiveExec>();
   private readonly activeSamples = new Set<SessionProtocolActiveSample>();
   private initialized = false;
   private clientToolRegistration?: {
@@ -303,6 +300,11 @@ export class SessionProtocolHandler {
     const interruptActiveTurns = mode === "interrupt" || shutdownHost;
 
     const states = [...this.sessionStates.values()];
+    const execPromises = new Set<Promise<void>>();
+    for (const exec of this.activeExecs) {
+      exec.abortController.abort();
+      execPromises.add(exec.promise);
+    }
     const samplePromises = new Set<Promise<void>>();
     for (const sample of this.activeSamples) {
       sample.abortController.abort();
@@ -316,11 +318,9 @@ export class SessionProtocolHandler {
         state.session.interruptTurn();
       }
       if (interruptActiveTurns) {
+        state.session.interruptExecs();
         state.session.interruptMaintenance();
         state.session.interruptSamples();
-      }
-      if (interruptActiveTurns && state.live.activeBash) {
-        state.live.activeBash.abortController.abort();
       }
     }
 
@@ -330,13 +330,10 @@ export class SessionProtocolHandler {
         states.map((state) => state.live.activeSubmit?.promise).filter((promise) => promise),
       );
       await Promise.allSettled(
-        states.map((state) => state.live.activeBash?.promise).filter((promise) => promise),
-      );
-      await Promise.allSettled(
         states.map((state) => getSessionMutationQueueState(state.session).queue),
       );
     }
-    await Promise.allSettled(samplePromises);
+    await Promise.allSettled([...execPromises, ...samplePromises]);
 
     this.sessionStates.clear();
     this.clientToolRegistration?.unregister();
@@ -456,7 +453,7 @@ export class SessionProtocolHandler {
     }
 
     const startedSubmit = await this.enqueueMutation(state, () => {
-      if (state.live.activeSubmit || state.session.isTurnRunning || state.live.activeBash) {
+      if (state.live.activeSubmit || state.session.isTurnRunning) {
         state.live.pendingQueuedSubmits.push({ id: randomUUID(), handler: this, request });
         publishPendingUserMessages(state.session, state.live);
         return undefined;
@@ -497,8 +494,7 @@ export class SessionProtocolHandler {
     }
 
     const startedSubmit = await this.enqueueMutation(state, () => {
-      const hasActiveSessionWork =
-        state.live.activeSubmit || state.session.isTurnRunning || state.live.activeBash;
+      const hasActiveSessionWork = state.live.activeSubmit || state.session.isTurnRunning;
       if (state.live.pendingSteeringSubmits.length > 0 || hasActiveSessionWork) {
         state.live.pendingSteeringSubmits.push({ id: randomUUID(), handler: this, request });
         publishPendingUserMessages(state.session, state.live);
@@ -581,31 +577,20 @@ export class SessionProtocolHandler {
       this.sendSessionNotFound(request.id, request.params.sessionId);
       return;
     }
-
-    if (
-      this.getPendingMutationCount(state) > 0 ||
-      state.live.activeSubmit ||
-      state.session.isTurnRunning ||
-      state.live.activeBash
-    ) {
-      this.sendSubmitBusy(state, request.id);
+    if (this.closed) {
       return;
     }
 
-    const activeBash = await this.enqueueMutation(state, () => this.startExec(state, request));
-    if (!activeBash) {
-      return;
-    }
-
+    const abortController = new AbortController();
+    const activeExec = {
+      abortController,
+      promise: this.executeExec(state, request, abortController.signal),
+    };
+    this.activeExecs.add(activeExec);
     try {
-      await activeBash.promise;
+      await activeExec.promise;
     } finally {
-      await this.enqueueMutation(state, () => {
-        if (state.live.activeBash === activeBash) {
-          state.live.activeBash = undefined;
-        }
-      });
-      this.schedulePendingSubmitDrains(state);
+      this.activeExecs.delete(activeExec);
     }
   }
 
@@ -791,7 +776,7 @@ export class SessionProtocolHandler {
       }
     | undefined
   > {
-    if (state.live.activeSubmit || state.session.isTurnRunning || state.live.activeBash) {
+    if (state.live.activeSubmit || state.session.isTurnRunning) {
       this.sendSubmitBusy(state, request.id);
       return undefined;
     }
@@ -817,7 +802,7 @@ export class SessionProtocolHandler {
     state: SessionProtocolHandlerSessionState,
     request: Extract<SessionProtocolRequestMessage, { method: "session.retry" }>,
   ) {
-    if (state.live.activeSubmit || state.session.isTurnRunning || state.live.activeBash) {
+    if (state.live.activeSubmit || state.session.isTurnRunning) {
       this.sendSubmitBusy(state, request.id);
       return undefined;
     }
@@ -829,22 +814,6 @@ export class SessionProtocolHandler {
     return {
       activeSubmit,
     };
-  }
-
-  private startExec(
-    state: SessionProtocolHandlerSessionState,
-    request: Extract<SessionProtocolRequestMessage, { method: "session.exec" }>,
-  ) {
-    if (state.live.activeSubmit || state.session.isTurnRunning || state.live.activeBash) {
-      this.sendSubmitBusy(state, request.id);
-      return undefined;
-    }
-
-    const abortController = new AbortController();
-    const promise = this.executeExec(state, request, abortController.signal);
-    const activeBash = { requestId: request.id, abortController, promise };
-    state.live.activeBash = activeBash;
-    return activeBash;
   }
 
   private schedulePendingSubmitDrains(state: SessionProtocolHandlerSessionState): void {
@@ -1083,13 +1052,14 @@ export class SessionProtocolHandler {
       });
       this.sendMessage(createSessionProtocolSuccessResponse(request.id, "session.exec", result));
     } catch (error) {
+      const cancelled = signal.aborted || isAbortError(error);
       this.sendMessage(
         createSessionProtocolErrorResponse(
           request.id,
-          signal.aborted
-            ? SESSION_PROTOCOL_ERROR_CODES.invalidRequest
+          cancelled
+            ? SESSION_PROTOCOL_ERROR_CODES.cancelled
             : SESSION_PROTOCOL_ERROR_CODES.internalError,
-          signal.aborted ? "execution command was interrupted" : "failed to run execution command",
+          cancelled ? "execution command was cancelled" : "failed to run execution command",
           { cause: error instanceof Error ? error.message : String(error) },
         ),
       );
@@ -1133,19 +1103,18 @@ export class SessionProtocolHandler {
     }
 
     const interruptedTurn = state.session.interruptTurn();
+    const interruptedExecs = state.session.interruptExecs();
     const interruptedMaintenance = state.session.interruptMaintenance();
-    const interruptedBash = Boolean(state.live.activeBash);
-    state.live.activeBash?.abortController.abort();
     const interruptedSamples = state.session.interruptSamples();
     this.rejectPendingSteeringSubmits(state, "session was interrupted");
 
     const result: SessionProtocolResultByMethod["session.interrupt"] = {
       interrupted:
-        interruptedTurn || interruptedMaintenance || interruptedBash || interruptedSamples,
+        interruptedTurn || interruptedExecs || interruptedMaintenance || interruptedSamples,
       isTurnRunning:
         state.session.isTurnRunning ||
+        interruptedExecs ||
         interruptedMaintenance ||
-        interruptedBash ||
         interruptedSamples,
     };
 
@@ -1293,15 +1262,19 @@ export class SessionProtocolHandler {
   private async handleEphemeralCreate(
     request: Extract<SessionProtocolRequestMessage, { method: "session.ephemeral.create" }>,
   ): Promise<void> {
-    await this.withSessionMutation(request, "ephemeral context created", async (mutationState) => {
-      const result = await mutationState.session.createEphemeralContext({
-        instructions: request.params.instructions,
-        tools: request.params.tools,
-      });
-      this.sendMessage(
-        createSessionProtocolSuccessResponse(request.id, "session.ephemeral.create", result),
-      );
+    const state = await this.getSessionState(request.params.sessionId);
+    if (!state) {
+      this.sendSessionNotFound(request.id, request.params.sessionId);
+      return;
+    }
+
+    const result = await state.session.createEphemeralContext({
+      instructions: request.params.instructions,
+      tools: request.params.tools,
     });
+    this.sendMessage(
+      createSessionProtocolSuccessResponse(request.id, "session.ephemeral.create", result),
+    );
   }
 
   private async handleEphemeralSubmit(
@@ -1341,12 +1314,16 @@ export class SessionProtocolHandler {
   private async handleEphemeralClose(
     request: Extract<SessionProtocolRequestMessage, { method: "session.ephemeral.close" }>,
   ): Promise<void> {
-    await this.withSessionMutation(request, "ephemeral context closed", async (mutationState) => {
-      const result = await mutationState.session.closeEphemeralContext(request.params.contextId);
-      this.sendMessage(
-        createSessionProtocolSuccessResponse(request.id, "session.ephemeral.close", result),
-      );
-    });
+    const state = await this.getSessionState(request.params.sessionId);
+    if (!state) {
+      this.sendSessionNotFound(request.id, request.params.sessionId);
+      return;
+    }
+
+    const result = await state.session.closeEphemeralContext(request.params.contextId);
+    this.sendMessage(
+      createSessionProtocolSuccessResponse(request.id, "session.ephemeral.close", result),
+    );
   }
 
   private async withSessionMutation(
@@ -1561,9 +1538,7 @@ export class SessionProtocolHandler {
     const message =
       this.getPendingMutationCount(state) > 0
         ? "a mutating session request is in progress"
-        : state.live.activeBash
-          ? "a bash command is already running"
-          : "a session turn is already running";
+        : "a session turn is already running";
 
     this.sendMessage(
       createSessionProtocolErrorResponse(id, SESSION_PROTOCOL_ERROR_CODES.busy, message),
@@ -1604,27 +1579,19 @@ export class SessionProtocolHandler {
     state: SessionProtocolHandlerSessionState,
   ): Promise<void> {
     const activeSubmit = state.live.activeSubmit;
-    const activeBash = state.live.activeBash;
-    if (!activeSubmit && !state.session.isTurnRunning && !activeBash) {
+    if (!activeSubmit && !state.session.isTurnRunning) {
       return;
     }
 
     state.session.interruptTurn();
-    activeBash?.abortController.abort();
-
-    if (!activeSubmit && !activeBash) {
+    if (!activeSubmit) {
       return;
     }
 
     try {
-      await activeSubmit?.promise;
+      await activeSubmit.promise;
     } catch {
       // ignore submit failure while finishing active mutation
-    }
-    try {
-      await activeBash?.promise;
-    } catch {
-      // ignore bash failure while finishing active mutation
     }
   }
 

--- a/test/in_process_session_transport.test.js
+++ b/test/in_process_session_transport.test.js
@@ -122,6 +122,7 @@ function createHostedSession(sessionId, sessions, options = {}) {
       releaseTurn();
       return true;
     }),
+    interruptExecs: vi.fn(() => false),
     interruptMaintenance: vi.fn(() => false),
     interruptSamples: vi.fn(() => false),
     async waitForActiveWork() {},

--- a/test/in_process_session_transport.test.js
+++ b/test/in_process_session_transport.test.js
@@ -122,9 +122,7 @@ function createHostedSession(sessionId, sessions, options = {}) {
       releaseTurn();
       return true;
     }),
-    interruptExecs: vi.fn(() => false),
-    interruptMaintenance: vi.fn(() => false),
-    interruptSamples: vi.fn(() => false),
+    interruptActiveWork: vi.fn(() => hostedSession.interruptTurn()),
     async waitForActiveWork() {},
     async exec() {
       return createProtocolExecResult({

--- a/test/local_session_host.test.js
+++ b/test/local_session_host.test.js
@@ -5,11 +5,13 @@ import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import { createLocalToolExecutionBackend, ToolCatalog } from "../dist/core/index.js";
 import { resolveModel } from "../dist/core/models/catalog.js";
+import { RpcServer } from "../dist/core/modes/rpc_server.js";
 import { personas } from "../dist/core/personas.js";
 import { prependTauUserMetadata } from "../dist/core/utils/user_metadata.js";
 import { HostedEphemeralAgentSession } from "../dist/host/hosted_ephemeral_agent_session.js";
 import { LocalSessionHost } from "../dist/host/local_session_host.js";
 import { EphemeralThreadBusyError } from "../dist/host/session_host.js";
+import { SESSION_PROTOCOL_VERSION } from "../dist/protocol/session_protocol.js";
 import { MemorySessionStore } from "../dist/store/memory_session_store.js";
 
 const localCreateInput = {
@@ -486,6 +488,229 @@ describe("LocalSessionHost", () => {
         }),
       }),
     );
+  });
+
+  it("completes a model-launched client tool through concurrent exec and ephemeral work", async () => {
+    const store = new MemorySessionStore();
+    const toolBackend = createLocalToolExecutionBackend();
+    vi.spyOn(toolBackend, "runBash").mockResolvedValue({
+      output: "diff output",
+      stdout: "diff output",
+      stderr: "",
+      exitCode: 0,
+      truncated: false,
+    });
+    const executionEnvironment = createTestExecutionEnvironment(
+      { kind: "local", cwd: "/repo", home: "/home/user" },
+      toolBackend,
+    );
+    const host = createHostForEnvironment(store, executionEnvironment);
+    const hostedSession = await host.createSession(localCreateInput);
+    const toolCall = fauxToolCall(
+      "diff_review",
+      { source: "git_diff", diffArgs: ["--", "src/main.ts"] },
+      { id: "diff-review-call" },
+    );
+    const toolMessage = fauxAssistantMessage([toolCall], { stopReason: "toolUse" });
+    const responses = [toolMessage, fauxAssistantMessage("parent resumed")];
+    hostedSession.runtime.session.engine.modelRuntime.streamModel = () => {
+      const response = responses.shift();
+      return {
+        async *[Symbol.asyncIterator]() {
+          if (response === toolMessage) {
+            yield { type: "toolcall_start", contentIndex: 0, partial: response };
+            yield {
+              type: "toolcall_end",
+              contentIndex: 0,
+              toolCall,
+              partial: response,
+            };
+          }
+        },
+        async result() {
+          return response;
+        },
+      };
+    };
+    const submitEphemeralThread = vi
+      .spyOn(HostedEphemeralAgentSession.prototype, "submitThreadMessage")
+      .mockResolvedValue({ threadId: "review-thread", response: "review complete" });
+    const lines = [];
+    let clientFlow;
+    const protocolRequest = (id, method, params) =>
+      JSON.stringify({
+        version: SESSION_PROTOCOL_VERSION,
+        type: "request",
+        id,
+        method,
+        params,
+      });
+    const server = new RpcServer({
+      host,
+      send: (line) => {
+        const message = JSON.parse(line);
+        lines.push(message);
+        if (message.type !== "session.clientTool.call") {
+          return;
+        }
+        clientFlow = (async () => {
+          await server.handleLine(
+            protocolRequest("client-tool-ack", "session.clientTool.ack", {
+              sessionId: hostedSession.sessionId,
+              callId: message.callId,
+            }),
+          );
+          await server.handleLine(
+            protocolRequest("capture", "session.exec", {
+              sessionId: hostedSession.sessionId,
+              command: "git diff -- src/main.ts",
+            }),
+          );
+          await server.handleLine(
+            protocolRequest("ephemeral-create", "session.ephemeral.create", {
+              sessionId: hostedSession.sessionId,
+              instructions: "review the captured diff",
+              tools: ["bash", "view_image"],
+            }),
+          );
+          const contextId = lines.find((item) => item.id === "ephemeral-create").result.contextId;
+          await server.handleLine(
+            protocolRequest("ephemeral-submit", "session.ephemeral.submit", {
+              sessionId: hostedSession.sessionId,
+              contextId,
+              threadId: "review-thread",
+              message: "review the diff",
+            }),
+          );
+          await server.handleLine(
+            protocolRequest("ephemeral-close", "session.ephemeral.close", {
+              sessionId: hostedSession.sessionId,
+              contextId,
+            }),
+          );
+          await server.handleLine(
+            protocolRequest("client-tool-result", "session.clientTool.result", {
+              sessionId: hostedSession.sessionId,
+              callId: message.callId,
+              ok: true,
+              content: "review complete",
+            }),
+          );
+        })();
+      },
+    });
+
+    try {
+      await server.handleLine(
+        protocolRequest("initialize", "initialize", {
+          client: {
+            name: "diff-review-test",
+            version: "1.0.0",
+            tools: [
+              {
+                name: "diff_review",
+                description: "Review a diff in the client.",
+                parameters: { type: "object" },
+              },
+            ],
+          },
+        }),
+      );
+      await server.handleLine(
+        protocolRequest("observe", "session.observe", { sessionId: hostedSession.sessionId }),
+      );
+      await server.handleLine(
+        protocolRequest("submit", "session.submit", {
+          sessionId: hostedSession.sessionId,
+          text: "review this diff",
+        }),
+      );
+      expect(clientFlow).toBeDefined();
+      await clientFlow;
+
+      expect(toolBackend.runBash).toHaveBeenCalledWith(
+        "git diff -- src/main.ts",
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+      expect(submitEphemeralThread).toHaveBeenCalledWith({
+        contextId: expect.stringMatching(/^ephemeral-/),
+        threadId: "review-thread",
+        message: "review the diff",
+      });
+      expect(lines.find((item) => item.id === "ephemeral-close")).toEqual(
+        expect.objectContaining({ ok: true, result: { closed: true } }),
+      );
+      expect(lines.find((item) => item.id === "client-tool-result")).toEqual(
+        expect.objectContaining({ ok: true, result: { accepted: true } }),
+      );
+      expect(lines.find((item) => item.id === "submit")).toEqual(
+        expect.objectContaining({
+          ok: true,
+          result: expect.objectContaining({
+            turn: { status: "completed", stopReason: "stop" },
+          }),
+        }),
+      );
+      await expect(hostedSession.snapshot()).resolves.toEqual(
+        expect.objectContaining({
+          messages: expect.arrayContaining([
+            expect.objectContaining({
+              message: expect.objectContaining({
+                role: "assistant",
+                content: [{ type: "text", text: "parent resumed" }],
+              }),
+            }),
+          ]),
+        }),
+      );
+    } finally {
+      submitEphemeralThread.mockRestore();
+      await server.close();
+    }
+  });
+
+  it.each([
+    ["direct session disposal", ({ hostedSession }) => hostedSession.dispose()],
+    ["host shutdown", ({ host }) => host.shutdown()],
+  ])("aborts and settles active execs before %s", async (_label, dispose) => {
+    const store = new MemorySessionStore();
+    const toolBackend = createLocalToolExecutionBackend();
+    let execSettled = false;
+    let markExecStarted;
+    const execStarted = new Promise((resolve) => {
+      markExecStarted = resolve;
+    });
+    vi.spyOn(toolBackend, "runBash").mockImplementation(
+      async (_command, options) =>
+        await new Promise((_resolve, reject) => {
+          markExecStarted();
+          options.signal.addEventListener(
+            "abort",
+            () => {
+              execSettled = true;
+              reject(options.signal.reason);
+            },
+            { once: true },
+          );
+        }),
+    );
+    const executionEnvironment = createTestExecutionEnvironment(
+      { kind: "local", cwd: "/repo", home: "/home/user" },
+      toolBackend,
+    );
+    executionEnvironment.dispose = vi.fn(async () => {
+      expect(execSettled).toBe(true);
+    });
+    const host = createHostForEnvironment(store, executionEnvironment);
+    const hostedSession = await host.createSession(localCreateInput);
+
+    const exec = hostedSession.exec({ command: "sleep forever" });
+    const execResult = expect(exec).rejects.toMatchObject({ name: "AbortError" });
+    await execStarted;
+
+    await expect(dispose({ host, hostedSession })).resolves.toBeUndefined();
+    await execResult;
+    expect(executionEnvironment.dispose).toHaveBeenCalledTimes(1);
   });
 
   it("samples without changing or persisting session state", async () => {

--- a/test/local_session_host.test.js
+++ b/test/local_session_host.test.js
@@ -713,6 +713,49 @@ describe("LocalSessionHost", () => {
     expect(executionEnvironment.dispose).toHaveBeenCalledTimes(1);
   });
 
+  it("rejects an exec when the backend resolves after interruption", async () => {
+    const store = new MemorySessionStore();
+    const toolBackend = createLocalToolExecutionBackend();
+    let markExecStarted;
+    const execStarted = new Promise((resolve) => {
+      markExecStarted = resolve;
+    });
+    vi.spyOn(toolBackend, "runBash").mockImplementation(
+      (_command, options) =>
+        new Promise((resolve) => {
+          markExecStarted();
+          options.signal.addEventListener(
+            "abort",
+            () =>
+              resolve({
+                output: "(tau) aborted",
+                stdout: "",
+                stderr: "(tau) aborted",
+                exitCode: 1,
+                truncated: false,
+              }),
+            { once: true },
+          );
+        }),
+    );
+    const executionEnvironment = createTestExecutionEnvironment(
+      { kind: "local", cwd: "/repo", home: "/home/user" },
+      toolBackend,
+    );
+    const host = createHostForEnvironment(store, executionEnvironment);
+    const hostedSession = await host.createSession(localCreateInput);
+
+    try {
+      const exec = hostedSession.exec({ command: "sleep forever" });
+      await execStarted;
+
+      expect(hostedSession.interruptExecs()).toBe(true);
+      await expect(exec).rejects.toMatchObject({ name: "AbortError" });
+    } finally {
+      await host.shutdown();
+    }
+  });
+
   it("samples without changing or persisting session state", async () => {
     const store = new MemorySessionStore();
     const originalCommit = store.commitSessionSnapshot.bind(store);

--- a/test/local_session_host.test.js
+++ b/test/local_session_host.test.js
@@ -5,13 +5,11 @@ import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import { createLocalToolExecutionBackend, ToolCatalog } from "../dist/core/index.js";
 import { resolveModel } from "../dist/core/models/catalog.js";
-import { RpcServer } from "../dist/core/modes/rpc_server.js";
 import { personas } from "../dist/core/personas.js";
 import { prependTauUserMetadata } from "../dist/core/utils/user_metadata.js";
 import { HostedEphemeralAgentSession } from "../dist/host/hosted_ephemeral_agent_session.js";
 import { LocalSessionHost } from "../dist/host/local_session_host.js";
 import { EphemeralThreadBusyError } from "../dist/host/session_host.js";
-import { SESSION_PROTOCOL_VERSION } from "../dist/protocol/session_protocol.js";
 import { MemorySessionStore } from "../dist/store/memory_session_store.js";
 
 const localCreateInput = {
@@ -490,229 +488,6 @@ describe("LocalSessionHost", () => {
     );
   });
 
-  it("completes a model-launched client tool through concurrent exec and ephemeral work", async () => {
-    const store = new MemorySessionStore();
-    const toolBackend = createLocalToolExecutionBackend();
-    vi.spyOn(toolBackend, "runBash").mockResolvedValue({
-      output: "diff output",
-      stdout: "diff output",
-      stderr: "",
-      exitCode: 0,
-      truncated: false,
-    });
-    const executionEnvironment = createTestExecutionEnvironment(
-      { kind: "local", cwd: "/repo", home: "/home/user" },
-      toolBackend,
-    );
-    const host = createHostForEnvironment(store, executionEnvironment);
-    const hostedSession = await host.createSession(localCreateInput);
-    const toolCall = fauxToolCall(
-      "diff_review",
-      { source: "git_diff", diffArgs: ["--", "src/main.ts"] },
-      { id: "diff-review-call" },
-    );
-    const toolMessage = fauxAssistantMessage([toolCall], { stopReason: "toolUse" });
-    const responses = [toolMessage, fauxAssistantMessage("parent resumed")];
-    hostedSession.runtime.session.engine.modelRuntime.streamModel = () => {
-      const response = responses.shift();
-      return {
-        async *[Symbol.asyncIterator]() {
-          if (response === toolMessage) {
-            yield { type: "toolcall_start", contentIndex: 0, partial: response };
-            yield {
-              type: "toolcall_end",
-              contentIndex: 0,
-              toolCall,
-              partial: response,
-            };
-          }
-        },
-        async result() {
-          return response;
-        },
-      };
-    };
-    const submitEphemeralThread = vi
-      .spyOn(HostedEphemeralAgentSession.prototype, "submitThreadMessage")
-      .mockResolvedValue({ threadId: "review-thread", response: "review complete" });
-    const lines = [];
-    let clientFlow;
-    const protocolRequest = (id, method, params) =>
-      JSON.stringify({
-        version: SESSION_PROTOCOL_VERSION,
-        type: "request",
-        id,
-        method,
-        params,
-      });
-    const server = new RpcServer({
-      host,
-      send: (line) => {
-        const message = JSON.parse(line);
-        lines.push(message);
-        if (message.type !== "session.clientTool.call") {
-          return;
-        }
-        clientFlow = (async () => {
-          await server.handleLine(
-            protocolRequest("client-tool-ack", "session.clientTool.ack", {
-              sessionId: hostedSession.sessionId,
-              callId: message.callId,
-            }),
-          );
-          await server.handleLine(
-            protocolRequest("capture", "session.exec", {
-              sessionId: hostedSession.sessionId,
-              command: "git diff -- src/main.ts",
-            }),
-          );
-          await server.handleLine(
-            protocolRequest("ephemeral-create", "session.ephemeral.create", {
-              sessionId: hostedSession.sessionId,
-              instructions: "review the captured diff",
-              tools: ["bash", "view_image"],
-            }),
-          );
-          const contextId = lines.find((item) => item.id === "ephemeral-create").result.contextId;
-          await server.handleLine(
-            protocolRequest("ephemeral-submit", "session.ephemeral.submit", {
-              sessionId: hostedSession.sessionId,
-              contextId,
-              threadId: "review-thread",
-              message: "review the diff",
-            }),
-          );
-          await server.handleLine(
-            protocolRequest("ephemeral-close", "session.ephemeral.close", {
-              sessionId: hostedSession.sessionId,
-              contextId,
-            }),
-          );
-          await server.handleLine(
-            protocolRequest("client-tool-result", "session.clientTool.result", {
-              sessionId: hostedSession.sessionId,
-              callId: message.callId,
-              ok: true,
-              content: "review complete",
-            }),
-          );
-        })();
-      },
-    });
-
-    try {
-      await server.handleLine(
-        protocolRequest("initialize", "initialize", {
-          client: {
-            name: "diff-review-test",
-            version: "1.0.0",
-            tools: [
-              {
-                name: "diff_review",
-                description: "Review a diff in the client.",
-                parameters: { type: "object" },
-              },
-            ],
-          },
-        }),
-      );
-      await server.handleLine(
-        protocolRequest("observe", "session.observe", { sessionId: hostedSession.sessionId }),
-      );
-      await server.handleLine(
-        protocolRequest("submit", "session.submit", {
-          sessionId: hostedSession.sessionId,
-          text: "review this diff",
-        }),
-      );
-      expect(clientFlow).toBeDefined();
-      await clientFlow;
-
-      expect(toolBackend.runBash).toHaveBeenCalledWith(
-        "git diff -- src/main.ts",
-        expect.objectContaining({ signal: expect.any(AbortSignal) }),
-      );
-      expect(submitEphemeralThread).toHaveBeenCalledWith({
-        contextId: expect.stringMatching(/^ephemeral-/),
-        threadId: "review-thread",
-        message: "review the diff",
-      });
-      expect(lines.find((item) => item.id === "ephemeral-close")).toEqual(
-        expect.objectContaining({ ok: true, result: { closed: true } }),
-      );
-      expect(lines.find((item) => item.id === "client-tool-result")).toEqual(
-        expect.objectContaining({ ok: true, result: { accepted: true } }),
-      );
-      expect(lines.find((item) => item.id === "submit")).toEqual(
-        expect.objectContaining({
-          ok: true,
-          result: expect.objectContaining({
-            turn: { status: "completed", stopReason: "stop" },
-          }),
-        }),
-      );
-      await expect(hostedSession.snapshot()).resolves.toEqual(
-        expect.objectContaining({
-          messages: expect.arrayContaining([
-            expect.objectContaining({
-              message: expect.objectContaining({
-                role: "assistant",
-                content: [{ type: "text", text: "parent resumed" }],
-              }),
-            }),
-          ]),
-        }),
-      );
-    } finally {
-      submitEphemeralThread.mockRestore();
-      await server.close();
-    }
-  });
-
-  it.each([
-    ["direct session disposal", ({ hostedSession }) => hostedSession.dispose()],
-    ["host shutdown", ({ host }) => host.shutdown()],
-  ])("aborts and settles active execs before %s", async (_label, dispose) => {
-    const store = new MemorySessionStore();
-    const toolBackend = createLocalToolExecutionBackend();
-    let execSettled = false;
-    let markExecStarted;
-    const execStarted = new Promise((resolve) => {
-      markExecStarted = resolve;
-    });
-    vi.spyOn(toolBackend, "runBash").mockImplementation(
-      async (_command, options) =>
-        await new Promise((_resolve, reject) => {
-          markExecStarted();
-          options.signal.addEventListener(
-            "abort",
-            () => {
-              execSettled = true;
-              reject(options.signal.reason);
-            },
-            { once: true },
-          );
-        }),
-    );
-    const executionEnvironment = createTestExecutionEnvironment(
-      { kind: "local", cwd: "/repo", home: "/home/user" },
-      toolBackend,
-    );
-    executionEnvironment.dispose = vi.fn(async () => {
-      expect(execSettled).toBe(true);
-    });
-    const host = createHostForEnvironment(store, executionEnvironment);
-    const hostedSession = await host.createSession(localCreateInput);
-
-    const exec = hostedSession.exec({ command: "sleep forever" });
-    const execResult = expect(exec).rejects.toMatchObject({ name: "AbortError" });
-    await execStarted;
-
-    await expect(dispose({ host, hostedSession })).resolves.toBeUndefined();
-    await execResult;
-    expect(executionEnvironment.dispose).toHaveBeenCalledTimes(1);
-  });
-
   it("rejects an exec when the backend resolves after interruption", async () => {
     const store = new MemorySessionStore();
     const toolBackend = createLocalToolExecutionBackend();
@@ -749,7 +524,7 @@ describe("LocalSessionHost", () => {
       const exec = hostedSession.exec({ command: "sleep forever" });
       await execStarted;
 
-      expect(hostedSession.interruptExecs()).toBe(true);
+      expect(hostedSession.interruptActiveWork()).toBe(true);
       await expect(exec).rejects.toMatchObject({ name: "AbortError" });
     } finally {
       await host.shutdown();

--- a/test/rpc_server.test.js
+++ b/test/rpc_server.test.js
@@ -121,6 +121,9 @@ function createHarness(options = {}) {
     let pendingTurnResult = { status: "completed", stopReason: "stop" };
     let pendingTurn = null;
     let reasoning = bootstrap.persona.settings.reasoning;
+    const ephemeralContexts = new Set();
+    const execAbortControllers = new Set();
+    const execPromises = new Set();
     const sampleAbortControllers = new Set();
     const samplePromises = new Set();
 
@@ -243,12 +246,23 @@ function createHarness(options = {}) {
       requestTurnBoundaryStop: vi.fn(() => running),
       cancelTurnBoundaryStop: vi.fn(() => running),
       async exec(runOptions) {
-        if (options.exec) {
-          return await options.exec(runOptions);
+        const abortController = new AbortController();
+        const signal = runOptions.signal
+          ? AbortSignal.any([runOptions.signal, abortController.signal])
+          : abortController.signal;
+        execAbortControllers.add(abortController);
+        const promise = Promise.resolve().then(() =>
+          options.exec
+            ? options.exec({ ...runOptions, signal })
+            : createProtocolExecResult({ command: runOptions.command }),
+        );
+        execPromises.add(promise);
+        try {
+          return await promise;
+        } finally {
+          execAbortControllers.delete(abortController);
+          execPromises.delete(promise);
         }
-        return createProtocolExecResult({
-          command: runOptions.command,
-        });
       },
       async sample(sampleOptions) {
         const abortController = new AbortController();
@@ -322,6 +336,16 @@ function createHarness(options = {}) {
         releaseTurn();
         return true;
       },
+      interruptExecs: vi.fn(() => {
+        let interrupted = false;
+        for (const abortController of execAbortControllers) {
+          if (!abortController.signal.aborted) {
+            abortController.abort();
+            interrupted = true;
+          }
+        }
+        return interrupted;
+      }),
       interruptMaintenance: vi.fn(() => false),
       interruptSamples: vi.fn(() => {
         let interrupted = false;
@@ -334,15 +358,23 @@ function createHarness(options = {}) {
         return interrupted;
       }),
       waitForActiveWork: vi.fn(async () => {
-        await Promise.allSettled(samplePromises);
+        await Promise.allSettled([...execPromises, ...samplePromises]);
       }),
       terminateSubagent: vi.fn(async () => ({ found: true })),
+      createEphemeralContext: vi.fn(async () => {
+        const contextId = `context-${ephemeralContexts.size + 1}`;
+        ephemeralContexts.add(contextId);
+        return { contextId };
+      }),
       async submitEphemeralThread(submitOptions) {
         if (options.submitEphemeralThread) {
           return await options.submitEphemeralThread(submitOptions);
         }
         return { threadId: submitOptions.threadId, response: "done" };
       },
+      closeEphemeralContext: vi.fn(async (contextId) => ({
+        closed: ephemeralContexts.delete(contextId),
+      })),
       releaseTurn: () => releaseTurn?.(),
       canReleaseTurn: () => Boolean(releaseTurn),
       emitNotice: (text, revision = historyEntries.length + 1) => {
@@ -495,6 +527,56 @@ describe("rpc_server", () => {
         },
       }),
     );
+  });
+
+  it("creates, uses, and closes ephemeral contexts during an active main turn", async () => {
+    const harness = createHarness();
+    const submit = harness.server.handleLine(
+      request("submit", "session.submit", {
+        sessionId: "session-1",
+        text: "keep the main turn active",
+      }),
+    );
+    await waitFor(() => harness.lines.some((line) => deltaHasNotice(line, "streaming")));
+
+    await harness.server.handleLine(
+      request("ephemeral-create", "session.ephemeral.create", {
+        sessionId: "session-1",
+        instructions: "review this",
+        tools: ["bash"],
+      }),
+    );
+    await harness.server.handleLine(
+      request("ephemeral-submit", "session.ephemeral.submit", {
+        sessionId: "session-1",
+        contextId: "context-1",
+        threadId: "thread-1",
+        message: "review",
+      }),
+    );
+    await harness.server.handleLine(
+      request("ephemeral-close", "session.ephemeral.close", {
+        sessionId: "session-1",
+        contextId: "context-1",
+      }),
+    );
+
+    expect(harness.seededSession.isTurnRunning).toBe(true);
+    expect(harness.lines.find((line) => line.id === "ephemeral-create")).toEqual(
+      expect.objectContaining({ ok: true, result: { contextId: "context-1" } }),
+    );
+    expect(harness.lines.find((line) => line.id === "ephemeral-submit")).toEqual(
+      expect.objectContaining({
+        ok: true,
+        result: { threadId: "thread-1", response: "done" },
+      }),
+    );
+    expect(harness.lines.find((line) => line.id === "ephemeral-close")).toEqual(
+      expect.objectContaining({ ok: true, result: { closed: true } }),
+    );
+
+    harness.releaseTurn();
+    await submit;
   });
 
   it("creates additional sessions and routes requests by session id", async () => {
@@ -1437,6 +1519,46 @@ describe("rpc_server", () => {
     expect(secondSubmitEvent).toBeDefined();
   });
 
+  it("cancels active execs through session.interrupt", async () => {
+    let execStarted = false;
+    const harness = createHarness({
+      exec: ({ signal }) =>
+        new Promise((_resolve, reject) => {
+          execStarted = true;
+          signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+        }),
+    });
+
+    const execution = harness.server.handleLine(
+      request("exec", "session.exec", {
+        sessionId: "session-1",
+        command: "sleep forever",
+      }),
+    );
+    await waitFor(() => execStarted);
+
+    await harness.server.handleLine(
+      request("interrupt-exec", "session.interrupt", { sessionId: "session-1" }),
+    );
+    await execution;
+
+    expect(harness.lines.find((line) => line.id === "exec")).toEqual(
+      expect.objectContaining({
+        ok: false,
+        error: expect.objectContaining({
+          code: SESSION_PROTOCOL_ERROR_CODES.cancelled,
+          message: "execution command was cancelled",
+        }),
+      }),
+    );
+    expect(harness.lines.find((line) => line.id === "interrupt-exec")).toEqual(
+      expect.objectContaining({
+        ok: true,
+        result: { interrupted: true, isTurnRunning: true },
+      }),
+    );
+  });
+
   it("cancels active model samples through session.interrupt", async () => {
     let sampleStarted = false;
     const harness = createHarness({
@@ -1726,66 +1848,81 @@ describe("rpc_server", () => {
     );
   });
 
-  it("drains queued user messages after an active execution bash command", async () => {
-    let releaseExecution;
+  it("runs execs alongside main turns and mutations without affecting scheduling", async () => {
+    const releaseExecutions = new Map();
     const harness = createHarness({
-      exec: async (runOptions) =>
-        await new Promise((resolve) => {
-          releaseExecution = () =>
+      exec: ({ command }) =>
+        new Promise((resolve) => {
+          releaseExecutions.set(command, () =>
             resolve(
               createProtocolExecResult({
-                command: runOptions.command,
+                command,
               }),
-            );
+            ),
+          );
         }),
     });
 
-    const execution = harness.server.handleLine(
+    const firstExecution = harness.server.handleLine(
       request("exec-1", "session.exec", {
         sessionId: "session-1",
-        command: "pwd",
+        command: "first",
       }),
     );
-    await waitFor(() => Boolean(releaseExecution));
+    await waitFor(() => releaseExecutions.has("first"));
 
-    await harness.server.handleLine(
-      request("queue-1", "session.queue", {
+    const submit = harness.server.handleLine(
+      request("submit", "session.submit", {
         sessionId: "session-1",
-        text: "after execution",
+        text: "run during exec",
       }),
     );
-
-    expect(harness.lines.some((line) => line.type === "response" && line.id === "queue-1")).toBe(
-      false,
-    );
-
-    releaseExecution();
-    await execution;
-    await waitFor(() =>
-      harness.seededSession.session.historyEntries.some((entry) =>
-        entry.message.content[0].text.includes("after execution"),
-      ),
-    );
-
-    const queuedEntry = harness.seededSession.session.historyEntries.find((entry) =>
-      entry.message.content[0].text.includes("after execution"),
-    );
+    await waitFor(() => harness.lines.some((line) => deltaHasNotice(line, "streaming")));
     harness.releaseTurn();
-    await waitFor(() =>
-      harness.lines.some((line) => line.type === "response" && line.id === "queue-1"),
+    await submit;
+
+    const queue = harness.server.handleLine(
+      request("queue", "session.queue", {
+        sessionId: "session-1",
+        text: "also run during exec",
+      }),
+    );
+    await waitFor(
+      () => harness.lines.filter((line) => deltaHasNotice(line, "streaming")).length === 2,
     );
 
-    const queueResponse = harness.lines.find(
-      (line) => line.type === "response" && line.id === "queue-1",
-    );
-    expect(queueResponse).toEqual(
-      expect.objectContaining({
-        ok: true,
-        result: {
-          userHistoryEntryId: queuedEntry.id,
-          turn: { status: "completed", stopReason: "stop" },
-        },
+    const secondExecution = harness.server.handleLine(
+      request("exec-2", "session.exec", {
+        sessionId: "session-1",
+        command: "second",
       }),
+    );
+    await waitFor(() => releaseExecutions.has("second"));
+    await harness.server.handleLine(
+      request("reasoning", "session.setReasoning", {
+        sessionId: "session-1",
+        reasoning: "high",
+      }),
+    );
+
+    expect(harness.seededSession.isTurnRunning).toBe(true);
+    expect(harness.lines.find((line) => line.id === "reasoning")).toEqual(
+      expect.objectContaining({ ok: true }),
+    );
+    expect(harness.lines.some((line) => line.id === "exec-1")).toBe(false);
+    expect(harness.lines.some((line) => line.id === "exec-2")).toBe(false);
+
+    harness.releaseTurn();
+    await queue;
+    releaseExecutions.get("first")();
+    releaseExecutions.get("second")();
+    await Promise.all([firstExecution, secondExecution]);
+
+    expect(harness.lines.find((line) => line.id === "exec-1")).toEqual(
+      expect.objectContaining({ ok: true }),
+    );
+    expect(harness.lines.find((line) => line.id === "exec-2")).toEqual(
+      expect.objectContaining({ ok: true }),
     );
   });
 

--- a/test/rpc_server.test.js
+++ b/test/rpc_server.test.js
@@ -122,10 +122,24 @@ function createHarness(options = {}) {
     let pendingTurn = null;
     let reasoning = bootstrap.persona.settings.reasoning;
     const ephemeralContexts = new Set();
-    const execAbortControllers = new Set();
-    const execPromises = new Set();
-    const sampleAbortControllers = new Set();
-    const samplePromises = new Set();
+    const activeWorkAbortControllers = new Set();
+    const activeWorkPromises = new Set();
+
+    const runActiveWork = async (operation, externalSignal) => {
+      const abortController = new AbortController();
+      const signal = externalSignal
+        ? AbortSignal.any([externalSignal, abortController.signal])
+        : abortController.signal;
+      activeWorkAbortControllers.add(abortController);
+      const promise = operation(signal);
+      activeWorkPromises.add(promise);
+      try {
+        return await promise;
+      } finally {
+        activeWorkAbortControllers.delete(abortController);
+        activeWorkPromises.delete(promise);
+      }
+    };
 
     const emitDelta = (delta) => {
       for (const handler of deltaHandlers) {
@@ -246,44 +260,22 @@ function createHarness(options = {}) {
       requestTurnBoundaryStop: vi.fn(() => running),
       cancelTurnBoundaryStop: vi.fn(() => running),
       async exec(runOptions) {
-        const abortController = new AbortController();
-        const signal = runOptions.signal
-          ? AbortSignal.any([runOptions.signal, abortController.signal])
-          : abortController.signal;
-        execAbortControllers.add(abortController);
-        const promise = Promise.resolve().then(() =>
-          options.exec
-            ? options.exec({ ...runOptions, signal })
-            : createProtocolExecResult({ command: runOptions.command }),
-        );
-        execPromises.add(promise);
-        try {
-          const result = await promise;
+        return await runActiveWork(async (signal) => {
+          const result = options.exec
+            ? await options.exec({ ...runOptions, signal })
+            : createProtocolExecResult({ command: runOptions.command });
           signal.throwIfAborted();
           return result;
-        } finally {
-          execAbortControllers.delete(abortController);
-          execPromises.delete(promise);
-        }
+        }, runOptions.signal);
       },
       async sample(sampleOptions) {
-        const abortController = new AbortController();
-        const signal = sampleOptions.signal
-          ? AbortSignal.any([sampleOptions.signal, abortController.signal])
-          : abortController.signal;
-        sampleAbortControllers.add(abortController);
-        const promise = Promise.resolve().then(() =>
-          options.sample
-            ? options.sample({ ...sampleOptions, signal })
-            : { message: fauxAssistantMessage("sampled") },
+        return await runActiveWork(
+          (signal) =>
+            options.sample
+              ? options.sample({ ...sampleOptions, signal })
+              : Promise.resolve({ message: fauxAssistantMessage("sampled") }),
+          sampleOptions.signal,
         );
-        samplePromises.add(promise);
-        try {
-          return await promise;
-        } finally {
-          sampleAbortControllers.delete(abortController);
-          samplePromises.delete(promise);
-        }
       },
       async setReasoning(nextReasoning) {
         reasoning = nextReasoning;
@@ -338,20 +330,9 @@ function createHarness(options = {}) {
         releaseTurn();
         return true;
       },
-      interruptExecs: vi.fn(() => {
-        let interrupted = false;
-        for (const abortController of execAbortControllers) {
-          if (!abortController.signal.aborted) {
-            abortController.abort();
-            interrupted = true;
-          }
-        }
-        return interrupted;
-      }),
-      interruptMaintenance: vi.fn(() => false),
-      interruptSamples: vi.fn(() => {
-        let interrupted = false;
-        for (const abortController of sampleAbortControllers) {
+      interruptActiveWork: vi.fn(() => {
+        let interrupted = hostedSession.interruptTurn();
+        for (const abortController of activeWorkAbortControllers) {
           if (!abortController.signal.aborted) {
             abortController.abort();
             interrupted = true;
@@ -360,7 +341,7 @@ function createHarness(options = {}) {
         return interrupted;
       }),
       waitForActiveWork: vi.fn(async () => {
-        await Promise.allSettled([...execPromises, ...samplePromises]);
+        await Promise.allSettled(activeWorkPromises);
       }),
       terminateSubagent: vi.fn(async () => ({ found: true })),
       createEphemeralContext: vi.fn(async () => {
@@ -1893,56 +1874,28 @@ describe("rpc_server", () => {
     );
   });
 
-  it("runs execs alongside main turns and mutations without affecting scheduling", async () => {
+  it("runs concurrent execs alongside main-session work", async () => {
     const releaseExecutions = new Map();
     const harness = createHarness({
       exec: ({ command }) =>
         new Promise((resolve) => {
-          releaseExecutions.set(command, () =>
-            resolve(
-              createProtocolExecResult({
-                command,
-              }),
-            ),
-          );
+          releaseExecutions.set(command, () => resolve(createProtocolExecResult({ command })));
         }),
     });
-
-    const firstExecution = harness.server.handleLine(
-      request("exec-1", "session.exec", {
-        sessionId: "session-1",
-        command: "first",
-      }),
-    );
-    await waitFor(() => releaseExecutions.has("first"));
-
     const submit = harness.server.handleLine(
       request("submit", "session.submit", {
         sessionId: "session-1",
-        text: "run during exec",
+        text: "keep the turn active",
       }),
     );
     await waitFor(() => harness.lines.some((line) => deltaHasNotice(line, "streaming")));
-    harness.releaseTurn();
-    await submit;
 
-    const queue = harness.server.handleLine(
-      request("queue", "session.queue", {
-        sessionId: "session-1",
-        text: "also run during exec",
-      }),
+    const executions = ["first", "second"].map((command) =>
+      harness.server.handleLine(
+        request(`exec-${command}`, "session.exec", { sessionId: "session-1", command }),
+      ),
     );
-    await waitFor(
-      () => harness.lines.filter((line) => deltaHasNotice(line, "streaming")).length === 2,
-    );
-
-    const secondExecution = harness.server.handleLine(
-      request("exec-2", "session.exec", {
-        sessionId: "session-1",
-        command: "second",
-      }),
-    );
-    await waitFor(() => releaseExecutions.has("second"));
+    await waitFor(() => releaseExecutions.size === 2);
     await harness.server.handleLine(
       request("reasoning", "session.setReasoning", {
         sessionId: "session-1",
@@ -1954,21 +1907,15 @@ describe("rpc_server", () => {
     expect(harness.lines.find((line) => line.id === "reasoning")).toEqual(
       expect.objectContaining({ ok: true }),
     );
-    expect(harness.lines.some((line) => line.id === "exec-1")).toBe(false);
-    expect(harness.lines.some((line) => line.id === "exec-2")).toBe(false);
+    for (const release of releaseExecutions.values()) {
+      release();
+    }
+    await Promise.all(executions);
+    expect(harness.seededSession.isTurnRunning).toBe(true);
+    expect(harness.lines.filter((line) => line.id?.startsWith("exec-") && line.ok)).toHaveLength(2);
 
     harness.releaseTurn();
-    await queue;
-    releaseExecutions.get("first")();
-    releaseExecutions.get("second")();
-    await Promise.all([firstExecution, secondExecution]);
-
-    expect(harness.lines.find((line) => line.id === "exec-1")).toEqual(
-      expect.objectContaining({ ok: true }),
-    );
-    expect(harness.lines.find((line) => line.id === "exec-2")).toEqual(
-      expect.objectContaining({ ok: true }),
-    );
+    await submit;
   });
 
   it("responds when a queued user message cannot be committed after the active turn", async () => {

--- a/test/rpc_server.test.js
+++ b/test/rpc_server.test.js
@@ -258,7 +258,9 @@ function createHarness(options = {}) {
         );
         execPromises.add(promise);
         try {
-          return await promise;
+          const result = await promise;
+          signal.throwIfAborted();
+          return result;
         } finally {
           execAbortControllers.delete(abortController);
           execPromises.delete(promise);
@@ -527,6 +529,47 @@ describe("rpc_server", () => {
         },
       }),
     );
+  });
+
+  it("does not create ephemeral contexts after closing during session recovery", async () => {
+    const harness = createHarness();
+    let markObserveStarted;
+    let releaseObserve;
+    const observeStarted = new Promise((resolve) => {
+      markObserveStarted = resolve;
+    });
+    const observeBlocker = new Promise((resolve) => {
+      releaseObserve = resolve;
+    });
+    const lines = [];
+    const server = new RpcServer({
+      host: {
+        ...harness.host,
+        async observeSession(sessionId) {
+          markObserveStarted();
+          await observeBlocker;
+          return await harness.host.observeSession(sessionId);
+        },
+        shutdown: vi.fn(async () => {}),
+      },
+      send: (line) => lines.push(JSON.parse(line)),
+    });
+
+    const create = server.handleLine(
+      request("ephemeral-create", "session.ephemeral.create", {
+        sessionId: "session-1",
+        instructions: "review this",
+        tools: ["bash"],
+      }),
+    );
+    await observeStarted;
+
+    await server.close();
+    releaseObserve();
+    await create;
+
+    expect(harness.seededSession.createEphemeralContext).not.toHaveBeenCalled();
+    expect(lines.some((line) => line.id === "ephemeral-create")).toBe(false);
   });
 
   it("creates, uses, and closes ephemeral contexts during an active main turn", async () => {
@@ -1522,10 +1565,12 @@ describe("rpc_server", () => {
   it("cancels active execs through session.interrupt", async () => {
     let execStarted = false;
     const harness = createHarness({
-      exec: ({ signal }) =>
-        new Promise((_resolve, reject) => {
+      exec: ({ command, signal }) =>
+        new Promise((resolve) => {
           execStarted = true;
-          signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+          signal.addEventListener("abort", () => resolve(createProtocolExecResult({ command })), {
+            once: true,
+          });
         }),
     });
 

--- a/test/websocket_session_transport.test.js
+++ b/test/websocket_session_transport.test.js
@@ -123,9 +123,7 @@ function createHostedSession(sessionId, sessions, options = {}) {
       releaseTurn();
       return true;
     }),
-    interruptExecs: vi.fn(() => false),
-    interruptMaintenance: vi.fn(() => false),
-    interruptSamples: vi.fn(() => false),
+    interruptActiveWork: vi.fn(() => hostedSession.interruptTurn()),
     async waitForActiveWork() {},
     async exec() {
       return createProtocolExecResult({

--- a/test/websocket_session_transport.test.js
+++ b/test/websocket_session_transport.test.js
@@ -123,6 +123,7 @@ function createHostedSession(sessionId, sessions, options = {}) {
       releaseTurn();
       return true;
     }),
+    interruptExecs: vi.fn(() => false),
     interruptMaintenance: vi.fn(() => false),
     interruptSamples: vi.fn(() => false),
     async waitForActiveWork() {},


### PR DESCRIPTION
## why

Model-launched diff review pauses its parent turn while the TUI captures a snapshot with `session.exec` and drives an ephemeral review context. The protocol treated exec and ephemeral lifecycle requests as main-session work, so exec returned `busy` and ephemeral create/close could interrupt or wait on the parent turn they needed to complete.

## what

Exec is now an execution-environment side channel that can overlap turns, mutations, samples, ephemeral work, and other exec requests without entering main-session scheduling. Hosted sessions use one active-work lifecycle for turns, execs, samples, and maintenance so explicit interrupt, connection closure, session disposal, and host shutdown cancel and settle work consistently.

Ephemeral context create and close now bypass the main-session mutation queue, matching ephemeral submit and keeping their independent, non-persisted lifecycle separate from recoverable session state.

Focused host and protocol regressions cover concurrent exec scheduling, cancellation when a backend resolves after abort, disconnect during delayed session recovery, and ephemeral lifecycle during an active turn. RPC and SDK concurrency documentation reflects the canonical contract.

## details

Workspace races between concurrent execs are intentional and remain the client's responsibility. `session.interrupt` cancels all active work for the hosted session, while closing an ephemeral context continues to own cancellation of that context's live threads.

fixes #327
