### PR TITLE
correct GPT-5.6 Terra and Luna pricing

### DIFF
--- a/src/core/models/tau_model_overrides.ts
+++ b/src/core/models/tau_model_overrides.ts
@@ -1,15 +1,110 @@
 import type { Api, Model } from "@earendil-works/pi-ai";
 
 const GPT_5_6_CODEX_MODEL_IDS = new Set(["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]);
+const GPT_5_6_PRICING_PROVIDER_IDS = new Set(["openai", "openai-codex"]);
+const OPENAI_LONG_CONTEXT_INPUT_THRESHOLD = 272_000;
+
+type ModelCost = Model<Api>["cost"];
+
+type PricingOverride = {
+  stale: ModelCost;
+  current: ModelCost;
+};
+
+function roundCost(value: number): number {
+  return Number(value.toFixed(6));
+}
+
+function withLongContextPricing(cost: Omit<ModelCost, "tiers">): ModelCost {
+  return {
+    ...cost,
+    tiers: [
+      {
+        inputTokensAbove: OPENAI_LONG_CONTEXT_INPUT_THRESHOLD,
+        input: roundCost(cost.input * 2),
+        output: roundCost(cost.output * 1.5),
+        cacheRead: roundCost(cost.cacheRead * 2),
+        cacheWrite: roundCost(cost.cacheWrite * 2),
+      },
+    ],
+  };
+}
+
+const GPT_5_6_PRICING_OVERRIDES: Record<string, PricingOverride> = {
+  "gpt-5.6-luna": {
+    stale: withLongContextPricing({
+      input: 1,
+      output: 6,
+      cacheRead: 0.1,
+      cacheWrite: 1.25,
+    }),
+    current: withLongContextPricing({
+      input: 0.2,
+      output: 1.2,
+      cacheRead: 0.02,
+      cacheWrite: 0.25,
+    }),
+  },
+  "gpt-5.6-terra": {
+    stale: withLongContextPricing({
+      input: 2.5,
+      output: 15,
+      cacheRead: 0.25,
+      cacheWrite: 3.125,
+    }),
+    current: withLongContextPricing({
+      input: 2,
+      output: 12,
+      cacheRead: 0.2,
+      cacheWrite: 2.5,
+    }),
+  },
+};
+
+function costsMatch(actual: ModelCost, expected: ModelCost): boolean {
+  return (
+    actual.input === expected.input &&
+    actual.output === expected.output &&
+    actual.cacheRead === expected.cacheRead &&
+    actual.cacheWrite === expected.cacheWrite &&
+    (actual.tiers?.length ?? 0) === (expected.tiers?.length ?? 0) &&
+    (actual.tiers?.every((tier, index) => {
+      const expectedTier = expected.tiers?.[index];
+      return (
+        expectedTier !== undefined &&
+        tier.inputTokensAbove === expectedTier.inputTokensAbove &&
+        tier.input === expectedTier.input &&
+        tier.output === expectedTier.output &&
+        tier.cacheRead === expectedTier.cacheRead &&
+        tier.cacheWrite === expectedTier.cacheWrite
+      );
+    }) ??
+      true)
+  );
+}
 
 export function applyTauModelOverrides(model: Model<Api>): Model<Api> {
+  let result = model;
+
+  const pricingOverride = GPT_5_6_PRICING_OVERRIDES[model.id];
   if (
-    model.provider !== "openai-codex" ||
-    model.contextWindow !== 272_000 ||
-    !GPT_5_6_CODEX_MODEL_IDS.has(model.id)
+    pricingOverride &&
+    GPT_5_6_PRICING_PROVIDER_IDS.has(model.provider) &&
+    costsMatch(model.cost, pricingOverride.stale)
   ) {
-    return model;
+    result = {
+      ...result,
+      cost: pricingOverride.current,
+    };
   }
 
-  return { ...model, contextWindow: 372_000 };
+  if (
+    model.provider === "openai-codex" &&
+    model.contextWindow === OPENAI_LONG_CONTEXT_INPUT_THRESHOLD &&
+    GPT_5_6_CODEX_MODEL_IDS.has(model.id)
+  ) {
+    result = { ...result, contextWindow: 372_000 };
+  }
+
+  return result;
 }

--- a/test/model_catalog.test.js
+++ b/test/model_catalog.test.js
@@ -73,49 +73,52 @@ describe("model catalog", () => {
     expect(merged.find((model) => model.id === "tau-only-model")).toBe(tauModel);
   });
 
-  it("loads GPT-5.6 models from pi-ai", () => {
-    const sol = resolveModel("openai", "gpt-5.6-sol");
-    expect(sol).toBeTruthy();
-    expect(sol.provider).toBe("openai");
-    expect(sol.api).toBe("openai-responses");
-    expect(sol.cost).toEqual({
-      input: 5,
-      output: 30,
-      cacheRead: 0.5,
-      cacheWrite: 6.25,
-      tiers: [
-        {
-          inputTokensAbove: 272000,
-          input: 10,
-          output: 45,
-          cacheRead: 1,
-          cacheWrite: 12.5,
-        },
-      ],
-    });
-    expect(sol.contextWindow).toBe(272000);
-    expect(sol.maxTokens).toBe(128000);
+  it("loads GPT-5.6 models with current first-party pricing", () => {
+    const expectedCosts = {
+      "gpt-5.6-luna": {
+        input: 0.2,
+        output: 1.2,
+        cacheRead: 0.02,
+        cacheWrite: 0.25,
+        tiers: [
+          {
+            inputTokensAbove: 272000,
+            input: 0.4,
+            output: 1.8,
+            cacheRead: 0.04,
+            cacheWrite: 0.5,
+          },
+        ],
+      },
+      "gpt-5.6-terra": {
+        input: 2,
+        output: 12,
+        cacheRead: 0.2,
+        cacheWrite: 2.5,
+        tiers: [
+          {
+            inputTokensAbove: 272000,
+            input: 4,
+            output: 18,
+            cacheRead: 0.4,
+            cacheWrite: 5,
+          },
+        ],
+      },
+    };
 
-    const terra = resolveModel("openai-codex", "gpt-5.6-terra");
-    expect(terra).toBeTruthy();
-    expect(terra.provider).toBe("openai-codex");
-    expect(terra.api).toBe("openai-codex-responses");
-    expect(terra.cost).toEqual({
-      input: 2.5,
-      output: 15,
-      cacheRead: 0.25,
-      cacheWrite: 3.125,
-      tiers: [
-        {
-          inputTokensAbove: 272000,
-          input: 5,
-          output: 22.5,
-          cacheRead: 0.5,
-          cacheWrite: 6.25,
-        },
-      ],
+    for (const provider of ["openai", "openai-codex"]) {
+      for (const [modelId, cost] of Object.entries(expectedCosts)) {
+        expect(resolveModel(provider, modelId)?.cost).toEqual(cost);
+      }
+    }
+
+    expect(resolveModel("cloudflare-ai-gateway", "gpt-5.6-luna")?.cost).toEqual({
+      input: 1,
+      output: 6,
+      cacheRead: 0.1,
+      cacheWrite: 0,
     });
-    expect(terra.contextWindow).toBe(372000);
   });
 
   it("overrides GPT-5.6 Codex context windows without changing OpenAI models", () => {
@@ -126,19 +129,69 @@ describe("model catalog", () => {
   });
 
   it("only applies model overrides to the expected pi metadata", () => {
-    const model = {
+    const codexModel = {
       provider: "openai-codex",
       id: "gpt-5.6-sol",
       contextWindow: 272000,
     };
 
-    expect(applyTauModelOverrides(model)).toEqual({ ...model, contextWindow: 372000 });
+    expect(applyTauModelOverrides(codexModel)).toEqual({
+      ...codexModel,
+      contextWindow: 372000,
+    });
 
     for (const unchanged of [
-      { ...model, contextWindow: 372000 },
-      { ...model, contextWindow: 400000 },
-      { ...model, provider: "openai" },
-      { ...model, id: "gpt-5.5" },
+      { ...codexModel, contextWindow: 372000 },
+      { ...codexModel, contextWindow: 400000 },
+      { ...codexModel, provider: "openai" },
+      { ...codexModel, id: "gpt-5.5" },
+    ]) {
+      expect(applyTauModelOverrides(unchanged)).toBe(unchanged);
+    }
+
+    const staleLuna = {
+      provider: "openai",
+      id: "gpt-5.6-luna",
+      cost: {
+        input: 1,
+        output: 6,
+        cacheRead: 0.1,
+        cacheWrite: 1.25,
+        tiers: [
+          {
+            inputTokensAbove: 272000,
+            input: 2,
+            output: 9,
+            cacheRead: 0.2,
+            cacheWrite: 2.5,
+          },
+        ],
+      },
+    };
+    const currentLunaCost = {
+      input: 0.2,
+      output: 1.2,
+      cacheRead: 0.02,
+      cacheWrite: 0.25,
+      tiers: [
+        {
+          inputTokensAbove: 272000,
+          input: 0.4,
+          output: 1.8,
+          cacheRead: 0.04,
+          cacheWrite: 0.5,
+        },
+      ],
+    };
+
+    for (const provider of ["openai", "openai-codex"]) {
+      expect(applyTauModelOverrides({ ...staleLuna, provider }).cost).toEqual(currentLunaCost);
+    }
+
+    for (const unchanged of [
+      { ...staleLuna, provider: "cloudflare-ai-gateway" },
+      { ...staleLuna, cost: currentLunaCost },
+      { ...staleLuna, cost: { ...staleLuna.cost, input: 0.9 } },
     ]) {
       expect(applyTauModelOverrides(unchanged)).toBe(unchanged);
     }


### PR DESCRIPTION
## why

Tau currently uses `@earendil-works/pi-ai@0.83.0`, whose bundled GPT-5.6 Terra and Luna metadata predates OpenAI's latest price reductions. Until Pi publishes and Tau adopts a release containing the correction, Tau reports stale estimated costs for the first-party OpenAI API and Codex endpoints.

## what

Add guarded Tau-side pricing overrides for GPT-5.6 Terra and Luna on the `openai` and `openai-codex` providers. The override applies only when Pi exposes the exact stale standard and long-context prices, so a future dependency update with corrected or otherwise changed metadata automatically takes precedence.

Keep passthrough catalogs untouched and preserve the existing Codex-only GPT-5.6 context-window override. Catalog coverage verifies both first-party providers, long-context pricing, passthrough exclusion, and the exact-metadata guard.
