### PR TITLE
recover Telegram sessions after failed turns

### DIFF
--- a/src/core/telegram/adapter.ts
+++ b/src/core/telegram/adapter.ts
@@ -2609,7 +2609,6 @@ class TelegramAdapterImpl {
         return;
       }
 
-      this.stopTypingIndicators(event.sessionId);
       this.notifySession(
         event.sessionId,
         event.failure.status === "failed"

--- a/src/core/telegram/adapter.ts
+++ b/src/core/telegram/adapter.ts
@@ -2604,6 +2604,21 @@ class TelegramAdapterImpl {
       return;
     }
 
+    if (event.type === "session-turn-failed") {
+      if (!this.chatsBySession.has(event.sessionId)) {
+        return;
+      }
+
+      this.stopTypingIndicators(event.sessionId);
+      this.notifySession(
+        event.sessionId,
+        event.failure.status === "failed"
+          ? `turn failed: ${event.failure.errorMessage ?? "model provider returned an error"}`
+          : `turn blocked: ${event.failure.message}`,
+      );
+      return;
+    }
+
     if (event.type !== "session-state-changed") {
       return;
     }

--- a/src/core/telegram/session_manager.ts
+++ b/src/core/telegram/session_manager.ts
@@ -184,6 +184,13 @@ export type TelegramSessionManagerEvent =
       log: TelegramSessionLogEntry;
     }
   | {
+      type: "session-turn-failed";
+      sessionId: string;
+      projectId: string;
+      timestamp: string;
+      failure: Extract<SessionProtocolSubmitResult["turn"], { status: "failed" | "blocked" }>;
+    }
+  | {
       type: "session-progress";
       sessionId: string;
       projectId: string;
@@ -909,11 +916,13 @@ class TelegramSessionManagerImpl implements TelegramSessionManager {
 
         if (!entry.cancelRequested) {
           if (failure) {
-            entry.record.error =
-              failure.status === "failed"
-                ? (failure.errorMessage ?? "model provider returned an error")
-                : failure.message;
-            this.setState(entry, "failed");
+            this.emit({
+              type: "session-turn-failed",
+              sessionId: entry.record.id,
+              projectId: entry.record.projectId,
+              timestamp: this.now().toISOString(),
+              failure,
+            });
           } else if (!entry.activeSubmit || entry.activeSubmit === submitPromise) {
             this.setState(entry, "waiting-input");
           }

--- a/src/core/telegram/session_manager.ts
+++ b/src/core/telegram/session_manager.ts
@@ -161,6 +161,7 @@ type SessionEntry = {
   workspaceCleanupPromise?: Promise<void>;
   consumedFacetEventCounts: Map<string, number>;
   emittedAssistantMessageIds: Set<string>;
+  emittedTurnFailureIds: Set<string>;
 };
 
 export type TelegramSessionManagerEvent =
@@ -353,6 +354,7 @@ class TelegramSessionManagerImpl implements TelegramSessionManager {
       cancelRequested: false,
       consumedFacetEventCounts: new Map(),
       emittedAssistantMessageIds: new Set(),
+      emittedTurnFailureIds: new Set(),
     };
 
     this.sessions.set(id, entry);
@@ -558,6 +560,7 @@ class TelegramSessionManagerImpl implements TelegramSessionManager {
         cancelRequested: false,
         consumedFacetEventCounts: new Map(),
         emittedAssistantMessageIds: new Set(),
+        emittedTurnFailureIds: new Set(),
       };
       this.sessions.set(record.id, entry);
     }
@@ -915,7 +918,8 @@ class TelegramSessionManagerImpl implements TelegramSessionManager {
         });
 
         if (!entry.cancelRequested) {
-          if (failure) {
+          if (failure && !entry.emittedTurnFailureIds.has(result.userHistoryEntryId)) {
+            entry.emittedTurnFailureIds.add(result.userHistoryEntryId);
             this.emit({
               type: "session-turn-failed",
               sessionId: entry.record.id,
@@ -923,7 +927,7 @@ class TelegramSessionManagerImpl implements TelegramSessionManager {
               timestamp: this.now().toISOString(),
               failure,
             });
-          } else if (!entry.activeSubmit || entry.activeSubmit === submitPromise) {
+          } else if (!failure && (!entry.activeSubmit || entry.activeSubmit === submitPromise)) {
             this.setState(entry, "waiting-input");
           }
         }

--- a/test/telegram_adapter.test.js
+++ b/test/telegram_adapter.test.js
@@ -1388,6 +1388,7 @@ describe("telegram adapter", () => {
     try {
       await waitFor(() => managerHarness.manager.sendMessage.mock.calls.length === 1);
 
+      vi.useFakeTimers();
       managerHarness.sessions.get("s12").state = "running";
       managerHarness.manager.emit({
         type: "session-state-changed",
@@ -1397,6 +1398,7 @@ describe("telegram adapter", () => {
         state: "running",
         updatedAt: "2024-01-01T00:01:00.000Z",
       });
+      const typingCountBeforeFailure = apiHarness.chatActions.length;
       managerHarness.manager.emit({
         type: "session-turn-failed",
         sessionId: "s12",
@@ -1408,6 +1410,9 @@ describe("telegram adapter", () => {
           errorMessage: "OpenAI is unavailable",
         },
       });
+      await vi.advanceTimersByTimeAsync(4_000);
+      expect(apiHarness.chatActions.length).toBeGreaterThan(typingCountBeforeFailure);
+
       managerHarness.sessions.get("s12").state = "waiting-input";
       managerHarness.manager.emit({
         type: "session-state-changed",
@@ -1417,6 +1422,10 @@ describe("telegram adapter", () => {
         state: "waiting-input",
         updatedAt: "2024-01-01T00:02:00.000Z",
       });
+      const typingCountAfterRun = apiHarness.chatActions.length;
+      await vi.advanceTimersByTimeAsync(8_000);
+      expect(apiHarness.chatActions).toHaveLength(typingCountAfterRun);
+      vi.useRealTimers();
 
       await waitFor(() =>
         apiHarness.sendMessages.some(
@@ -1443,6 +1452,7 @@ describe("telegram adapter", () => {
       ]);
       expect(managerHarness.sessions.get("s12").state).toBe("waiting-input");
     } finally {
+      vi.useRealTimers();
       await adapter.close();
     }
   });

--- a/test/telegram_adapter.test.js
+++ b/test/telegram_adapter.test.js
@@ -30,6 +30,14 @@ async function waitFor(predicate, timeoutMs = 2000) {
   }
 }
 
+function deferred() {
+  let resolve;
+  const promise = new Promise((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 function createJsonResponse(payload, status = 200) {
   return new Response(JSON.stringify(payload), {
     status,
@@ -1334,6 +1342,106 @@ describe("telegram adapter", () => {
         "unsupported command. supported commands: /new, /status, /compact, /interrupt, /use_demo",
       );
       expect(managerHarness.manager.closeSession).not.toHaveBeenCalled();
+    } finally {
+      await adapter.close();
+    }
+  });
+
+  it("reports a failed turn and keeps routing messages to the same session", async () => {
+    const nextUpdate = deferred();
+    const apiHarness = createApiHarness([
+      [
+        {
+          update_id: 1,
+          message: {
+            message_id: 700,
+            chat: { id: 470, type: "private" },
+            from: { id: 7 },
+            text: "first",
+          },
+        },
+      ],
+      nextUpdate.promise,
+    ]);
+    const managerHarness = createSessionManagerHarness(
+      [
+        {
+          id: "s12",
+          projectId: "demo",
+          state: "waiting-input",
+          createdAt: "2024-01-01T00:00:00.000Z",
+          updatedAt: "2024-01-01T00:00:00.000Z",
+        },
+      ],
+      { defaultOwnerId: ownerIdForChat(470) },
+    );
+
+    const adapter = await startAdapter({
+      botToken: "token",
+      projects: { demo: { repo: "git@example.com:demo.git" } },
+      sessionManager: managerHarness.manager,
+      api: apiHarness.api,
+      pollIntervalMs: 1,
+      requestTimeoutSeconds: 1,
+    });
+
+    try {
+      await waitFor(() => managerHarness.manager.sendMessage.mock.calls.length === 1);
+
+      managerHarness.sessions.get("s12").state = "running";
+      managerHarness.manager.emit({
+        type: "session-state-changed",
+        sessionId: "s12",
+        projectId: "demo",
+        previousState: "waiting-input",
+        state: "running",
+        updatedAt: "2024-01-01T00:01:00.000Z",
+      });
+      managerHarness.manager.emit({
+        type: "session-turn-failed",
+        sessionId: "s12",
+        projectId: "demo",
+        timestamp: "2024-01-01T00:01:30.000Z",
+        failure: {
+          status: "failed",
+          stopReason: "error",
+          errorMessage: "OpenAI is unavailable",
+        },
+      });
+      managerHarness.sessions.get("s12").state = "waiting-input";
+      managerHarness.manager.emit({
+        type: "session-state-changed",
+        sessionId: "s12",
+        projectId: "demo",
+        previousState: "running",
+        state: "waiting-input",
+        updatedAt: "2024-01-01T00:02:00.000Z",
+      });
+
+      await waitFor(() =>
+        apiHarness.sendMessages.some(
+          (message) => message.text === "turn failed: OpenAI is unavailable",
+        ),
+      );
+
+      nextUpdate.resolve([
+        {
+          update_id: 2,
+          message: {
+            message_id: 701,
+            chat: { id: 470, type: "private" },
+            from: { id: 7 },
+            text: "second",
+          },
+        },
+      ]);
+      await waitFor(() => managerHarness.manager.sendMessage.mock.calls.length === 2);
+
+      expect(managerHarness.manager.sendMessage.mock.calls.map((call) => call[0])).toEqual([
+        "s12",
+        "s12",
+      ]);
+      expect(managerHarness.sessions.get("s12").state).toBe("waiting-input");
     } finally {
       await adapter.close();
     }

--- a/test/telegram_session_manager.test.js
+++ b/test/telegram_session_manager.test.js
@@ -480,6 +480,42 @@ describe("telegram session manager", () => {
     await waitFor(() => manager.getSession(created.id)?.state === "waiting-input");
   });
 
+  it("emits one failure event for a batched steering turn", async () => {
+    const clientHarness = createClientHarness();
+    const steeringTurn = deferred();
+    clientHarness.session.steer = vi.fn(async () => await steeringTurn.promise);
+    const manager = createDemoSessionManager(clientHarness);
+    const events = [];
+    manager.onEvent((event) => events.push(event));
+
+    const created = await manager.createSession({ projectId: "demo" });
+    await waitFor(() => manager.getSession(created.id)?.state === "waiting-input");
+
+    await manager.sendMessage(created.id, "first steering message", { mode: "steer" });
+    await manager.sendMessage(created.id, "second steering message", { mode: "steer" });
+    expect(clientHarness.session.steer).toHaveBeenCalledTimes(2);
+
+    steeringTurn.resolve({
+      userHistoryEntryId: "history-steering-batch",
+      turn: {
+        status: "failed",
+        stopReason: "error",
+        errorMessage: "OpenAI is unavailable",
+      },
+    });
+    await waitFor(() => manager.getSession(created.id)?.state === "waiting-input");
+
+    expect(events.filter((event) => event.type === "session-turn-failed")).toEqual([
+      expect.objectContaining({
+        sessionId: created.id,
+        failure: expect.objectContaining({
+          status: "failed",
+          errorMessage: "OpenAI is unavailable",
+        }),
+      }),
+    ]);
+  });
+
   it("returns from sendMessage immediately and rejects concurrent submits", async () => {
     const clientHarness = createClientHarness();
     const manager = createTelegramSessionManager({

--- a/test/telegram_session_manager.test.js
+++ b/test/telegram_session_manager.test.js
@@ -516,6 +516,132 @@ describe("telegram session manager", () => {
     await waitFor(() => manager.getSession(created.id)?.state === "waiting-input");
   });
 
+  it("keeps a provider-failed turn recoverable and accepts the next message", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "tau-telegram-turn-failure-"));
+    const workspacePath = join(tempRoot, "workspaces", "demo", "session");
+    const persistencePath = join(tempRoot, "sessions.json");
+    await mkdir(workspacePath, { recursive: true });
+
+    const clientHarness = createClientHarness();
+    clientHarness.session.submit = vi
+      .fn()
+      .mockResolvedValueOnce({
+        userHistoryEntryId: "history-failed",
+        turn: {
+          status: "failed",
+          stopReason: "error",
+          errorMessage: "OpenAI is unavailable",
+        },
+      })
+      .mockResolvedValueOnce({
+        userHistoryEntryId: "history-completed",
+        turn: { status: "completed", stopReason: "stop" },
+      });
+
+    const manager = createTelegramSessionManager({
+      projects: { demo: { repo: "git@example.com:demo.git" } },
+      persistencePath,
+      prepareWorkspace: vi.fn(async () => ({ workspacePath, sessionCwd: workspacePath })),
+      createClient: vi.fn(async () => clientHarness.client),
+    });
+    const events = [];
+    manager.onEvent((event) => events.push(event));
+    let recoveredManager;
+
+    try {
+      const created = await manager.createSession({ projectId: "demo" });
+      await waitFor(() => manager.getSession(created.id)?.state === "waiting-input");
+
+      await manager.sendMessage(created.id, "first");
+      await waitFor(() => manager.getSession(created.id)?.state === "waiting-input");
+
+      expect(manager.getSession(created.id)?.error).toBeUndefined();
+      expect(clientHarness.client.close).not.toHaveBeenCalled();
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "session-turn-failed",
+          sessionId: created.id,
+          failure: {
+            status: "failed",
+            stopReason: "error",
+            errorMessage: "OpenAI is unavailable",
+          },
+        }),
+      );
+
+      await manager.sendMessage(created.id, "second");
+      await waitFor(() => clientHarness.session.submit.mock.calls.length === 2);
+      await waitFor(() => manager.getSession(created.id)?.state === "waiting-input");
+      await manager.close();
+
+      const storedState = JSON.parse(await readFile(persistencePath, "utf8"));
+      expect(storedState.sessions).toEqual([
+        expect.objectContaining({ id: created.id, tauSessionId: "rpc-1" }),
+      ]);
+
+      const recoveredClientHarness = createClientHarness();
+      recoveredManager = createTelegramSessionManager({
+        projects: { demo: { repo: "git@example.com:demo.git" } },
+        persistencePath,
+        prepareWorkspace: vi.fn(async () => ({ workspacePath, sessionCwd: workspacePath })),
+        createClient: vi.fn(async () => recoveredClientHarness.client),
+      });
+      await recoveredManager.initialize();
+
+      expect(recoveredManager.getSession(created.id)?.state).toBe("waiting-input");
+      expect(recoveredClientHarness.client.sessions.observe).toHaveBeenCalledWith("rpc-1");
+    } finally {
+      await recoveredManager?.close();
+      await manager.close();
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps a blocked turn active and accepts the next message", async () => {
+    const clientHarness = createClientHarness();
+    clientHarness.session.submit = vi
+      .fn()
+      .mockResolvedValueOnce({
+        userHistoryEntryId: "history-blocked",
+        turn: {
+          status: "blocked",
+          reason: "auto-compaction-failed",
+          message: "automatic compaction failed",
+        },
+      })
+      .mockResolvedValueOnce({
+        userHistoryEntryId: "history-completed",
+        turn: { status: "completed", stopReason: "stop" },
+      });
+    const manager = createDemoSessionManager(clientHarness);
+    const events = [];
+    manager.onEvent((event) => events.push(event));
+
+    const created = await manager.createSession({ projectId: "demo" });
+    await waitFor(() => manager.getSession(created.id)?.state === "waiting-input");
+
+    await manager.sendMessage(created.id, "first");
+    await waitFor(() => manager.getSession(created.id)?.state === "waiting-input");
+
+    expect(manager.getSession(created.id)?.error).toBeUndefined();
+    expect(clientHarness.client.close).not.toHaveBeenCalled();
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "session-turn-failed",
+        sessionId: created.id,
+        failure: {
+          status: "blocked",
+          reason: "auto-compaction-failed",
+          message: "automatic compaction failed",
+        },
+      }),
+    );
+
+    await manager.sendMessage(created.id, "second");
+    await waitFor(() => clientHarness.session.submit.mock.calls.length === 2);
+    await waitFor(() => manager.getSession(created.id)?.state === "waiting-input");
+  });
+
   it("marks the session failed and closes the client when submit rejects", async () => {
     const clientHarness = createClientHarness();
     clientHarness.session.submit = vi.fn(async () => {


### PR DESCRIPTION
## why

A provider-returned failed turn currently moves the Telegram session into its terminal `failed` state, even though the underlying Tau session remains usable. That drops the persisted chat mapping and forces the user to start a new session after a transient provider or compaction failure.

## what

The Telegram session manager now emits a dedicated failed-turn event for resolved `failed` and `blocked` outcomes and lets the tracked submit lifecycle return the session to `waiting-input`. Failed steering batches emit one event per completed turn, keyed by their shared user history entry.

The adapter reports the concrete provider or blocking error, keeps typing active while aggregated steering work remains, and preserves chat routing to the same session for the next message.

Regression coverage verifies failed and blocked outcomes, batched steering deduplication, typing lifecycle, client retention, follow-up submission, persistence and recovery, user notification, and same-session routing.

## details

Rejected `submit()` or `steer()` operations still have terminal semantics and close the SDK client because they represent a session or transport boundary failure. Resolved turn outcomes reuse the canonical session protocol failure shape rather than introducing a duplicate Telegram error contract. No documentation changes are needed, and there are no remaining implementation questions.

fixes #329
