### PR TITLE
override GPT-5.6 Codex context windows

### DIFF
--- a/src/core/models/catalog.ts
+++ b/src/core/models/catalog.ts
@@ -8,6 +8,7 @@ import {
   type TauProviderApiKeyResolverArgs,
   validateTauProviderExtensionModel,
 } from "./tau_extensions.js";
+import { applyTauModelOverrides } from "./tau_model_overrides.js";
 
 type ApiKeyResolver = (args: TauProviderApiKeyResolverArgs) => string | undefined;
 
@@ -156,7 +157,12 @@ function createCatalogState(): CatalogState {
 
   for (const provider of getBuiltinProviders()) {
     for (const model of getBuiltinModels(provider)) {
-      registerModel({ providers, provider, model, source: "pi-ai" });
+      registerModel({
+        providers,
+        provider,
+        model: applyTauModelOverrides(model),
+        source: "pi-ai",
+      });
     }
   }
 

--- a/src/core/models/tau_model_overrides.ts
+++ b/src/core/models/tau_model_overrides.ts
@@ -1,0 +1,15 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+
+const GPT_5_6_CODEX_MODEL_IDS = new Set(["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]);
+
+export function applyTauModelOverrides(model: Model<Api>): Model<Api> {
+  if (
+    model.provider !== "openai-codex" ||
+    model.contextWindow !== 272_000 ||
+    !GPT_5_6_CODEX_MODEL_IDS.has(model.id)
+  ) {
+    return model;
+  }
+
+  return { ...model, contextWindow: 372_000 };
+}

--- a/test/model_catalog.test.js
+++ b/test/model_catalog.test.js
@@ -19,6 +19,7 @@ import {
   resolveModel,
 } from "../dist/core/models/catalog.js";
 import { mergeTauProviderExtensionModels } from "../dist/core/models/tau_extensions.js";
+import { applyTauModelOverrides } from "../dist/core/models/tau_model_overrides.js";
 
 describe("model catalog", () => {
   it("loads pi-ai providers and models", () => {
@@ -114,7 +115,33 @@ describe("model catalog", () => {
         },
       ],
     });
-    expect(terra.contextWindow).toBe(272000);
+    expect(terra.contextWindow).toBe(372000);
+  });
+
+  it("overrides GPT-5.6 Codex context windows without changing OpenAI models", () => {
+    for (const modelId of ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]) {
+      expect(resolveModel("openai-codex", modelId)?.contextWindow).toBe(372000);
+      expect(resolveModel("openai", modelId)?.contextWindow).toBe(272000);
+    }
+  });
+
+  it("only applies model overrides to the expected pi metadata", () => {
+    const model = {
+      provider: "openai-codex",
+      id: "gpt-5.6-sol",
+      contextWindow: 272000,
+    };
+
+    expect(applyTauModelOverrides(model)).toEqual({ ...model, contextWindow: 372000 });
+
+    for (const unchanged of [
+      { ...model, contextWindow: 372000 },
+      { ...model, contextWindow: 400000 },
+      { ...model, provider: "openai" },
+      { ...model, id: "gpt-5.5" },
+    ]) {
+      expect(applyTauModelOverrides(unchanged)).toBe(unchanged);
+    }
   });
 
   it("returns no models for unknown providers", () => {


### PR DESCRIPTION
## why

Tau currently inherits a 272k context window from pi for the GPT-5.6 Codex models even though the backend accepts a 372k window. That causes automatic compaction and other context-window decisions to happen substantially earlier than necessary.

## what

I added a Tau-owned override at the pi model ingestion boundary for `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` under the exact `openai-codex` provider. The override raises `contextWindow` to 372k only when pi still advertises exactly 272k.

I added coverage showing that all three Codex models resolve to 372k, the corresponding `openai` models remain at pi's value, and nonmatching providers, model ids, and source context windows pass through unchanged.

## details

I treated 372k as a correction for the current pi metadata rather than a permanent override. A future pi value such as 372k or 400k is preserved, and user `models.json` overlays continue to apply after this base catalog correction. There are no remaining implementation questions.

fixes #359
