### PR TITLE
acknowledge Telegram new commands promptly

### DIFF
--- a/src/core/telegram/adapter.ts
+++ b/src/core/telegram/adapter.ts
@@ -231,8 +231,8 @@ const DEFAULT_TELEGRAM_AUDIO_MIME_TYPE = "audio/mpeg";
 const DEFAULT_TELEGRAM_AUDIO_FILE_NAME = "audio.mp3";
 const DEFAULT_TELEGRAM_PHOTO_MIME_TYPE = "image/jpeg";
 const DEFAULT_TELEGRAM_DOCUMENT_MIME_TYPE = "application/octet-stream";
-const MESSAGE_QUEUED_REACTION_EMOJI = "👀";
-const MESSAGE_QUEUED_REACTION_DELAY_MS = 1000;
+const MESSAGE_ACKNOWLEDGMENT_REACTION_EMOJI = "👀";
+const MESSAGE_ACKNOWLEDGMENT_DELAY_MS = 1000;
 const TELEGRAM_MAX_MESSAGE_BYTES = 4096;
 const TELEGRAM_MAX_RICH_MESSAGE_BYTES = 32 * 1024;
 
@@ -1008,7 +1008,7 @@ function createTelegramApi(botToken: string): TelegramApi {
         {
           chat_id: chatId,
           message_id: messageId,
-          reaction: [{ type: "emoji", emoji: MESSAGE_QUEUED_REACTION_EMOJI }],
+          reaction: [{ type: "emoji", emoji: MESSAGE_ACKNOWLEDGMENT_REACTION_EMOJI }],
         },
         TelegramAckResultSchema,
       );
@@ -2049,6 +2049,8 @@ class TelegramAdapterImpl {
       return;
     }
 
+    void this.acknowledgeMessageAfterDelay(chatId, sourceMessageId);
+
     try {
       const sessionManager = this.getSessionManagerForChat(chatId);
       const previousSession = this.getActiveSession(chatId);
@@ -2062,7 +2064,6 @@ class TelegramAdapterImpl {
       });
 
       this.setActiveSession(chatId, session.id);
-      void this.reactToQueuedMessage(chatId, sourceMessageId);
     } catch (error) {
       await this.reply(chatId, this.formatManagerError(error));
     }
@@ -2468,7 +2469,7 @@ class TelegramAdapterImpl {
       ...(this.systemMessage ? { additionalSystemMessage: this.systemMessage } : {}),
     });
     this.resetPendingAttachmentQueue(sessionId);
-    await this.reactToQueuedMessage(chatId, sourceMessageId);
+    await this.acknowledgeMessageAfterDelay(chatId, sourceMessageId);
     if (this.isVerboseSession(sessionId)) {
       await this.reply(chatId, this.formatMessageQueued(sessionId));
     }
@@ -2826,12 +2827,12 @@ class TelegramAdapterImpl {
     return `${sessionId}:${chatId}`;
   }
 
-  private async reactToQueuedMessage(chatId: number, messageId?: number): Promise<void> {
+  private async acknowledgeMessageAfterDelay(chatId: number, messageId?: number): Promise<void> {
     if (typeof messageId !== "number" || !Number.isInteger(messageId) || messageId <= 0) {
       return;
     }
 
-    await this.wait(MESSAGE_QUEUED_REACTION_DELAY_MS);
+    await this.wait(MESSAGE_ACKNOWLEDGMENT_DELAY_MS);
     if (this.abortController.signal.aborted) {
       return;
     }

--- a/test/telegram_adapter.test.js
+++ b/test/telegram_adapter.test.js
@@ -985,6 +985,71 @@ describe("telegram adapter", () => {
     }
   });
 
+  it("starts the delayed /new acknowledgment before closing the previous session", async () => {
+    const chatId = 199;
+    const apiHarness = createApiHarness([
+      [
+        {
+          update_id: 1,
+          message: {
+            message_id: 500,
+            chat: { id: chatId, type: "private" },
+            from: { id: 7 },
+            text: "/new",
+          },
+        },
+      ],
+    ]);
+    const managerHarness = createSessionManagerHarness(
+      [
+        {
+          id: "old-session",
+          projectId: "demo",
+          state: "waiting-input",
+          createdAt: "2024-01-01T00:00:00.000Z",
+          updatedAt: "2024-01-01T00:00:00.000Z",
+        },
+      ],
+      { defaultOwnerId: ownerIdForChat(chatId) },
+    );
+    const closeSession = deferred();
+    managerHarness.manager.closeSession.mockImplementation(async (sessionId) => {
+      const session = managerHarness.sessions.get(sessionId);
+      if (!session) {
+        throw new Error("missing session");
+      }
+      await closeSession.promise;
+      managerHarness.sessions.delete(sessionId);
+      return { ...session };
+    });
+
+    const adapter = await startAdapter({
+      botToken: "token",
+      projects: { demo: { repo: "git@example.com:demo.git" } },
+      defaultProjectId: "demo",
+      sessionManager: managerHarness.manager,
+      api: apiHarness.api,
+      pollIntervalMs: 1,
+      requestTimeoutSeconds: 1,
+    });
+
+    try {
+      await waitFor(() => managerHarness.manager.closeSession.mock.calls.length === 1);
+      await waitFor(() =>
+        apiHarness.setMessageReactions.some(
+          (entry) => entry.chatId === chatId && entry.messageId === 500,
+        ),
+      );
+      expect(managerHarness.manager.createSession).not.toHaveBeenCalled();
+
+      closeSession.resolve();
+      await waitFor(() => managerHarness.manager.createSession.mock.calls.length === 1);
+    } finally {
+      closeSession.resolve();
+      await adapter.close();
+    }
+  });
+
   it("supports /new and routes plain text to the active session", async () => {
     const apiHarness = createApiHarness([
       [
@@ -1104,6 +1169,7 @@ describe("telegram adapter", () => {
         {
           update_id: 2,
           message: {
+            message_id: 504,
             chat: { id: 205, type: "private" },
             from: { id: 7 },
             caption: "release notes",
@@ -1167,6 +1233,7 @@ describe("telegram adapter", () => {
           (entry) => entry.chatId === 205 && entry.messageId === 503,
         ),
       );
+      expect(apiHarness.setMessageReactions).not.toContainEqual({ chatId: 205, messageId: 504 });
     } finally {
       await adapter.close();
     }


### PR DESCRIPTION
## why

Telegram's eyes reaction is a delayed acknowledgement for work that may take time. `/new` currently starts that delay only after the previous session has closed and the replacement session has been created, so its acknowledgement can arrive much later than turn-triggering messages.

## what

Start `/new`'s existing one-second acknowledgement timer immediately after the command and project are validated, before session teardown begins. Keep the existing scope unchanged: turn-triggering messages continue to receive the reaction after submission, while attachment-only messages and quick commands do not.

Rename the reaction helper and constants around acknowledgement semantics, and cover both the early `/new` timing and the attachment-only exclusion with regression tests.
