### PR TITLE
increase model subturn limit

### DIFF
--- a/src/core/session/runner.ts
+++ b/src/core/session/runner.ts
@@ -23,6 +23,7 @@ import type { TauStreamOptions } from "../utils/streaming_settings.js";
 import { MessageAccumulator } from "./message_accumulator.js";
 
 const ASSISTANT_PARTIAL_MIN_INTERVAL_MS = 33;
+export const MAX_MODEL_SUBTURNS = 512;
 
 export type ModelRunnerEvent =
   | CoreNoticeEvent

--- a/src/core/session/session_engine.ts
+++ b/src/core/session/session_engine.ts
@@ -77,12 +77,12 @@ import {
   type SessionPruneResult,
 } from "./pruning.js";
 import {
+  MAX_MODEL_SUBTURNS,
   runModelSubturn,
   SequentialToolCallRunner,
   type SequentialToolCallRunnerOptions,
 } from "./runner.js";
 
-const MAX_ASSISTANT_SUBTURNS = 256;
 const MAX_SUBTURN_RETRIES = 1;
 
 export type SessionEngineOptions = {
@@ -783,12 +783,14 @@ export class SessionEngine {
     options?: { shouldStopAtBoundary?: () => boolean },
   ): AsyncGenerator<CoreEvent, ProcessTurnResult, void> {
     let subturns = 0;
+    let needsAnotherSubturn = false;
     let autoCompactionAttempted = false;
     let retryBudget: SubturnRetryBudget = { remaining: MAX_SUBTURN_RETRIES };
     const originHistoryEntryId = this.getCurrentTurnUserHistoryEntryId();
     const turnSettings = this.captureTurnSettings();
 
-    while (subturns < MAX_ASSISTANT_SUBTURNS && !signal.aborted) {
+    while (subturns < MAX_MODEL_SUBTURNS && !signal.aborted) {
+      needsAnotherSubturn = false;
       if (!autoCompactionAttempted && this.shouldRunAutoCompaction()) {
         autoCompactionAttempted = true;
         const compactionResult = yield* this.runAutoCompactionIfNeeded(signal);
@@ -842,6 +844,7 @@ export class SessionEngine {
         if (options?.shouldStopAtBoundary?.()) {
           break;
         }
+        needsAnotherSubturn = true;
         continue;
       }
 
@@ -858,14 +861,15 @@ export class SessionEngine {
         break;
       }
 
+      needsAnotherSubturn = true;
       retryBudget = { remaining: MAX_SUBTURN_RETRIES };
     }
 
-    if (subturns >= MAX_ASSISTANT_SUBTURNS) {
+    if (needsAnotherSubturn && subturns >= MAX_MODEL_SUBTURNS && !signal.aborted) {
       const event: CoreEvent = {
         type: "notice",
         severity: "warn",
-        text: `stopped after ${MAX_ASSISTANT_SUBTURNS} tool subturns to avoid an infinite loop.`,
+        text: `stopped after ${MAX_MODEL_SUBTURNS} model subturns to avoid an infinite loop.`,
       };
       this.emitEvent(event);
       yield event;

--- a/src/core/subagents/subagent_engine.ts
+++ b/src/core/subagents/subagent_engine.ts
@@ -4,7 +4,12 @@ import { getAuthPath } from "../auth/auth_paths.js";
 import { AuthStorage } from "../auth/auth_storage.js";
 import type { Config } from "../config/index.js";
 import type { ModelResolver } from "../models/catalog.js";
-import { type RunnerEvent, runModelSubturn, runToolCalls } from "../session/runner.js";
+import {
+  MAX_MODEL_SUBTURNS,
+  type RunnerEvent,
+  runModelSubturn,
+  runToolCalls,
+} from "../session/runner.js";
 import { ToolCatalog } from "../tools/catalog.js";
 import type { ToolExecutionBackend } from "../tools/execution_backend.js";
 import {
@@ -55,8 +60,6 @@ export type SubagentRunResult = {
   turns: number;
   toolCalls: number;
 };
-
-const MAX_SUBAGENT_SUBTURNS = 256;
 
 function getStreamingSettings(settings: SubagentRuntimeConfig["settings"]): TauStreamOptions {
   const merged = { ...(settings ?? {}) } as Record<string, unknown>;
@@ -137,7 +140,6 @@ export async function runSubagent(options: {
   let cacheRead = 0;
   let cacheWrite = 0;
   let contextWindowUsageTokens = 0;
-  const maxSubturns = MAX_SUBAGENT_SUBTURNS;
 
   const getUsageSnapshot = (): SubagentUsageSnapshot => ({
     input,
@@ -177,7 +179,7 @@ export async function runSubagent(options: {
     } catch {}
   };
 
-  for (let subturn = 1; subturn <= maxSubturns && !signal.aborted; subturn++) {
+  for (let subturn = 1; subturn <= MAX_MODEL_SUBTURNS && !signal.aborted; subturn++) {
     emitProgress("assistant: thinking");
 
     const context: Context = {
@@ -365,7 +367,7 @@ export async function runSubagent(options: {
     throw new Error("sub-agent aborted");
   }
 
-  emitProgress(`done (stopped after ${maxSubturns} subturns)`);
+  emitProgress(`done (stopped after ${MAX_MODEL_SUBTURNS} model subturns)`);
   const lastAssistant = [...messages].reverse().find((m) => m.role === "assistant") as
     | AssistantMessage
     | undefined;
@@ -377,7 +379,7 @@ export async function runSubagent(options: {
   const lastNote = lastAssistantLine ? ` Last output: "${lastAssistantLine}".` : "";
 
   throw new Error(
-    `Sub-agent stopped after ${maxSubturns} subturns without producing a final response.${lastNote}${formatIssueSummary()}`,
+    `Sub-agent stopped after ${MAX_MODEL_SUBTURNS} model subturns without producing a final response.${lastNote}${formatIssueSummary()}`,
   );
 }
 

--- a/test/core_runtime.test.js
+++ b/test/core_runtime.test.js
@@ -389,6 +389,75 @@ describe("core session rewind APIs", () => {
     }
   });
 
+  it("accepts a final response on model subturn 512", async () => {
+    let modelCalls = 0;
+    const toolRegistry = new ToolRegistry([
+      {
+        schema: {
+          name: "fake_tool",
+          description: "test tool",
+          parameters: { type: "object", properties: {}, additionalProperties: false },
+        },
+        getDisplayTarget: (toolCall) => toolCall.name,
+        dispatch: async (toolCall) => ({
+          run: Promise.resolve({
+            toolResult: {
+              role: "toolResult",
+              toolCallId: toolCall.id,
+              toolName: toolCall.name,
+              content: [{ type: "text", text: "done" }],
+              isError: false,
+              timestamp: 2,
+            },
+          }),
+        }),
+      },
+    ]);
+    const session = new CoreSession({
+      persona: { ...personas[0], tools: ["fake_tool"] },
+      systemPrompt: "system",
+      subagentPrompts: {},
+      toolRegistry,
+    });
+    session.engine.modelRuntime.streamModel = () => {
+      modelCalls += 1;
+      const toolCall =
+        modelCalls === 512
+          ? undefined
+          : fauxToolCall("fake_tool", {}, { id: `tool-call-${modelCalls}` });
+      const response = toolCall
+        ? fauxAssistantMessage([toolCall], { stopReason: "toolUse" })
+        : fauxAssistantMessage("done");
+      return {
+        async *[Symbol.asyncIterator]() {
+          if (toolCall) {
+            yield { type: "toolcall_start", contentIndex: 0, partial: response };
+            yield {
+              type: "toolcall_end",
+              contentIndex: 0,
+              toolCall,
+              partial: response,
+            };
+          }
+        },
+        async result() {
+          return response;
+        },
+      };
+    };
+
+    session.addUserText("keep going");
+    const notices = [];
+    for await (const event of session.events(new AbortController().signal)) {
+      if (event.type === "notice") {
+        notices.push(event.text);
+      }
+    }
+
+    expect(modelCalls).toBe(512);
+    expect(notices).not.toContain("stopped after 512 model subturns to avoid an infinite loop.");
+  });
+
   it("preserves the session id when compacting manually", async () => {
     const faux = fauxProvider({
       provider: "faux-manual-compact-session-id",

--- a/test/subagent_engine.test.js
+++ b/test/subagent_engine.test.js
@@ -10,6 +10,7 @@ const { capturedUserMessages, runModelSubturnMock, runToolCallsMock } = vi.hoist
 }));
 
 vi.mock("../dist/core/session/runner.js", () => ({
+  MAX_MODEL_SUBTURNS: 512,
   runModelSubturn: runModelSubturnMock,
   runToolCalls: runToolCallsMock,
 }));


### PR DESCRIPTION
## why

Long autonomous turns can make legitimate forward progress beyond the existing 256 model-subturn guard. Main sessions and background subagents also declared the same policy independently, which allowed the limits and their user-facing descriptions to drift.

## what

The model-subturn limit is now a single shared 512-subturn policy used by both main-session turns and spawned subagents. The count remains based on assistant/model subturns, not individual tool calls, so parallel tool calls still consume one subturn.

The main-session guard now emits its warning only when the 512th response requires another model subturn. A normal final response on subturn 512 completes normally, and guard messages now accurately refer to model subturns.

## details

The limit remains an internal fixed safety guard rather than new configuration. There are no remaining implementation questions.

fixes #337
