### PR TITLE
split deslop into shared and repository patterns

### DIFF
--- a/.tau/skills/deslop-patterns/SKILL.md
+++ b/.tau/skills/deslop-patterns/SKILL.md
@@ -1,19 +1,34 @@
 ---
 name: "deslop-patterns"
-description: "Apply Tau-specific architecture and contract-alignment patterns during deslop cleanup, using AGENTS.md as the source of truth for repository policy and conventions. Use only alongside the deslop skill in the Tau repository. Trigger: explicit."
+description: "Apply Tau-specific canonical-contract, ownership-boundary, protocol-alignment, and regression patterns during deslop cleanup. Use only alongside the deslop skill in the Tau repository. Trigger: explicit."
 ---
 
 # Tau deslop patterns
 
-Use these patterns alongside `deslop`. Treat `AGENTS.md` as the source of truth for Tau's canonical change policy, architecture and execution boundaries, repository conventions, dependency inspection rules, and verification commands.
+Use these patterns alongside `deslop`.
 
-If the user provides a trigger phrase such as "ack when you are done," acknowledge and stop until they follow up.
+## Canonical Tau contracts
 
-## Apply repository policy
+Tau is pre-v1. Treat compatibility scaffolding for unshipped behavior as slop and converge on one explicit contract.
 
-Use the ownership map and canonical change policy in `AGENTS.md` as cleanup criteria, not background context. When the target violates them, update the complete contract and its callers rather than adding another representation, fallback, or local shortcut. When new behavior does not fit an existing boundary, reshape the owning abstraction instead of creating a second path.
+- Make fields, options, attributes, and methods required when callers can provide them. Optionality must represent a real absent state.
+- Update every caller when a contract changes. Remove fallback branches, aliases, legacy shapes, dual readers, and migrations that have no shipped data or external compatibility requirement.
+- Validate and normalize at the owning boundary, then trust the canonical internal representation.
+- Fail fast when a required value cannot be produced instead of silently omitting, defaulting, or coercing it.
+- When release or persisted-state compatibility is genuinely unclear, ask once whether the behavior shipped or data must survive. Without evidence of a compatibility requirement, simplify to the canonical shape.
 
-When release or persisted-state compatibility is genuinely unclear, ask once whether the behavior shipped or data must survive. Without evidence of a compatibility requirement, simplify to the canonical shape.
+## Ownership-boundary slop
+
+Flag code that creates a second owner or bypasses an existing boundary:
+
+- TUI/client or host code inspecting agent-visible files and processes instead of using the execution environment
+- Tau-specific config, prompt, resource, or session semantics placed in generic execution backends
+- local-only behavior that bypasses the session protocol used by SDK, RPC, WebSocket, TUI, Telegram, or diff-review paths
+- session state reconstructed from parallel caches instead of the snapshot and its canonical deltas
+- transport mechanics mixed with session lifecycle, persistence, runtime orchestration, or presentation concerns
+- built-in diff-tool implementation details shared outside the narrow diff-review protocol
+
+Move behavior to its single owning layer. When new behavior does not fit cleanly, reshape that abstraction instead of adding another path.
 
 ## Contract alignment
 
@@ -21,13 +36,13 @@ Hunt Tau-specific drift across:
 
 - protocol DTOs, constructors, strict parsers, transports, host handlers, and SDK facades
 - snapshot state, deltas, persistence, recovery, and client view models
-- core events, tool metadata, tool registries, tool UI models, prompts, and documentation
+- core events, tool metadata, tool registries, tool UI models, and prompts
 - config schema, precedence, virtual defaults, loaders, and execution-environment snapshots
 - model catalog metadata, persona settings, reasoning levels, and provider adapters
 - truncation limits, token budgets, metadata descriptions, and the prompts that tell agents about them
 
-Parser and serializer behavior must be symmetric. Streaming and recovery must preserve one snapshot-owned source of truth. Do not hide protocol drift behind optional fields or permissive parsers.
+Parser and serializer behavior must be symmetric. Streaming and recovery must preserve one snapshot-owned source of truth. Do not hide protocol drift behind optional fields, permissive parsers, duplicate state, or client-specific shortcuts.
 
 ## Tau regression surfaces
 
-Within the testing guidance in `deslop` and `AGENTS.md`, prioritize meaningful coverage for protocol reconstruction, streaming, interruption, persistence, recovery, execution boundaries, hosted/local parity, tool dispatch, sandboxing, and other regression-prone behavior. Simple rendering does not need dedicated tests unless it protects a non-obvious invariant.
+Keep tests when they protect protocol reconstruction, streaming, interruption, persistence, recovery, execution boundaries, hosted/local parity, tool dispatch, sandboxing, or another non-obvious invariant. Delete tests for simple rendering, visible literals, and direct delegation when stronger coverage already protects the behavior.

--- a/.tau/skills/deslop-patterns/SKILL.md
+++ b/.tau/skills/deslop-patterns/SKILL.md
@@ -41,7 +41,9 @@ Hunt Tau-specific drift across:
 - model catalog metadata, persona settings, reasoning levels, and provider adapters
 - truncation limits, token budgets, metadata descriptions, and the prompts that tell agents about them
 
-Parser and serializer behavior must be symmetric. Streaming and recovery must preserve one snapshot-owned source of truth. Do not hide protocol drift behind optional fields, permissive parsers, duplicate state, or client-specific shortcuts.
+Parser and serializer behavior must be symmetric. Collapse independently declared representations when their contracts are identical; keep a boundary-specific type only when it encodes a real semantic difference, with an explicit transformation. Derive values from canonical state instead of plumbing redundant metadata across layers.
+
+Streaming and recovery must preserve one snapshot-owned source of truth. Do not hide protocol drift behind optional fields, permissive parsers, duplicate state, or client-specific shortcuts.
 
 ## Tau regression surfaces
 

--- a/.tau/skills/deslop-patterns/SKILL.md
+++ b/.tau/skills/deslop-patterns/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: "deslop-patterns"
+description: "Apply Tau-specific pre-v1 canonical-change, architecture, protocol, execution-boundary, compatibility, and verification patterns during deslop cleanup. Use only alongside the deslop skill in the Tau repository. Trigger: explicit."
+---
+
+# Tau deslop patterns
+
+Use these patterns alongside `deslop` and `AGENTS.md`.
+
+If the user provides a trigger phrase such as "ack when you are done," acknowledge and stop until they follow up.
+
+## Canonical change policy
+
+Tau is pre-v1 and prioritizes a clean stable v1 design over backward compatibility. Prefer one explicit canonical contract even when the change is breaking.
+
+- Make new fields, options, attributes, and methods required when callers can provide them. Optionality must represent a real absent state with documented behavior.
+- Update every caller when a contract changes. Do not add fallback branches, aliases, legacy shapes, dual readers, or migrations for unshipped state unless explicitly requested.
+- Fail fast at the owning boundary when a required value cannot be produced.
+- When release or persisted-state compatibility is genuinely unclear, ask once whether the behavior shipped or data must survive. Without evidence of a compatibility requirement, simplify to the canonical shape.
+
+## Architecture boundaries
+
+Preserve the detailed ownership map in `AGENTS.md`. The highest-risk boundaries are:
+
+- TUI/client, host, and execution environment are separate logical machines. Agent-visible files and processes must go through the execution environment, even when physically local.
+- `CoreSession` owns session state and core events; `SessionEngine` owns internal streaming and tool dispatch; runtime modules own prompt composition and turn orchestration.
+- `src/protocol/` is the canonical session wire contract shared by transports, hosts, and SDK clients.
+- `src/transport/` owns transport mechanics; `src/host/` owns session lifecycle and protocol handling; `src/store/` owns persisted snapshots.
+- Execution backends expose generic target capabilities only. Tau-specific config, prompt, resource, and session semantics belong above them.
+- SDK, RPC, WebSocket, TUI, Telegram, and diff-review paths must share canonical protocol behavior rather than local shortcuts.
+- The built-in diff tool is an isolated reference implementation. Share narrow protocol types, not app implementation details.
+
+When a feature does not fit these boundaries, reshape the owning abstraction instead of adding a second path.
+
+## Contract alignment
+
+Hunt Tau-specific drift across:
+
+- protocol DTOs, constructors, strict parsers, transports, host handlers, and SDK facades
+- snapshot state, deltas, persistence, recovery, and client view models
+- core events, tool metadata, tool registries, tool UI models, prompts, and documentation
+- config schema, precedence, virtual defaults, loaders, and execution-environment snapshots
+- model catalog metadata, persona settings, reasoning levels, and provider adapters
+- truncation limits, token budgets, metadata descriptions, and the prompts that tell agents about them
+
+Parser and serializer behavior must be symmetric. Streaming and recovery must preserve one snapshot-owned source of truth. Do not hide protocol drift behind optional fields or permissive parsers.
+
+## Repository conventions
+
+Use TypeScript, strict types, Biome formatting, lowercase filenames, semantic UI theme tokens, and established event and error patterns. Prefer required contracts and exhaustive branches. Keep Windows unsupported unless product policy changes.
+
+Do not inspect `node_modules`; use refreshed read-only checkouts under `references/repos/` for dependency internals. Do not run the interactive app.
+
+## Tests and verification
+
+Keep tests for protocol reconstruction, streaming, interruption, persistence, recovery, execution boundaries, hosted/local parity, tool dispatch, sandboxing, and other regression-prone behavior. Avoid low-value tests for visible literals, direct delegation, or simple rendering.
+
+Start with formatting and type checking, then build and test:
+
+```sh
+npm run check
+npm run build
+npm test
+```
+
+Fresh clones may require `npm ci` in `src/diff_tool/app`. Never run `npm start` or `node dist/main.js`.

--- a/.tau/skills/deslop-patterns/SKILL.md
+++ b/.tau/skills/deslop-patterns/SKILL.md
@@ -1,36 +1,19 @@
 ---
 name: "deslop-patterns"
-description: "Apply Tau-specific pre-v1 canonical-change, architecture, protocol, execution-boundary, compatibility, and verification patterns during deslop cleanup. Use only alongside the deslop skill in the Tau repository. Trigger: explicit."
+description: "Apply Tau-specific architecture and contract-alignment patterns during deslop cleanup, using AGENTS.md as the source of truth for repository policy and conventions. Use only alongside the deslop skill in the Tau repository. Trigger: explicit."
 ---
 
 # Tau deslop patterns
 
-Use these patterns alongside `deslop` and `AGENTS.md`.
+Use these patterns alongside `deslop`. Treat `AGENTS.md` as the source of truth for Tau's canonical change policy, architecture and execution boundaries, repository conventions, dependency inspection rules, and verification commands.
 
 If the user provides a trigger phrase such as "ack when you are done," acknowledge and stop until they follow up.
 
-## Canonical change policy
+## Apply repository policy
 
-Tau is pre-v1 and prioritizes a clean stable v1 design over backward compatibility. Prefer one explicit canonical contract even when the change is breaking.
+Use the ownership map and canonical change policy in `AGENTS.md` as cleanup criteria, not background context. When the target violates them, update the complete contract and its callers rather than adding another representation, fallback, or local shortcut. When new behavior does not fit an existing boundary, reshape the owning abstraction instead of creating a second path.
 
-- Make new fields, options, attributes, and methods required when callers can provide them. Optionality must represent a real absent state with documented behavior.
-- Update every caller when a contract changes. Do not add fallback branches, aliases, legacy shapes, dual readers, or migrations for unshipped state unless explicitly requested.
-- Fail fast at the owning boundary when a required value cannot be produced.
-- When release or persisted-state compatibility is genuinely unclear, ask once whether the behavior shipped or data must survive. Without evidence of a compatibility requirement, simplify to the canonical shape.
-
-## Architecture boundaries
-
-Preserve the detailed ownership map in `AGENTS.md`. The highest-risk boundaries are:
-
-- TUI/client, host, and execution environment are separate logical machines. Agent-visible files and processes must go through the execution environment, even when physically local.
-- `CoreSession` owns session state and core events; `SessionEngine` owns internal streaming and tool dispatch; runtime modules own prompt composition and turn orchestration.
-- `src/protocol/` is the canonical session wire contract shared by transports, hosts, and SDK clients.
-- `src/transport/` owns transport mechanics; `src/host/` owns session lifecycle and protocol handling; `src/store/` owns persisted snapshots.
-- Execution backends expose generic target capabilities only. Tau-specific config, prompt, resource, and session semantics belong above them.
-- SDK, RPC, WebSocket, TUI, Telegram, and diff-review paths must share canonical protocol behavior rather than local shortcuts.
-- The built-in diff tool is an isolated reference implementation. Share narrow protocol types, not app implementation details.
-
-When a feature does not fit these boundaries, reshape the owning abstraction instead of adding a second path.
+When release or persisted-state compatibility is genuinely unclear, ask once whether the behavior shipped or data must survive. Without evidence of a compatibility requirement, simplify to the canonical shape.
 
 ## Contract alignment
 
@@ -45,22 +28,6 @@ Hunt Tau-specific drift across:
 
 Parser and serializer behavior must be symmetric. Streaming and recovery must preserve one snapshot-owned source of truth. Do not hide protocol drift behind optional fields or permissive parsers.
 
-## Repository conventions
+## Tau regression surfaces
 
-Use TypeScript, strict types, Biome formatting, lowercase filenames, semantic UI theme tokens, and established event and error patterns. Prefer required contracts and exhaustive branches. Keep Windows unsupported unless product policy changes.
-
-Do not inspect `node_modules`; use refreshed read-only checkouts under `references/repos/` for dependency internals. Do not run the interactive app.
-
-## Tests and verification
-
-Keep tests for protocol reconstruction, streaming, interruption, persistence, recovery, execution boundaries, hosted/local parity, tool dispatch, sandboxing, and other regression-prone behavior. Avoid low-value tests for visible literals, direct delegation, or simple rendering.
-
-Start with formatting and type checking, then build and test:
-
-```sh
-npm run check
-npm run build
-npm test
-```
-
-Fresh clones may require `npm ci` in `src/diff_tool/app`. Never run `npm start` or `node dist/main.js`.
+Within the testing guidance in `deslop` and `AGENTS.md`, prioritize meaningful coverage for protocol reconstruction, streaming, interruption, persistence, recovery, execution boundaries, hosted/local parity, tool dispatch, sandboxing, and other regression-prone behavior. Simple rendering does not need dedicated tests unless it protects a non-obvious invariant.

--- a/.tau/skills/deslop/SKILL.md
+++ b/.tau/skills/deslop/SKILL.md
@@ -1,31 +1,30 @@
 ---
 name: "deslop"
-description: "Clean up, canonicalize, and tighten a specified Tau target (often a branch of PR work from a junior or AI agent, but also a package, the current changes, or any other bounded slice), refactoring freely within the target when that raises overall quality. Trigger: explicit."
+description: "Clean up, canonicalize, and tighten a specified target (often a branch of PR work from a junior or AI agent, but also a package, the current changes, or any other bounded slice), refactoring freely within the target when that raises overall quality. Trigger: explicit."
 ---
 
 ## Goal
 
-Assume the code in your target was written by an inexperienced junior (human or AI). It compiles. It solves the original problem. But it carries the telltale weight of whoever reached for the first thing that worked: optional fields that are never actually optional, parsers that accept two shapes, defensive wrappers, narrative comments, low-value tests, compat shims for code that never shipped, runtime type guards that paper over weak types.
+Assume the code in your target was written by an inexperienced junior (human or AI). It passes its existing checks. It solves the original problem. But it carries the telltale weight of whoever reached for the first thing that worked: inputs that are optional only for convenience, parsers that accept multiple shapes, defensive wrappers, narrative comments, low-value tests, compatibility shims for behavior that never shipped, and runtime checks that paper over weak contracts.
 
-Your job is to read it critically and tighten it. Leave the codebase strictly better than you found it: tighter types, one canonical way to represent each concept, clear ownership of validation and normalization, no redundant plumbing, tests that genuinely earn their keep.
+Your job is to read it critically and tighten it. Leave the codebase strictly better than you found it: stronger contracts, one canonical representation for each concept, clear ownership of validation and normalization, no redundant plumbing, and tests that genuinely earn their keep.
 
 Sloppy cleanup accumulates more debt than the original slop. Understand first, then cut.
 
 ## Mindset
 
-- **Assume flaws.** Every function, type, test, and comment is on trial. Default to removing before keeping; every optional parameter, fallback, helper, comment, and test needs to justify its existence.
-- **Tau is pre-v1.** Prefer the clean canonical contract over compatibility scaffolding. When a contract changes, update all call sites instead of supporting both old and new shapes. Do not add migration paths for unshipped data unless explicitly asked.
-- **Respect Tau architecture.** Keep `ChatApp`, `ChatController`, `CoreSession`, `SessionEngine`, runtime helpers, events, tools, diff review, SDK, and TUI boundaries clean. If new code twists around an existing boundary, consider whether the boundary should move.
-- **Review at every level of abstraction.** Start wide (architecture, module boundaries, shared abstractions), then narrow (functions, types, expressions). Each level has its own slop, and architectural drift is usually the highest-leverage thing to fix.
+- **Assume flaws.** Every function, type or schema, test, and comment is on trial. Default to removing before keeping; every optional input, fallback, helper, comment, and test needs to justify its existence.
+- **Respect repository maturity.** Prefer the clean canonical contract over compatibility scaffolding for unreleased behavior. Preserve compatibility when existing data, deployments, or external clients require it.
+- **Respect the repository architecture.** Keep established module and ownership boundaries clean. If new code twists around an existing boundary, consider whether the boundary should move.
+- **Review at every level of abstraction.** Start wide (architecture, module boundaries, shared abstractions), then narrow (functions, contracts, expressions). Each level has its own slop, and architectural drift is usually the highest-leverage thing to fix.
 - **Reshape abstractions when new code does not fit.** Sometimes the target adds something that cannot sit cleanly inside existing patterns. Do not contort the new code to fit; evolve the patterns until the new code fits naturally. This takes more thought and more edits than local cleanup, and the end result is dramatically better. It is often the single most valuable thing you can do.
 - **Scope is flexible.** The target is the starting point, not a fence. If a larger refactor inside the touched area makes the overall codebase meaningfully better, do it. If you spot a real bug adjacent to your changes, fix it and call it out.
-- **One way to do a thing.** When two shapes, two parsers, or two code paths exist for the same concept, collapse to one. Pick the cleaner one, delete the other.
-- **Validate at the edge; trust internals.** Normalize and reject at the system boundary (HTTP handler, deserializer, CLI entry). Downstream code takes well-formed values and uses them. Stop re-validating, re-parsing, and re-defaulting at every layer.
-- **Types are your first reviewer.** Prefer required fields, non-nullable types, and exhaustive switches. When you add a new argument, option, field, or method to a shared contract, make it required unless absence is a real domain state. Changing every call site is the point: the compiler tells you exactly what was forgotten. Never choose optional to avoid editing files.
-- **Make contracts explicit.** Optionality is for meaningful absence, not convenience. If callers should always make a choice, require the field. If implementations should all expose a capability, require the method. Use explicit empty values or no-op implementations at the edge instead of pushing `?.`, `??`, and implicit defaults through the codebase.
+- **One way to do a thing.** When two shapes, two parsers, or two code paths exist for the same concept, collapse to one. Pick the cleaner one and delete the other.
+- **Validate at the edge; trust internals.** Normalize and reject at the system boundary. Downstream code takes well-formed values and uses them. Stop re-validating, re-parsing, and re-defaulting at every layer.
+- **Make contracts explicit.** Absence must represent a real domain state, not convenience. If callers should always make a choice, require it. Use the strongest guarantees available in the target language and project.
 - **Simple beats clever.** Dumb, direct, obvious code wins over elegant abstractions. If you can delete an indirection, delete it. Optimize for clarity, never for the amount of code you had to edit.
-- **Defensive code is noise.** Guards against states the types forbid, checks for inputs callers never produce, and catch-alls that swallow real errors clutter code without adding safety. They are harder to read and easier to misinterpret than the straight-line version. Delete them.
-- **Match the codebase.** Read surrounding code. Follow existing naming, structure, and style. "Cleaner" does not mean "my preferred style"; it means closer to the repo's established patterns. For Tau, use TypeScript, 2-space Biome formatting, lower-case file names, semantic UI theme tokens, and existing error/event patterns.
+- **Defensive code is noise.** Guards against impossible states, checks for inputs callers never produce, and catch-alls that swallow real errors clutter code without adding safety. Delete them or strengthen the boundary that should make them unnecessary.
+- **Match the codebase.** Read surrounding code. Follow existing naming, structure, style, tooling, and error patterns. "Cleaner" does not mean "my preferred style"; it means closer to the repository's established conventions.
 
 ## Workflow
 
@@ -33,39 +32,41 @@ Complete each phase before moving on.
 
 ### Phase 1: Understand
 
-1. Know the target. The invoking prompt names it (a branch, a package, a set of changes, a file tree) and tells you how to enumerate it. Resolve the concrete files and interfaces that belong to the target before anything else.
-2. Read `AGENTS.md` files that cover the target. Respect project-specific conventions.
-3. Read the target's files to build up your understanding, not just the pieces you plan to edit. Follow call sites, related types, and tests.
-4. Form a mental model of what the code does end-to-end and what the changes' intent is. Do not start editing until you could describe it without re-reading the source.
+A repository may provide an optional companion skill named `deslop-patterns` with product, maturity, architecture, ownership, compatibility, and verification context.
 
-If the user provides a trigger phrase like "ack when you are done," acknowledge and stop until they follow up.
+1. Know the target. The invoking prompt names it (a branch, a package, a set of changes, a file tree) and tells you how to enumerate it. Resolve the concrete files and interfaces that belong to the target before anything else.
+2. If you can see a `deslop-patterns` skill, activate `@@skill:deslop-patterns` and use it alongside this skill. Continue without it when unavailable.
+3. Read `AGENTS.md` files that cover the target. Respect project-specific conventions.
+4. Load [`references/typescript.md`](references/typescript.md) when the target contains TypeScript or JavaScript. Load [`references/go.md`](references/go.md) when it contains Go. Load both for a mixed target. For other languages, use this skill and the project's established patterns without forcing guidance from an unrelated language.
+5. Read the target's files to build up your understanding, not just the pieces you plan to edit. Follow call sites, related contracts, and tests.
+6. Form a mental model of what the code does end-to-end and what the changes' intent is. Do not start editing until you could describe it without re-reading the source.
 
 ### Phase 2: Hunt slop
 
-Scan at every level of abstraction. Start wide: does the architecture still hold with the new changes, are module and package boundaries sensible, do the existing abstractions still carry the new code cleanly? Then narrow into functions, types, and expressions. The "Slop patterns" catalog below leans line-level, so treat it as a starting point, not a checklist, and bring your own architectural questions.
+Scan at every level of abstraction. Start wide: does the architecture still hold with the new changes, are module and package boundaries sensible, do the existing abstractions still carry the new code cleanly? Then narrow into functions, contracts, and expressions. Treat the catalog below and the language references as starting points, not checklists, and bring your own architectural questions.
 
 For each instance, decide: remove, collapse, refactor, simplify, or leave. Prefer remove and collapse; prefer reshaping an abstraction over working around it.
 
 Additional signals worth noticing, among others:
 
-- **Abstractions that no longer fit.** The new code has to twist around an existing pattern, or duplicates logic that an abstraction was meant to centralize. The pattern is what needs to change, not the new code.
-- **Module or package boundaries in the wrong place.** Two packages owning pieces of one concept, or one package doing two unrelated jobs.
-- **Real bugs** present in or exposed by the target, such as cleanup-on-wrong-path (destroying persisted state after the server already accepted it), swallowed errors, missed `org_id` scoping, off-by-one in ranges, misordered defers.
-- **Redundant plumbing**: the same fact carried across three layers when one would do.
-- **Optional fields that are never actually optional.** Every call site ends up passing a value, or the field should be nullable instead of optional.
+- **Abstractions that no longer fit.** New code twists around an existing pattern or duplicates logic that an abstraction was meant to centralize. The pattern may be what needs to change.
+- **Module or package boundaries in the wrong place.** Two modules own pieces of one concept, or one module owns unrelated responsibilities.
+- **Real bugs** present in or exposed by the target, such as cleanup affecting the wrong resource, swallowed errors, missing authorization or tenant scoping, races, and boundary errors.
+- **Redundant plumbing** carrying the same fact across several layers when one owner would do.
+- **Inputs that are optional only for convenience.** Every caller supplies a value, or absence has no defined meaning.
 - **Dual representations** of the same concept that have drifted apart.
-- **Runtime branching on shape** that the type system should enforce at compile time.
-- **Tau contract drift** across core events, RPC/SDK types, tool metadata, TUI view models, prompts, and docs. Keep these shapes canonical and symmetric.
+- **Runtime branching on shape** that a stronger contract should eliminate.
+- **Contract drift** across domain models, public interfaces, persisted formats, transport shapes, view models, prompts, and documentation.
 - **Hidden budgets, truncation, or parser rules** that can fail at runtime without being represented in prompts, tests, and metadata contracts.
-- **Defensive code for states the types already forbid.**
+- **Defensive code for states the system already forbids.**
 
 ### Phase 3: Execute
 
 Make the changes. Stay incremental: prefer a series of focused edits over one sprawling rewrite. After each meaningful change, re-read the surrounding code to confirm you have not broken a contract.
 
-When cleanup requires changes outside the original target (for example, tightening a shared type forces call-site updates elsewhere), do them. The goal is a consistent codebase, not a minimized edit count.
+When cleanup requires changes outside the original target (for example, tightening a shared contract forces call-site updates elsewhere), do them. The goal is a consistent codebase, not a minimized edit count.
 
-When compatibility versus simplicity is genuinely a judgment call, ask the user once: "Is this feature released? Do we need to preserve existing data or contracts?" Absent a clear yes, prefer wiping and simplifying.
+When compatibility versus simplicity is genuinely a judgment call, inspect `deslop-patterns`, repository guidance, issue and pull request context, release history, and source for evidence that existing data or contracts must be preserved. Ask the user only when the workflow allows interaction and the answer cannot be established from the available context.
 
 ### Phase 4: Verify
 
@@ -73,147 +74,87 @@ Follow the Verification section below. Do not skip checks, and do not rationaliz
 
 ## Slop patterns
 
-Hunt these aggressively. Examples are illustrative; more patterns will show up in real diffs.
+Hunt these aggressively. The language references show concrete forms.
 
 ### Fallback parsing and multi-shape readers
 
-```ts
-// before
-result = readString(o, "result") ?? readString(o, "outputText") ?? "";
-content = readContent(o.content, result) ?? [{ type: "text", text: result }];
-```
+If the canonical shape is known, parse only that shape and reject anything else. Migrate or reset old data instead of accepting obsolete forms forever when compatibility is not required.
 
-If the canonical shape is known, parse only that shape and throw on anything else. Migrate or reset old data instead of accepting it forever.
+### Fake optionality and implicit defaults
 
-### Optional arguments that are always passed
+Require values that every caller supplies. Make meaningful absence explicit. Remove defaults that merely hide forgotten call sites or weak contracts.
 
-```ts
-// before
-interface Input {
-  attachments?: Attachment[];
-  system?: string[];
-}
-// inside: attachments: input.attachments ?? [], system: input.system ?? [],
-```
+### Defensive serialization
 
-Require them in the type. Delete the `??`. Update call sites to pass `[]`, `null`, or an explicit implementation when that is the real contract.
-
-### Defensive spreading to "only include when truthy"
-
-```ts
-// before
-return {
-  ...(width === undefined ? {} : { width }),
-  ...(height === undefined ? {} : { height }),
-};
-```
-
-If the field is required on the wire, parse it as required and construct `{ width, height }` directly.
+Construct the canonical output directly. Do not conditionally omit required values or spread fields only when truthy when the contract already determines their presence.
 
 ### Defensive code for impossible states
 
-```ts
-function send(message: Message) {
-  if (!message) return;
-  if (!message.content) return;
-  if (typeof message.content !== "string") return;
-  channel.write(message.content);
-}
-```
+Delete guards against states that validated inputs, static contracts, or construction rules already prohibit. If the state is possible, fix the contract or validation boundary instead of silently returning.
 
-If `Message` requires `content: string`, none of these guards can fire. Delete them. The type is the guard. Checks for inputs callers never produce, null guards against non-nullable values, and catch-alls that swallow errors the caller should see are visual debt: they obscure the real logic without adding safety, and they routinely mask bugs by turning unexpected states into silent no-ops.
+### Duplicated representations
 
-### Runtime type guards that duplicate the type system
+Collapse duplicate models where ownership allows it. When layers genuinely need different representations, make their transformation explicit and keep serialization and parsing symmetric.
 
-```ts
-function process(input: ProcessInput) {
-  if (!Array.isArray(input.attachments)) return;
-  if (typeof input.system !== "string") {
-    // ...
-  }
-}
-```
+### Thin indirection
 
-If the type says `attachments: Attachment[]`, trust it. Scattered `Array.isArray`, `typeof x === "string"`, or hand-rolled shape guards inside non-boundary code mean one of two things: the type is weak (tighten it), or validation was skipped at the boundary (validate once with a schema parser like Zod, then trust). Runtime branching on shape is a substitute for a type the compiler should enforce.
-
-### Duplicated types across layers
-
-Watch for a domain type duplicated in the API client, the browser, and a DTO, each with slightly different optionality. Collapse to one shape or make the derivation explicit (for example, derive a download URL from an ID client-side instead of sending redundant metadata over the wire).
-
-### Helpers with one caller
-
-Inline them. Named helpers earn their name when there are at least two real callers or when they encapsulate a non-trivial invariant. A named wrapper around one call site usually obscures more than it helps.
+Inline helpers, wrappers, interfaces, and adapters that have one trivial caller and enforce no meaningful invariant. Keep an abstraction when it owns complexity, defines a real boundary, or has multiple genuine implementations.
 
 ### Narrative comments
 
-```ts
-// Try the new attachments field, fall back to metadata for older payloads.
-```
-
-If the code needs a comment to explain this, the code is wrong. Fix the code, delete the comment. Keep comments only for genuine tribal knowledge or non-obvious invariants.
+Delete comments that narrate fallback logic, obvious control flow, or historical implementation steps. Keep comments for non-obvious invariants, external constraints, or context the code cannot express.
 
 ### Silently accepting unexpected input
 
-Multipart parsers that ignore unknown field names. JSON parsers that accept either `metadata.attachments` or top-level `attachments`. HTTP handlers that accept any content type. Reject unknown inputs with a clear error.
+Reject unknown fields, unsupported forms, and invalid combinations at the owning boundary. Do not ignore or coerce input merely to keep execution moving.
 
-### Optional config with the same effective default everywhere
+### Configuration without a real choice
 
-If every caller passes the same value, remove the option. If a "default" is never deliberately overridden, it is not a default, it is noise.
+If every caller supplies the same value, remove the option. If a default is never deliberately overridden, it is not a useful default.
 
-### Compat shims, migration paths, and deployment-skew guards
+### Compatibility scaffolding without compatibility requirements
 
-Migrations that rewrite old payload shapes for a feature that never shipped. Dual-read code paths guarding against nonexistent historical data. Service A defensively coercing responses from Service B in case an old version is still deployed. None of this applies here: services ship together, unreleased features have no historical data, and there are no external clients to support. Drop the data, tighten the schema, move on. Confirm with the user only if genuinely uncertain whether something is released.
+Remove migrations, dual reads, deployment-skew guards, and legacy aliases when no shipped data, external consumer, or independent deployment requires them. Preserve them when project context establishes a real compatibility contract.
 
-### Tests that restate the code
+### Tests that restate implementation
 
-`test("create returns the thing")` where the body calls `create` and asserts the shape the function literally returns. Delete it. A reader can verify that by reading the function.
+Delete tests that only repeat a return literal, validation string, trivial delegation, or behavior already covered at a stronger boundary. Preserve the only test protecting a meaningful regression.
 
-### Over-broad try/catch
+### Over-broad error handling
 
-Wrapping a block in `try/catch` to turn a specific expected failure into a generic "something went wrong" erases useful information. Catch the narrowest case, or let it propagate.
+Do not turn specific failures into generic success, empty values, or vague errors. Handle only failures the current layer owns and preserve useful context for the caller.
 
-### Vestigial fields and parameters
+### Vestigial state
 
-A parameter that is now always `nil`, a struct field that is always the zero value, a response field that is always empty. Remove.
+Remove fields, parameters, variants, branches, and helpers that are always empty, zero-valued, unreachable, or ignored. Delete the entire dead path, including tests.
 
 ## Cleanup principles
 
 ### Evolve abstractions when new code does not fit
 
-The highest-leverage cleanup is usually not a local edit. When the target adds something that duplicates logic an abstraction was meant to centralize, forces awkward branching in a shared helper, or crosses a module boundary drawn in the wrong place, the existing pattern is what needs to change, not the new code.
+The highest-leverage cleanup is usually not a local edit. When the target duplicates logic an abstraction was meant to centralize, forces awkward branching in a shared helper, or crosses a boundary drawn in the wrong place, the existing pattern may need to change.
 
-This takes effort. You have to understand why the pattern was drawn the way it was, what constraint has now shifted, and what shape would carry the whole system cleanly. When you can see the better shape, make the change: split or merge modules, rename concepts, redraw boundaries, replace one abstraction with another. The diff will be larger than a local tidy-up. The result will be dramatically cleaner than any amount of line-level polish.
+Understand why the pattern exists and what constraint has shifted. When a better shape becomes clear, make the change: split or merge modules, rename concepts, redraw boundaries, or replace the abstraction. A larger coherent diff is better than a small workaround that leaves the design worse.
 
 ### Validation ownership
 
-Every piece of data has one boundary where it is validated and normalized (HTTP handler, deserializer, client entry point). Downstream code takes the already-validated value and trusts it. A schema parser like Zod at the edge is often the cleanest form of this.
-
-When you find `?? ""`, `?? []`, `?? 0`, `strings.TrimSpace`, runtime type checks, or repeated length checks deep inside a function, ask: where should this have been enforced? Push the check to the boundary. Delete the duplicates.
+Every external value has one owning boundary where it is validated and normalized. Downstream code trusts the validated representation. Push repeated parsing, defaulting, trimming, type checks, and length checks to that boundary and delete duplicates.
 
 ### Canonical shapes
 
-For each concept in the system (user message, tool result, attachment, and similar), there is one canonical shape. It appears in:
-
-- one domain type
-- one serializer
-- one parser
-- one set of wire DTOs mirroring it
-
-Parser and serializer should be symmetric. If the serializer always writes a field, the parser should require it.
+Each concept has one authoritative representation per necessary boundary. Serializer and parser behavior should be symmetric. If the serializer always writes a field, the matching parser should require it. If multiple layers need different representations, define the transformation explicitly.
 
 ### Derive, don't duplicate
 
-If B can be computed from A, don't plumb B through the system next to A. A file download URL can be computed from a file ID. A content type can often be inferred from a filename extension. Derive at the consumer, not at the producer.
+If one value can be computed reliably from canonical data, do not carry both through every layer. Derive it at the owner or consumer unless performance, consistency, or compatibility requirements justify materializing it.
 
-### Strict types beat runtime defaults
+### Explicit contracts beat runtime defaults
 
-Prefer required fields, non-nullable types, and exhaustive switches over permissive shapes with runtime fallbacks. Let the compiler be the first reviewer.
-
-When you add a new argument, option, or field, add it as required. Changing every call site is the point. The biggest source of drift in a pre-release codebase is "I'll make it optional so I don't have to edit those other files." That is optimizing for work saved instead of for correctness. Do not do it.
+Use the language's type system, schemas, constructors, parsers, and validation tools to make invalid states difficult or impossible to represent. Do not weaken a contract merely to avoid updating callers.
 
 ### Remove entire code paths
 
-When deleting a dual code path, remove the whole thing: types, helpers, branches, tests. Do not leave an unreachable function or a dead enum variant.
+When deleting a dual path, remove its contracts, helpers, branches, and tests. Do not leave unreachable functions, dead variants, or compatibility aliases behind.
 
 ### Inline small refactors as you go
 
@@ -221,52 +162,44 @@ When you touch a function to remove a fallback and notice a redundant variable t
 
 ## Tests
 
-The bar for tests is deliberately high. Often the correct answer is no test at all.
+The bar for tests is deliberately high. Often the correct answer is no new test.
 
-A hacky test is worse than no test. It adds maintenance cost, noise in the test runner, and false confidence without catching anything a careful reader would miss. If writing the test requires heavy mocks, intricate setup, or deep knowledge of internals, that is usually a signal the design is wrong or the test is not earning its place.
+A hacky test is worse than no test. It adds maintenance cost, noise, and false confidence without catching anything a careful reader would miss. If a test requires heavy mocks, intricate setup, or deep knowledge of internals, that often signals a design problem or a test that is not earning its place.
 
-Only write or keep a test when the behavior cannot reasonably be verified by reading the code and reasoning through it. Examples of behavior that can clear that bar, among others:
+Only write or keep a test when the behavior cannot reasonably be verified by reading the code and reasoning through it. Examples that can clear that bar include:
 
-- **Lifecycle**: startup, shutdown, drain, recovery after interruption.
-- **Storage**: migrations, persistence semantics, crash safety.
-- **Cross-service behavior**: how components compose, what gets forwarded, what gets sanitized.
-- **Sandbox or isolation**: security boundaries, what is and is not exposed to untrusted code.
-- **Non-trivial algorithms**: parsing, scheduling, image processing, anything with edge cases a reader cannot run in their head.
-- **Easy-to-regress invariants**: things that would silently break without a test, such as which fields are redacted in a response envelope.
+- **Lifecycle**: startup, shutdown, draining, and recovery after interruption.
+- **Storage**: migrations, persistence semantics, and crash safety.
+- **Cross-component behavior**: composition, forwarding, normalization, and sanitization.
+- **Isolation**: security boundaries and exposure to untrusted code.
+- **Non-trivial algorithms**: parsing, scheduling, media processing, and other edge-case-heavy behavior.
+- **Easy-to-regress invariants**: behavior that could silently break without focused protection.
 
-Delete tests that fall outside this bar. Common categories, not exhaustive:
+Delete tests that restate implementation, assert visible literals, exercise trivial delegation, duplicate stronger coverage, or depend on elaborate mocks that break on every refactor. Before deleting, verify remaining tests still protect the underlying behavior. Never delete the only thing catching a real class of bug.
 
-- Tests that restate what a function literally does.
-- Tests that assert a specific validation string a reader can see inline.
-- Tests for a wrapper that just delegates to another function.
-- Tests duplicating coverage already provided by an end-to-end test.
-- Tests propped up by elaborate mocks that break on every refactor.
-
-When deleting, verify remaining tests still cover the underlying behavior somewhere. Never delete the only thing catching a real class of bug.
-
-Never add a test to raise coverage, demonstrate that code works, or reassure yourself. If you need reassurance, read the code more carefully.
+Never add a test only to raise coverage, demonstrate that obvious code works, or reassure yourself. If you need reassurance, read the code more carefully or test the meaningful boundary.
 
 ## Non-goals
 
-- **Do not restyle unrelated code.** Cleanup licenses structural refactors that serve the target and fixes to adjacent bugs. It does not license reformatting or rewriting files that the target never interacts with.
+- **Do not restyle unrelated code.** Cleanup licenses structural refactors that serve the target and fixes to adjacent bugs. It does not license rewriting files the target never interacts with.
 - **Do not introduce new features.** Cleanup is cleanup.
-- **Do not add tests to raise coverage numbers.** Only add a test when a new invariant genuinely needs protection and it clears the bar above.
-- **Do not add documentation files.** No README updates, no CHANGELOG entries, no markdown narratives of what you did. The diff is the record.
-- **Do not be clever.** Simple, dumb, obvious code beats elegant abstractions.
+- **Do not add tests to raise coverage numbers.** Add a test only when a meaningful invariant genuinely needs protection.
+- **Do not add documentation files.** No README updates, changelog entries, or narratives of the cleanup unless project guidance explicitly requires a contract update.
+- **Do not be clever.** Simple, direct, obvious code beats elegant indirection.
 
 ## Verification
 
-Before reporting done, verify the touched code end-to-end. The relevant `AGENTS.md` files define the commands (build, lint, format, tests) and conventions (line lengths, tooling, style) for each app you touched. Read them and follow them. For Tau, start with `npm run check`, then run the smallest relevant tests; for branch-level cleanup prefer `npm test` when practical. Do not run the interactive app (`npm start`, `node dist/main.js`) and do not inspect `node_modules` unless explicitly asked.
+Before reporting done, verify the touched code end-to-end. Use commands and conventions from `deslop-patterns`, applicable `AGENTS.md` files, and existing project configuration. Run formatting first when required, then the project's checks, build, and relevant tests. Do not run unrelated interactive applications or inspect dependencies unless the target requires it.
 
-Any failure is yours, even if it surfaces in a file you did not touch but your type change broke. Fix it before finishing.
+Any failure is yours, even if it surfaces outside the original target because your contract change broke it. Fix it before finishing.
 
 ## Output
 
 When done, reply with:
 
-1. **What changed**: a short, scannable list grouped by theme (types, boundaries, tests, real bugs). Use `path:line` references where useful.
-2. **Bugs fixed along the way**: any real correctness issues you fixed outside the strict cleanup scope, called out explicitly.
-3. **Tests removed**: brief list, each with one line on why the remaining coverage is sufficient.
-4. **Verified**: the exact commands you ran and their result.
+1. **What changed**: a short, scannable list grouped by theme (contracts, boundaries, tests, real bugs). Use `path:line` references where useful.
+2. **Bugs fixed along the way**: correctness issues fixed outside the strict cleanup scope, called out explicitly.
+3. **Tests removed**: a brief list, each with one line on why remaining coverage is sufficient.
+4. **Verified**: the exact commands run and their result.
 
-Do not narrate the process. Do not apologize. Do not offer to keep going. Do not create markdown summary files. The diff and the summary are the output.
+Do not narrate the process. Do not apologize. Do not offer to keep going. Do not create Markdown summary files. The diff and the summary are the output.

--- a/.tau/skills/deslop/references/go.md
+++ b/.tau/skills/deslop/references/go.md
@@ -1,0 +1,157 @@
+# Go patterns
+
+Load this reference when the deslop target contains Go.
+
+## Make absence meaningful
+
+Use pointers, `nil`, and optional wrapper types only when absence is a real domain state. A pointer used merely to avoid updating constructors or call sites weakens the contract and spreads nil handling through otherwise straightforward code.
+
+When every caller supplies a value, use the value directly. When empty and absent differ, make that distinction explicit and document it at the owning boundary.
+
+```go
+// slop: every caller passes Jobs and nil becomes an empty slice
+type Batch struct {
+	Jobs *[]Job
+}
+
+// tighter: an empty batch is represented by an empty slice
+type Batch struct {
+	Jobs []Job
+}
+```
+
+## Trust constructed internal values
+
+Validate and normalize external input at the handler, decoder, or constructor that owns the boundary. Internal functions should receive values that already satisfy their invariants.
+
+Repeated nil checks, zero-value fallbacks, trimming, length checks, and shape validation deep in a call path usually mean the boundary is weak or ownership is unclear. Move the rule to the boundary and remove downstream duplicates.
+
+```go
+// slop: every layer repeats normalization
+func saveUser(name string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return errors.New("name is required")
+	}
+	return store.Save(name)
+}
+
+// tighter: the boundary produces a valid domain value
+name, err := ParseUserName(request.Name)
+if err != nil {
+	return err
+}
+return saveUser(name)
+```
+
+## Do not hide errors with zero values
+
+Do not swallow an error and continue with `nil`, an empty slice, an empty string, or a zero-valued struct unless that fallback is the documented contract. Return the error with useful context or handle the specific failure at the layer that owns recovery.
+
+Remove logging-and-continuing when the caller needs to know the operation failed. Avoid returning both a misleading usable value and a non-nil error.
+
+```go
+// slop
+func loadConfig(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		log.Printf("could not load config: %v", err)
+		return []byte{}, nil
+	}
+	return data, nil
+}
+
+// tighter
+func loadConfig(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read config: %w", err)
+	}
+	return data, nil
+}
+```
+
+## Keep cleanup ownership obvious
+
+Place `defer` only after successful resource acquisition and in the function that owns the resource lifetime. Check the acquisition error before scheduling cleanup.
+
+```go
+// slop
+file, err := os.Open(path)
+defer file.Close()
+if err != nil {
+	return err
+}
+
+// tighter
+file, err := os.Open(path)
+if err != nil {
+	return err
+}
+defer file.Close()
+```
+
+Watch for cleanup acting on the wrong path, handle, transaction, or temporary resource after state has moved or ownership has transferred. A deferred closure should capture the exact resource it owns, not mutable state that may later point elsewhere.
+
+Do not use `defer` when the surrounding loop or long-lived function would retain resources beyond their intended lifetime. Introduce a smaller owning function when that makes cleanup timing explicit.
+
+## Remove vestigial struct state
+
+Delete struct fields and parameters that are always their zero value, always `nil`, or written but never read. Remove associated constructor arguments, serialization tags, branches, and tests in the same change.
+
+Do not preserve a field merely because the zero value makes it cheap. Dead state still expands the contract and invites future ambiguity.
+
+```go
+// slop: LegacyID is never assigned or read
+type User struct {
+	ID       string
+	LegacyID string
+}
+
+// tighter
+type User struct {
+	ID string
+}
+```
+
+## Keep representations canonical
+
+Watch for parallel structs representing the same concept across domain, storage, transport, and presentation layers. Share one owned type when the contracts are truly identical. When boundaries need different structs, use an explicit conversion function and keep field meaning and optionality aligned.
+
+Do not accept multiple JSON or storage shapes indefinitely without a compatibility requirement. Decode the canonical form, reject unexpected alternatives, and migrate or reset obsolete data when project context permits.
+
+## Keep interfaces earned
+
+An interface should express a real boundary, support multiple meaningful implementations, or isolate a dependency that callers should not own. Remove one-implementation interfaces and pass-through adapters that add no policy or invariant.
+
+Prefer accepting the smallest interface needed at the consumer, but do not create an interface solely to mock a trivial function in a low-value test.
+
+```go
+// slop: one implementation and no boundary policy
+type UserLoader interface {
+	Load(string) (User, error)
+}
+
+type userLoader struct {
+	store *Store
+}
+
+func (l *userLoader) Load(id string) (User, error) {
+	return l.store.LoadUser(id)
+}
+
+// tighter
+user, err := store.LoadUser(id)
+```
+
+## Keep helpers substantial
+
+Inline helpers with one trivial caller when the name and indirection obscure more than the body explains. Keep a helper when it centralizes an invariant, owns resource or error handling, or makes several callers consistent.
+
+Avoid generic utility packages that collect unrelated one-line helpers. Put behavior with the package that owns the concept.
+
+## Test behavior, not syntax
+
+Keep tests for lifecycle, concurrency, persistence, parsing, security boundaries, and error behavior that is easy to regress. Remove tests that only assert a literal return, zero-value initialization, direct field assignment, or a wrapper forwarding its arguments.
+
+Heavy mocking and large fake interfaces often indicate the production boundary is too broad. Tighten the design before adding more test machinery.

--- a/.tau/skills/deslop/references/typescript.md
+++ b/.tau/skills/deslop/references/typescript.md
@@ -1,0 +1,158 @@
+# TypeScript and JavaScript patterns
+
+Load this reference when the deslop target contains TypeScript or JavaScript.
+
+## Prefer required, canonical types
+
+Use required properties, non-nullable values, discriminated unions, and exhaustive switches when they represent the real domain. Making a new field optional merely to avoid changing callers hides incomplete work from the compiler.
+
+```ts
+// slop
+interface Input {
+  attachments?: Attachment[];
+  system?: string[];
+}
+
+function process(input: Input) {
+  const attachments = input.attachments ?? [];
+  const system = input.system ?? [];
+}
+```
+
+If every caller has a meaningful value, require the fields and update every call site. Pass `[]`, `null`, or an explicit no-op implementation only when that value is the canonical contract.
+
+```ts
+// tighter
+interface Input {
+  attachments: Attachment[];
+  system: string[];
+}
+
+function process(input: Input) {
+  use(input.attachments, input.system);
+}
+```
+
+## Validate once at the boundary
+
+Inside trusted code, repeated `Array.isArray`, `typeof`, property-existence checks, and fallback defaults usually indicate a weak type or a missing validation boundary.
+
+```ts
+// slop inside typed internal code
+if (!Array.isArray(input.attachments)) return;
+if (typeof input.system !== "string") return;
+```
+
+Validate external input once with the project's established parser or schema library, produce a strong internal type, and trust that type downstream. Do not scatter hand-written shape guards through business logic.
+
+```ts
+// tighter boundary
+const input = inputSchema.parse(request.body);
+process(input);
+
+function process(input: Input) {
+  use(input.attachments, input.system);
+}
+```
+
+## Parse one shape
+
+Do not keep old and new property names alive without a compatibility requirement.
+
+```ts
+// slop
+const result =
+  readString(value, "result") ?? readString(value, "outputText") ?? "";
+const content = readContent(value.content, result) ?? [
+  { type: "text", text: result },
+];
+```
+
+Choose the canonical serialized shape. Make its parser and serializer symmetric, reject unexpected alternatives, and migrate or reset obsolete data when project context permits.
+
+```ts
+// tighter
+const result = readRequiredString(value, "result");
+const content = readRequiredContent(value, "content");
+```
+
+## Construct canonical objects directly
+
+Avoid defensive spreading that conditionally includes fields the contract requires.
+
+```ts
+// slop
+return {
+  ...(width === undefined ? {} : { width }),
+  ...(height === undefined ? {} : { height }),
+};
+```
+
+Once boundary parsing has established both values, construct the canonical object directly.
+
+```ts
+// tighter
+return { width, height };
+```
+
+## Remove guards for impossible typed states
+
+```ts
+// slop
+function send(message: Message) {
+  if (!message) return;
+  if (!message.content) return;
+  if (typeof message.content !== "string") return;
+  channel.write(message.content);
+}
+```
+
+If `Message` requires `content: string`, delete the guards. If callers can violate that contract, fix the boundary or type instead of silently turning the violation into a no-op.
+
+```ts
+// tighter
+function send(message: Message) {
+  channel.write(message.content);
+}
+```
+
+## Keep representations aligned
+
+Watch for the same concept independently declared in domain code, API clients, wire payloads, persistence models, and UI state with slightly different optionality. Reuse one owned type where appropriate or define explicit transformations between genuinely distinct layers.
+
+Avoid runtime branching that guesses which version of a union or payload arrived. Prefer a canonical discriminant and exhaustive handling.
+
+## Remove thin helpers and abstractions
+
+Inline a helper with one trivial caller unless it owns a non-obvious invariant. Remove wrapper functions that only rename another call, generic utilities used once, interfaces with one implementation and no meaningful boundary, and types that merely alias another type without narrowing or adding semantics.
+
+```ts
+// slop
+const loadUser = (id: string) => userRepository.get(id);
+const user = await loadUser(id);
+
+// tighter
+const user = await userRepository.get(id);
+```
+
+## Preserve useful errors
+
+Avoid broad `try/catch` blocks that convert unrelated failures into a generic message or fallback value. Catch the narrow failure the current layer can handle. Otherwise let the original error propagate with its useful context.
+
+Do not use `catch` to normalize programmer errors or impossible typed states into successful empty results.
+
+```ts
+// slop
+try {
+  return await loadConfig();
+} catch {
+  return {};
+}
+
+// tighter when this layer cannot recover
+return await loadConfig();
+```
+
+## Remove dead contracts completely
+
+When removing an obsolete field, variant, parser branch, or compatibility shape, remove its type members, runtime handling, serializers, callers, and tests together. Search for both property names and string literals so dead wire-format handling does not survive the type cleanup.


### PR DESCRIPTION
## why

Tau's existing deslop skill combines reusable cleanup guidance with detailed pre-v1, protocol, execution-boundary, and verification rules. Splitting those layers allows the shared workflow to evolve while keeping Tau's canonical-change policy explicit.

## what

Replace deslop with the shared language-agnostic workflow and TypeScript and Go references. Add a Tau-specific `deslop-patterns` companion preserving pre-v1 compatibility policy, architecture ownership, protocol and snapshot alignment, execution-environment isolation, repository conventions, focused tests, and canonical verification.
