### PR TITLE
double agent subturn limit

### DIFF
--- a/src/core/session/runner.ts
+++ b/src/core/session/runner.ts
@@ -23,7 +23,7 @@ import type { TauStreamOptions } from "../utils/streaming_settings.js";
 import { MessageAccumulator } from "./message_accumulator.js";
 
 const ASSISTANT_PARTIAL_MIN_INTERVAL_MS = 33;
-export const MAX_MODEL_SUBTURNS = 512;
+export const MAX_MODEL_SUBTURNS = 1024;
 
 export type ModelRunnerEvent =
   | CoreNoticeEvent

--- a/test/core_runtime.test.js
+++ b/test/core_runtime.test.js
@@ -405,7 +405,7 @@ describe("core session rewind APIs", () => {
     }
   });
 
-  it("accepts a final response on model subturn 512", async () => {
+  it("accepts a final response on model subturn 1024", async () => {
     let modelCalls = 0;
     const toolRegistry = new ToolRegistry([
       {
@@ -438,7 +438,7 @@ describe("core session rewind APIs", () => {
     session.engine.modelRuntime.streamModel = () => {
       modelCalls += 1;
       const toolCall =
-        modelCalls === 512
+        modelCalls === 1024
           ? undefined
           : fauxToolCall("fake_tool", {}, { id: `tool-call-${modelCalls}` });
       const response = toolCall
@@ -470,8 +470,8 @@ describe("core session rewind APIs", () => {
       }
     }
 
-    expect(modelCalls).toBe(512);
-    expect(notices).not.toContain("stopped after 512 model subturns to avoid an infinite loop.");
+    expect(modelCalls).toBe(1024);
+    expect(notices).not.toContain("stopped after 1024 model subturns to avoid an infinite loop.");
   });
 
   it("preserves the session id when compacting manually", async () => {

--- a/test/subagent_engine.test.js
+++ b/test/subagent_engine.test.js
@@ -10,7 +10,7 @@ const { capturedUserMessages, runModelSubturnMock, runToolCallsMock } = vi.hoist
 }));
 
 vi.mock("../dist/core/session/runner.js", () => ({
-  MAX_MODEL_SUBTURNS: 512,
+  MAX_MODEL_SUBTURNS: 1024,
   runModelSubturn: runModelSubturnMock,
   runToolCalls: runToolCallsMock,
 }));


### PR DESCRIPTION
## why

Agent turns can still exhaust the existing 512-model-subturn ceiling before producing a final response.

## what

I doubled the shared model subturn limit from 512 to 1024. The same canonical limit governs main-session and subagent execution, so both paths receive the increase. I also updated the boundary regression to prove a final response is accepted on subturn 1024 and kept the subagent runner mock aligned with the production contract.

## details

I interpreted “increase to 2x” as doubling the current 512 limit to 1024. No configuration or compatibility path was added because the limit remains an internal safety ceiling with one shared owner.

fixes #354
