### PR TITLE
serialize repeated steering projections

### DIFF
--- a/src/host/local_session_host.ts
+++ b/src/host/local_session_host.ts
@@ -730,14 +730,12 @@ class LocalHostedSessionHandle implements LocalHostedSession {
     const submission = this.runtime.steer(text);
     return {
       id: submission.id,
-      applied: submission.applied.then(async (association) => {
-        await this.commitSnapshot();
-        return { userHistoryEntryId: association.historyEntryId };
-      }),
+      applied: submission.applied.then((association) => ({
+        userHistoryEntryId: association.historyEntryId,
+      })),
       result: submission.result.then(async (association) => {
         const turn = turnOutcomeFromResult(association.result, association.result.finalMessage);
-        this.turnOutcomes.set(association.historyEntryId, turn);
-        await this.emitSnapshotResetIfChanged("assistant-message");
+        await this.commitSteeringTurnOutcome(association.historyEntryId, turn);
         return {
           userHistoryEntryId: association.historyEntryId,
           turn,
@@ -1582,6 +1580,34 @@ class LocalHostedSessionHandle implements LocalHostedSession {
       .then(() => this.recordRuntimeEvent(event));
     this.runtimeEventQueue = write.catch(() => undefined);
     return write;
+  }
+
+  private async commitSteeringTurnOutcome(
+    historyEntryId: string,
+    turn: SessionProtocolTurnOutcome,
+  ): Promise<void> {
+    const write = this.runtimeEventQueue
+      .catch(() => undefined)
+      .then(async () => {
+        this.turnOutcomes.set(historyEntryId, turn);
+        const message = this.committedSnapshot?.messages.find(
+          (candidate) => candidate.id === historyEntryId,
+        );
+        if (!message) {
+          throw new Error(`missing steering user message '${historyEntryId}'`);
+        }
+        if (isDeepStrictEqual(message.turn, turn)) {
+          return;
+        }
+        await this.emitPatch("assistant-message", [
+          {
+            type: "message.replace",
+            message: { ...structuredClone(message), turn },
+          },
+        ]);
+      });
+    this.runtimeEventQueue = write.catch(() => undefined);
+    await write;
   }
 
   private removeToolRun(tool: SessionProtocolToolRun, changes: SessionProtocolChange[]): void {

--- a/src/host/session_protocol_handler.ts
+++ b/src/host/session_protocol_handler.ts
@@ -922,18 +922,22 @@ export class SessionProtocolHandler {
         const started = await pending.handler.startUserMessageTurn(state, pending.request);
         return started
           ? { type: "started" as const, activeSubmit: started.activeSubmit }
-          : { type: "failed" as const };
+          : { type: "rejected" as const };
       } catch (error) {
         this.sendUserMessageDrainFailure([pending], error);
-        return { type: "failed" as const };
+        return { type: "failed" as const, error };
       }
     });
 
     if (action.type === "idle") {
       return;
     }
-    if (action.type === "failed") {
+    if (action.type === "rejected") {
       this.schedulePendingSubmitDrains(state);
+      return;
+    }
+    if (action.type === "failed") {
+      this.failPendingUserMessageRequests(state, action.error);
       return;
     }
 

--- a/src/host/session_protocol_handler.ts
+++ b/src/host/session_protocol_handler.ts
@@ -131,7 +131,11 @@ function publishPendingUserMessages(
     state: buildPendingUserMessagesState(state),
   });
   for (const listener of [...state.listeners]) {
-    listener(message);
+    try {
+      listener(message);
+    } catch {
+      // Pending-message observers must not be able to fail shared session work.
+    }
   }
 }
 
@@ -903,34 +907,41 @@ export class SessionProtocolHandler {
   private async drainPendingQueuedSubmits(
     state: SessionProtocolHandlerSessionState,
   ): Promise<void> {
-    const next = await this.enqueueMutation(state, async () => {
+    const action = await this.enqueueMutation(state, async () => {
       if (
         state.live.pendingQueuedSubmits.length === 0 ||
         state.live.activeSubmit ||
         state.session.isTurnRunning
       ) {
-        return undefined;
+        return { type: "idle" as const };
       }
 
       const pending = state.live.pendingQueuedSubmits.shift()!;
       publishPendingUserMessages(state.session, state.live);
       try {
-        return await pending.handler.startUserMessageTurn(state, pending.request);
+        const started = await pending.handler.startUserMessageTurn(state, pending.request);
+        return started
+          ? { type: "started" as const, activeSubmit: started.activeSubmit }
+          : { type: "failed" as const };
       } catch (error) {
         this.sendUserMessageDrainFailure([pending], error);
-        return undefined;
+        return { type: "failed" as const };
       }
     });
 
-    if (!next) {
+    if (action.type === "idle") {
+      return;
+    }
+    if (action.type === "failed") {
+      this.schedulePendingSubmitDrains(state);
       return;
     }
 
     try {
-      await next.activeSubmit.promise;
+      await action.activeSubmit.promise;
     } finally {
       await this.enqueueMutation(state, () => {
-        if (state.live.activeSubmit === next.activeSubmit) {
+        if (state.live.activeSubmit === action.activeSubmit) {
           state.live.activeSubmit = undefined;
         }
       });

--- a/src/host/session_protocol_handler.ts
+++ b/src/host/session_protocol_handler.ts
@@ -32,31 +32,48 @@ export type SessionProtocolHandlerOptions = {
 type SessionProtocolHandlerCloseMode = "detach" | "interrupt" | "shutdown-host";
 
 type SessionProtocolActiveSubmit = {
-  requestId: SessionProtocolRequestId;
   promise: Promise<void>;
 };
 
-type SessionProtocolPendingRequest<Method extends "session.queue" | "session.steer"> = {
+type SessionProtocolUserSubmissionRequest = Extract<
+  SessionProtocolRequestMessage,
+  { method: "session.submit" | "session.queue" | "session.steer" }
+>;
+
+type SessionProtocolPendingIdleSubmission = {
   id: string;
-  mode: "queue" | "steer";
+  delivery: "when-idle";
   handler: SessionProtocolHandler;
-  request: Extract<SessionProtocolRequestMessage, { method: Method }>;
+  request: Extract<SessionProtocolRequestMessage, { method: "session.queue" | "session.steer" }>;
 };
 
-type SessionProtocolPendingSteeringRequest = SessionProtocolPendingRequest<"session.steer"> & {
+type SessionProtocolPendingBoundarySubmission = {
+  id: string;
+  delivery: "turn-boundary";
   steeringId: string;
+  handler: SessionProtocolHandler;
+  request: Extract<SessionProtocolRequestMessage, { method: "session.steer" }>;
 };
 
-type SessionProtocolPendingUserMessageRequest =
-  | SessionProtocolPendingRequest<"session.queue">
-  | SessionProtocolPendingRequest<"session.steer">;
+type SessionProtocolPendingUserSubmission =
+  | SessionProtocolPendingIdleSubmission
+  | SessionProtocolPendingBoundarySubmission;
+
+type SessionProtocolUserSubmissionAction =
+  | { type: "busy" }
+  | { type: "pending" }
+  | { type: "started"; activeSubmit: SessionProtocolActiveSubmit }
+  | {
+      type: "boundary";
+      pending: SessionProtocolPendingBoundarySubmission;
+      submission: ReturnType<TauHostedSession["steer"]>;
+    };
 
 type SessionProtocolLiveSessionState = {
   activeSubmit?: SessionProtocolActiveSubmit;
   interrupting: boolean;
   revision: number;
-  pendingSteeringSubmits: SessionProtocolPendingSteeringRequest[];
-  pendingQueuedSubmits: SessionProtocolPendingUserMessageRequest[];
+  pendingSubmissions: SessionProtocolPendingUserSubmission[];
   listeners: Set<(message: SessionProtocolPendingUserMessagesMessage) => void>;
 };
 
@@ -88,8 +105,7 @@ function getSessionLiveState(session: TauHostedSession): SessionProtocolLiveSess
     state = {
       interrupting: false,
       revision: 1,
-      pendingSteeringSubmits: [],
-      pendingQueuedSubmits: [],
+      pendingSubmissions: [],
       listeners: new Set(),
     };
     sessionLiveStates.set(session, state);
@@ -97,27 +113,31 @@ function getSessionLiveState(session: TauHostedSession): SessionProtocolLiveSess
   return state;
 }
 
+function pendingSubmissionsInDeliveryOrder(
+  state: SessionProtocolLiveSessionState,
+): SessionProtocolPendingUserSubmission[] {
+  return [
+    ...state.pendingSubmissions.filter((pending) => pending.delivery === "turn-boundary"),
+    ...state.pendingSubmissions.filter((pending) => pending.delivery === "when-idle"),
+  ];
+}
+
+function toPendingUserMessage(
+  pending: SessionProtocolPendingUserSubmission,
+): SessionProtocolPendingUserMessage {
+  return {
+    id: pending.id,
+    mode: pending.request.method === "session.queue" ? "queue" : "steer",
+    text: pending.request.params.text,
+  };
+}
+
 function buildPendingUserMessagesState(
   state: SessionProtocolLiveSessionState,
 ): SessionProtocolPendingUserMessagesState {
   return {
     revision: state.revision,
-    messages: [
-      ...state.pendingSteeringSubmits.map(
-        (pending): SessionProtocolPendingUserMessage => ({
-          id: pending.id,
-          mode: pending.mode,
-          text: pending.request.params.text,
-        }),
-      ),
-      ...state.pendingQueuedSubmits.map(
-        (pending): SessionProtocolPendingUserMessage => ({
-          id: pending.id,
-          mode: pending.mode,
-          text: pending.request.params.text,
-        }),
-      ),
-    ],
+    messages: pendingSubmissionsInDeliveryOrder(state).map(toPendingUserMessage),
   };
 }
 
@@ -392,88 +412,22 @@ export class SessionProtocolHandler {
   private async handleSubmit(
     request: Extract<SessionProtocolRequestMessage, { method: "session.submit" }>,
   ): Promise<void> {
-    const state = await this.getSessionState(request.params.sessionId);
-    if (!state) {
-      this.sendSessionNotFound(request.id, request.params.sessionId);
-      return;
-    }
-
-    if (this.getPendingMutationCount(state) > 0) {
-      this.sendSubmitBusy(state, request.id);
-      return;
-    }
-
-    const startedSubmit = await this.enqueueMutation(state, () =>
-      this.startUserMessageTurn(state, request),
-    );
-
-    if (!startedSubmit) {
-      return;
-    }
-
-    const { activeSubmit } = startedSubmit;
-
-    try {
-      await activeSubmit.promise;
-    } finally {
-      await this.enqueueMutation(state, () => {
-        if (state.live.activeSubmit === activeSubmit) {
-          state.live.activeSubmit = undefined;
-        }
-      });
-      this.schedulePendingSubmitDrains(state);
-    }
+    await this.handleUserSubmission(request);
   }
 
   private async handleQueue(
     request: Extract<SessionProtocolRequestMessage, { method: "session.queue" }>,
   ): Promise<void> {
-    const state = await this.getSessionState(request.params.sessionId);
-    if (!state) {
-      this.sendSessionNotFound(request.id, request.params.sessionId);
-      return;
-    }
-
-    if (this.getPendingMutationCount(state) > 0) {
-      this.sendSubmitBusy(state, request.id);
-      return;
-    }
-
-    const startedSubmit = await this.enqueueMutation(state, () => {
-      if (state.live.activeSubmit || state.session.isTurnRunning) {
-        state.live.pendingQueuedSubmits.push({
-          id: randomUUID(),
-          mode: "queue",
-          handler: this,
-          request,
-        });
-        publishPendingUserMessages(state.session, state.live);
-        return undefined;
-      }
-      return this.startUserMessageTurn(state, request);
-    });
-
-    if (!startedSubmit) {
-      return;
-    }
-
-    const { activeSubmit } = startedSubmit;
-
-    try {
-      await activeSubmit.promise;
-    } finally {
-      await this.enqueueMutation(state, () => {
-        if (state.live.activeSubmit === activeSubmit) {
-          state.live.activeSubmit = undefined;
-        }
-      });
-      this.schedulePendingSubmitDrains(state);
-    }
+    await this.handleUserSubmission(request);
   }
 
   private async handleSteer(
     request: Extract<SessionProtocolRequestMessage, { method: "session.steer" }>,
   ): Promise<void> {
+    await this.handleUserSubmission(request);
+  }
+
+  private async handleUserSubmission(request: SessionProtocolUserSubmissionRequest): Promise<void> {
     const state = await this.getSessionState(request.params.sessionId);
     if (!state) {
       this.sendSessionNotFound(request.id, request.params.sessionId);
@@ -484,81 +438,86 @@ export class SessionProtocolHandler {
       return;
     }
 
-    const action = await this.enqueueMutation(state, async () => {
+    const action = await this.enqueueMutation(state, () =>
+      this.dispatchUserSubmission(state, request),
+    );
+    if (action.type === "busy") {
+      this.sendSubmitBusy(state, request.id);
+      return;
+    }
+    if (action.type === "pending") {
+      return;
+    }
+    if (action.type === "started") {
+      await this.finishActiveSubmit(state, action.activeSubmit);
+      return;
+    }
+
+    await this.finishBoundarySteering(state, action.pending, action.submission);
+  }
+
+  private async dispatchUserSubmission(
+    state: SessionProtocolHandlerSessionState,
+    request: SessionProtocolUserSubmissionRequest,
+  ): Promise<SessionProtocolUserSubmissionAction> {
+    if (request.method === "session.steer") {
       if (state.live.interrupting) {
         return { type: "busy" as const };
       }
       if (state.session.isTurnRunning) {
         const submission = state.session.steer(request.params.text);
-        const pending = {
+        const pending: SessionProtocolPendingBoundarySubmission = {
           id: randomUUID(),
-          mode: "steer" as const,
+          delivery: "turn-boundary",
           steeringId: submission.id,
           handler: this,
           request,
         };
-        state.live.pendingSteeringSubmits.push(pending);
-        publishPendingUserMessages(state.session, state.live);
-        return { type: "steer" as const, pending, submission };
+        this.addPendingSubmission(state, pending);
+        return { type: "boundary" as const, pending, submission };
       }
-      if (state.live.activeSubmit) {
-        state.live.pendingQueuedSubmits.push({
-          id: randomUUID(),
-          mode: "steer",
-          handler: this,
-          request,
-        });
-        publishPendingUserMessages(state.session, state.live);
-        return { type: "queued" as const };
+    }
+
+    if (state.live.activeSubmit || state.session.isTurnRunning) {
+      if (request.method === "session.submit") {
+        return { type: "busy" as const };
       }
-      return {
-        type: "submit" as const,
-        started: await this.startUserMessageTurn(state, request),
+      const pending: SessionProtocolPendingIdleSubmission = {
+        id: randomUUID(),
+        delivery: "when-idle",
+        handler: this,
+        request,
       };
-    });
-
-    if (action.type === "busy") {
-      this.sendSubmitBusy(state, request.id);
-      return;
+      this.addPendingSubmission(state, pending);
+      return { type: "pending" as const };
     }
 
-    if (action.type === "queued") {
-      return;
-    }
+    return {
+      type: "started",
+      activeSubmit: await this.startUserMessageTurn(state, request),
+    };
+  }
 
-    if (action.type === "submit") {
-      const started = await action.started;
-      if (!started) return;
-      try {
-        await started.activeSubmit.promise;
-      } finally {
-        await this.enqueueMutation(state, () => {
-          if (state.live.activeSubmit === started.activeSubmit) {
-            state.live.activeSubmit = undefined;
-          }
-        });
-        this.schedulePendingSubmitDrains(state);
-      }
-      return;
-    }
-
+  private async finishBoundarySteering(
+    state: SessionProtocolHandlerSessionState,
+    pending: SessionProtocolPendingBoundarySubmission,
+    submission: ReturnType<TauHostedSession["steer"]>,
+  ): Promise<void> {
     let applied = false;
-    void action.submission.result.catch(() => {});
+    void submission.result.catch(() => {});
     try {
-      await action.submission.applied;
+      await submission.applied;
       applied = true;
-      await this.enqueueMutation(state, () => {
-        const index = state.live.pendingSteeringSubmits.indexOf(action.pending);
-        if (index >= 0) state.live.pendingSteeringSubmits.splice(index, 1);
-        publishPendingUserMessages(state.session, state.live);
-      });
-      const result = await action.submission.result;
-      this.sendMessage(createSessionProtocolSuccessResponse(request.id, "session.steer", result));
+      await this.enqueueMutation(state, () => this.removePendingSubmission(state, pending));
+      const result = await submission.result;
+      this.sendMessage(
+        createSessionProtocolSuccessResponse(pending.request.id, "session.steer", result),
+      );
     } catch (error) {
-      if (applied || state.live.pendingSteeringSubmits.includes(action.pending)) {
+      if (applied || state.live.pendingSubmissions.includes(pending)) {
         this.sendMessage(
           createSessionProtocolErrorResponse(
-            request.id,
+            pending.request.id,
             SESSION_PROTOCOL_ERROR_CODES.internalError,
             "steering turn failed",
             { cause: error instanceof Error ? error.message : String(error) },
@@ -566,13 +525,54 @@ export class SessionProtocolHandler {
         );
       }
     } finally {
+      await this.enqueueMutation(state, () => this.removePendingSubmission(state, pending));
+    }
+  }
+
+  private addPendingSubmission(
+    state: SessionProtocolHandlerSessionState,
+    pending: SessionProtocolPendingUserSubmission,
+  ): void {
+    state.live.pendingSubmissions.push(pending);
+    publishPendingUserMessages(state.session, state.live);
+  }
+
+  private removePendingSubmission(
+    state: SessionProtocolHandlerSessionState,
+    pending: SessionProtocolPendingUserSubmission,
+  ): boolean {
+    return this.removePendingSubmissions(state, [pending]);
+  }
+
+  private removePendingSubmissions(
+    state: SessionProtocolHandlerSessionState,
+    pending: SessionProtocolPendingUserSubmission[],
+  ): boolean {
+    const removed = new Set(pending);
+    const remaining = state.live.pendingSubmissions.filter(
+      (submission) => !removed.has(submission),
+    );
+    if (remaining.length === state.live.pendingSubmissions.length) {
+      return false;
+    }
+    state.live.pendingSubmissions = remaining;
+    publishPendingUserMessages(state.session, state.live);
+    return true;
+  }
+
+  private async finishActiveSubmit(
+    state: SessionProtocolHandlerSessionState,
+    activeSubmit: SessionProtocolActiveSubmit,
+  ): Promise<void> {
+    try {
+      await activeSubmit.promise;
+    } finally {
       await this.enqueueMutation(state, () => {
-        const index = state.live.pendingSteeringSubmits.indexOf(action.pending);
-        if (index >= 0) {
-          state.live.pendingSteeringSubmits.splice(index, 1);
-          publishPendingUserMessages(state.session, state.live);
+        if (state.live.activeSubmit === activeSubmit) {
+          state.live.activeSubmit = undefined;
         }
       });
+      this.schedulePendingSubmissionDrain(state);
     }
   }
 
@@ -589,18 +589,15 @@ export class SessionProtocolHandler {
       const cancelledSteeringIds = new Set(
         state.session.cancelSteering().map((submission) => submission.id),
       );
-      const cancelledSteering = state.live.pendingSteeringSubmits.filter((pending) =>
-        cancelledSteeringIds.has(pending.steeringId),
+      const pending = pendingSubmissionsInDeliveryOrder(state.live).filter(
+        (submission) =>
+          submission.delivery === "when-idle" || cancelledSteeringIds.has(submission.steeringId),
       );
-      state.live.pendingSteeringSubmits = state.live.pendingSteeringSubmits.filter(
-        (pending) => !cancelledSteeringIds.has(pending.steeringId),
-      );
-      const pending = [...cancelledSteering, ...state.live.pendingQueuedSubmits.splice(0)];
       if (pending.length === 0) {
         return [];
       }
 
-      publishPendingUserMessages(state.session, state.live);
+      this.removePendingSubmissions(state, pending);
       for (const item of pending) {
         item.handler.sendMessage(
           createSessionProtocolErrorResponse(
@@ -610,13 +607,7 @@ export class SessionProtocolHandler {
           ),
         );
       }
-      return pending.map(
-        (item): SessionProtocolPendingUserMessage => ({
-          id: item.id,
-          mode: item.mode,
-          text: item.request.params.text,
-        }),
-      );
+      return pending.map(toPendingUserMessage);
     });
 
     this.sendMessage(
@@ -714,23 +705,9 @@ export class SessionProtocolHandler {
       return;
     }
 
-    const startedRetry = await this.enqueueMutation(state, () => this.startRetry(state, request));
-
-    if (!startedRetry) {
-      return;
-    }
-
-    const { activeSubmit } = startedRetry;
-
-    try {
-      await activeSubmit.promise;
-    } finally {
-      await this.enqueueMutation(state, () => {
-        if (state.live.activeSubmit === activeSubmit) {
-          state.live.activeSubmit = undefined;
-        }
-      });
-      this.schedulePendingSubmitDrains(state);
+    const activeSubmit = await this.enqueueMutation(state, () => this.startRetry(state, request));
+    if (activeSubmit) {
+      await this.finishActiveSubmit(state, activeSubmit);
     }
   }
 
@@ -842,26 +819,8 @@ export class SessionProtocolHandler {
 
   private async startUserMessageTurn(
     state: SessionProtocolHandlerSessionState,
-    request: Extract<
-      SessionProtocolRequestMessage,
-      {
-        method: "session.submit" | "session.queue" | "session.steer";
-      }
-    >,
-  ): Promise<
-    | {
-        activeSubmit: {
-          requestId: SessionProtocolRequestId;
-          promise: Promise<void>;
-        };
-      }
-    | undefined
-  > {
-    if (state.live.activeSubmit || state.session.isTurnRunning) {
-      this.sendSubmitBusy(state, request.id);
-      return undefined;
-    }
-
+    request: SessionProtocolUserSubmissionRequest,
+  ): Promise<SessionProtocolActiveSubmit> {
     const addOptions =
       request.method !== "session.steer" && request.params.historyEntryId
         ? { historyEntryId: request.params.historyEntryId }
@@ -871,13 +830,11 @@ export class SessionProtocolHandler {
       ...(addOptions ? { historyEntryId: addOptions.historyEntryId } : {}),
     });
 
-    const submitPromise = this.executeSubmit(state, request.id, request.method, userHistoryEntryId);
-    const activeSubmit = { requestId: request.id, promise: submitPromise };
-    state.live.activeSubmit = activeSubmit;
-
-    return {
-      activeSubmit,
+    const activeSubmit = {
+      promise: this.executeSubmit(state, request.id, request.method, userHistoryEntryId),
     };
+    state.live.activeSubmit = activeSubmit;
+    return activeSubmit;
   }
 
   private startRetry(
@@ -889,40 +846,39 @@ export class SessionProtocolHandler {
       return undefined;
     }
 
-    const retryPromise = this.executeRetry(state, request.id);
-    const activeSubmit = { requestId: request.id, promise: retryPromise };
-    state.live.activeSubmit = activeSubmit;
-
-    return {
-      activeSubmit,
+    const activeSubmit = {
+      promise: this.executeRetry(state, request.id),
     };
+    state.live.activeSubmit = activeSubmit;
+    return activeSubmit;
   }
 
-  private schedulePendingSubmitDrains(state: SessionProtocolHandlerSessionState): void {
-    void this.drainPendingQueuedSubmits(state).catch((error) => {
-      this.failPendingUserMessageRequests(state, error);
+  private schedulePendingSubmissionDrain(state: SessionProtocolHandlerSessionState): void {
+    void this.drainPendingIdleSubmissions(state).catch((error) => {
+      this.failPendingIdleSubmissions(state, error);
     });
   }
 
-  private async drainPendingQueuedSubmits(
+  private async drainPendingIdleSubmissions(
     state: SessionProtocolHandlerSessionState,
   ): Promise<void> {
     const action = await this.enqueueMutation(state, async () => {
-      if (
-        state.live.pendingQueuedSubmits.length === 0 ||
-        state.live.activeSubmit ||
-        state.session.isTurnRunning
-      ) {
+      const pendingIndex = state.live.pendingSubmissions.findIndex(
+        (pending) => pending.delivery === "when-idle",
+      );
+      if (pendingIndex < 0 || state.live.activeSubmit || state.session.isTurnRunning) {
         return { type: "idle" as const };
       }
 
-      const pending = state.live.pendingQueuedSubmits.shift()!;
+      const [pending] = state.live.pendingSubmissions.splice(pendingIndex, 1) as [
+        SessionProtocolPendingIdleSubmission,
+      ];
       publishPendingUserMessages(state.session, state.live);
       try {
-        const started = await pending.handler.startUserMessageTurn(state, pending.request);
-        return started
-          ? { type: "started" as const, activeSubmit: started.activeSubmit }
-          : { type: "rejected" as const };
+        return {
+          type: "started" as const,
+          activeSubmit: await pending.handler.startUserMessageTurn(state, pending.request),
+        };
       } catch (error) {
         this.sendUserMessageDrainFailure([pending], error);
         return { type: "failed" as const, error };
@@ -932,40 +888,28 @@ export class SessionProtocolHandler {
     if (action.type === "idle") {
       return;
     }
-    if (action.type === "rejected") {
-      this.schedulePendingSubmitDrains(state);
-      return;
-    }
     if (action.type === "failed") {
-      this.failPendingUserMessageRequests(state, action.error);
+      this.failPendingIdleSubmissions(state, action.error);
       return;
     }
 
-    try {
-      await action.activeSubmit.promise;
-    } finally {
-      await this.enqueueMutation(state, () => {
-        if (state.live.activeSubmit === action.activeSubmit) {
-          state.live.activeSubmit = undefined;
-        }
-      });
-      this.schedulePendingSubmitDrains(state);
-    }
+    await this.finishActiveSubmit(state, action.activeSubmit);
   }
 
-  private failPendingUserMessageRequests(
+  private failPendingIdleSubmissions(
     state: SessionProtocolHandlerSessionState,
     error: unknown,
   ): void {
-    const pending = state.live.pendingQueuedSubmits.splice(0);
-    if (pending.length > 0) {
-      publishPendingUserMessages(state.session, state.live);
-    }
+    const pending = state.live.pendingSubmissions.filter(
+      (submission): submission is SessionProtocolPendingIdleSubmission =>
+        submission.delivery === "when-idle",
+    );
+    this.removePendingSubmissions(state, pending);
     this.sendUserMessageDrainFailure(pending, error);
   }
 
   private sendUserMessageDrainFailure(
-    requests: SessionProtocolPendingUserMessageRequest[],
+    requests: SessionProtocolPendingIdleSubmission[],
     error: unknown,
   ): void {
     for (const { handler, request } of requests) {
@@ -985,7 +929,6 @@ export class SessionProtocolHandler {
     requestId: SessionProtocolRequestId,
     method: "session.submit" | "session.queue" | "session.steer",
     userHistoryEntryId: string,
-    responseRequests?: SessionProtocolPendingUserMessageRequest[],
   ): Promise<void> {
     try {
       const turnResult = await state.session.runTurn();
@@ -995,37 +938,17 @@ export class SessionProtocolHandler {
         userHistoryEntryId,
         turn: turnResult,
       };
-
-      if (responseRequests) {
-        for (const { handler, request } of responseRequests) {
-          handler.sendMessage(createSessionProtocolSuccessResponse(request.id, method, result));
-        }
-      } else {
-        this.sendMessage(createSessionProtocolSuccessResponse(requestId, method, result));
-      }
+      this.sendMessage(createSessionProtocolSuccessResponse(requestId, method, result));
     } catch (error) {
       await this.snapshotAfterFailedSubmit(state);
-      if (responseRequests) {
-        for (const { handler, request } of responseRequests) {
-          handler.sendMessage(
-            createSessionProtocolErrorResponse(
-              request.id,
-              SESSION_PROTOCOL_ERROR_CODES.internalError,
-              "failed to run session turn",
-              { cause: error instanceof Error ? error.message : String(error) },
-            ),
-          );
-        }
-      } else {
-        this.sendMessage(
-          createSessionProtocolErrorResponse(
-            requestId,
-            SESSION_PROTOCOL_ERROR_CODES.internalError,
-            "failed to run session turn",
-            { cause: error instanceof Error ? error.message : String(error) },
-          ),
-        );
-      }
+      this.sendMessage(
+        createSessionProtocolErrorResponse(
+          requestId,
+          SESSION_PROTOCOL_ERROR_CODES.internalError,
+          "failed to run session turn",
+          { cause: error instanceof Error ? error.message : String(error) },
+        ),
+      );
     }
   }
 
@@ -1160,7 +1083,7 @@ export class SessionProtocolHandler {
       if (interrupted) {
         state.live.interrupting = true;
       }
-      this.rejectPendingSteeringSubmits(state, "session was interrupted");
+      this.rejectPendingBoundarySubmissions(state, "session was interrupted");
       return {
         interrupted,
         isTurnRunning: state.session.isTurnRunning || interrupted,
@@ -1290,8 +1213,7 @@ export class SessionProtocolHandler {
       if (
         state.live.activeSubmit ||
         state.session.isTurnRunning ||
-        state.live.pendingSteeringSubmits.length > 0 ||
-        state.live.pendingQueuedSubmits.length > 0
+        state.live.pendingSubmissions.length > 0
       ) {
         this.sendMessage(
           createSessionProtocolErrorResponse(
@@ -1411,8 +1333,8 @@ export class SessionProtocolHandler {
         return;
       }
       await this.interruptAndWaitForActiveSubmit(state);
-      this.rejectPendingSteeringSubmits(state, queuedSteeringRejectionMessage);
-      this.rejectPendingQueuedSubmits(state, queuedSteeringRejectionMessage);
+      this.rejectPendingBoundarySubmissions(state, queuedSteeringRejectionMessage);
+      this.rejectPendingIdleSubmissions(state, queuedSteeringRejectionMessage);
       await handler(state);
     });
   }
@@ -1439,40 +1361,41 @@ export class SessionProtocolHandler {
     });
   }
 
-  private rejectPendingSteeringSubmits(
+  private rejectPendingBoundarySubmissions(
     state: SessionProtocolHandlerSessionState,
     message: string,
   ): void {
     const cancelledIds = new Set(state.session.cancelSteering().map((submission) => submission.id));
-    const requests = state.live.pendingSteeringSubmits.filter((pending) =>
-      cancelledIds.has(pending.steeringId),
+    this.rejectPendingSubmissions(
+      state,
+      state.live.pendingSubmissions.filter(
+        (pending) => pending.delivery === "turn-boundary" && cancelledIds.has(pending.steeringId),
+      ),
+      message,
     );
-    state.live.pendingSteeringSubmits = state.live.pendingSteeringSubmits.filter(
-      (pending) => !cancelledIds.has(pending.steeringId),
-    );
-    if (requests.length > 0) {
-      publishPendingUserMessages(state.session, state.live);
-    }
-    for (const { handler, request } of requests) {
-      handler.sendMessage(
-        createSessionProtocolErrorResponse(
-          request.id,
-          SESSION_PROTOCOL_ERROR_CODES.invalidRequest,
-          message,
-        ),
-      );
-    }
   }
 
-  private rejectPendingQueuedSubmits(
+  private rejectPendingIdleSubmissions(
     state: SessionProtocolHandlerSessionState,
     message: string,
   ): void {
-    const requests = state.live.pendingQueuedSubmits.splice(0);
-    if (requests.length > 0) {
-      publishPendingUserMessages(state.session, state.live);
+    this.rejectPendingSubmissions(
+      state,
+      state.live.pendingSubmissions.filter((pending) => pending.delivery === "when-idle"),
+      message,
+    );
+  }
+
+  private rejectPendingSubmissions(
+    state: SessionProtocolHandlerSessionState,
+    pending: SessionProtocolPendingUserSubmission[],
+    message: string,
+  ): void {
+    if (pending.length === 0) {
+      return;
     }
-    for (const { handler, request } of requests) {
+    this.removePendingSubmissions(state, pending);
+    for (const { handler, request } of pending) {
       handler.sendMessage(
         createSessionProtocolErrorResponse(
           request.id,

--- a/src/tui/session_chat_controller.ts
+++ b/src/tui/session_chat_controller.ts
@@ -661,7 +661,7 @@ export class SessionChatController {
       .queue(text, { historyEntryId: `session-queue-${randomUUID()}` })
       .catch((error) => {
         if (!this.isPendingMessageCancellation(error)) {
-          this.view.addSystemMessage(`queueing failed: ${(error as Error).message}`, "error");
+          this.view.addSystemMessage(`queueing failed: ${formatSessionError(error)}`, "error");
         }
       });
   }
@@ -669,7 +669,7 @@ export class SessionChatController {
   private submitSteeringText(text: string): void {
     void this.session.steer(text).catch((error) => {
       if (!this.isPendingMessageCancellation(error)) {
-        this.view.addSystemMessage(`steering failed: ${(error as Error).message}`, "error");
+        this.view.addSystemMessage(`steering failed: ${formatSessionError(error)}`, "error");
       }
     });
   }
@@ -774,7 +774,7 @@ export class SessionChatController {
       }
       await this.syncFromSessionSnapshot();
     } catch (error) {
-      this.view.addSystemMessage(`session turn failed: ${(error as Error).message}`, "error");
+      this.view.addSystemMessage(`session turn failed: ${formatSessionError(error)}`, "error");
       this.stopVisibleSessionTurn();
       void this.stopTurnCaffeinate();
       await this.syncFromSessionSnapshot();
@@ -2313,6 +2313,21 @@ export class SessionChatController {
       (persona) => persona.id.toLowerCase() === this.snapshot.settings.personaId.toLowerCase(),
     );
   }
+}
+
+function formatSessionError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  const data =
+    typeof error === "object" && error !== null ? (error as { data?: unknown }).data : undefined;
+  const cause =
+    typeof data === "object" &&
+    data !== null &&
+    "cause" in data &&
+    typeof data.cause === "string" &&
+    data.cause.trim()
+      ? data.cause.trim()
+      : undefined;
+  return cause && cause !== message ? `${message}: ${cause}` : message;
 }
 
 function getTimelineMessages(snapshot: SessionProtocolSnapshot): SessionProtocolMessage[] {

--- a/test/local_session_host.test.js
+++ b/test/local_session_host.test.js
@@ -1307,6 +1307,74 @@ describe("LocalSessionHost", () => {
     expect(deltas).toHaveLength(1);
   });
 
+  it("projects each steering outcome before a later steering continuation", async () => {
+    const host = createHost(new MemorySessionStore());
+
+    try {
+      const hostedSession = await host.createSession(localCreateInput);
+      await hostedSession.snapshot();
+
+      const createGate = () => {
+        let resolve;
+        const promise = new Promise((settle) => {
+          resolve = settle;
+        });
+        return { promise, resolve };
+      };
+      const modelGates = [createGate(), createGate(), createGate()];
+      const modelStarts = [createGate(), createGate(), createGate()];
+      let modelCall = 0;
+      hostedSession.runtime.agent.spec.model.stream = () => {
+        const index = modelCall++;
+        const response = fauxAssistantMessage(`response ${index + 1}`);
+        return {
+          async *[Symbol.asyncIterator]() {
+            modelStarts[index].resolve();
+            await modelGates[index].promise;
+            yield* [];
+          },
+          async result() {
+            return response;
+          },
+        };
+      };
+
+      await hostedSession.record({ text: "original" });
+      const turn = hostedSession.runTurn();
+      await modelStarts[0].promise;
+
+      const firstSteering = hostedSession.steer("first steer");
+      modelGates[0].resolve();
+      await firstSteering.applied;
+      await modelStarts[1].promise;
+
+      const secondSteering = hostedSession.steer("second steer");
+      modelGates[1].resolve();
+      const [firstResult, secondApplied] = await Promise.all([
+        firstSteering.result,
+        secondSteering.applied,
+      ]);
+      await modelStarts[2].promise;
+
+      modelGates[2].resolve();
+      const [secondResult] = await Promise.all([secondSteering.result, turn]);
+      const snapshot = await hostedSession.snapshot();
+
+      expect(firstResult.turn).toEqual({ status: "completed", stopReason: "stop" });
+      expect(secondResult.turn).toEqual({ status: "completed", stopReason: "stop" });
+      expect(secondApplied).toEqual({ userHistoryEntryId: secondResult.userHistoryEntryId });
+      expect(
+        snapshot.messages.find((message) => message.id === firstResult.userHistoryEntryId),
+      ).toEqual(expect.objectContaining({ turn: firstResult.turn }));
+      expect(
+        snapshot.messages.find((message) => message.id === secondResult.userHistoryEntryId),
+      ).toEqual(expect.objectContaining({ turn: secondResult.turn }));
+      expect(modelCall).toBe(3);
+    } finally {
+      await host.shutdown();
+    }
+  });
+
   it("serializes overlapping snapshots from the same live local session", async () => {
     const store = new MemorySessionStore();
     const host = createHost(store);

--- a/test/rpc_server.test.js
+++ b/test/rpc_server.test.js
@@ -1661,6 +1661,54 @@ describe("rpc_server", () => {
     await observer.close();
   });
 
+  it("isolates pending-message observer failures from shared session work", async () => {
+    const harness = createHarness();
+    let rejectPendingMessages = false;
+    const observer = new RpcServer({
+      host: harness.host,
+      send: (line) => {
+        const message = JSON.parse(line);
+        if (rejectPendingMessages && message.type === "session.pendingUserMessages") {
+          throw new Error("observer unavailable");
+        }
+      },
+    });
+    await observer.handleLine(request("attach", "session.observe", { sessionId: "session-1" }));
+    rejectPendingMessages = true;
+
+    const firstSubmit = harness.server.handleLine(
+      request("submit-1", "session.submit", {
+        sessionId: "session-1",
+        text: "first turn",
+      }),
+    );
+    await waitFor(() => harness.lines.some((line) => deltaHasNotice(line, "streaming")));
+    const queued = harness.server.handleLine(
+      request("queue-1", "session.queue", {
+        sessionId: "session-1",
+        text: "queued turn",
+      }),
+    );
+    await waitFor(() =>
+      harness.lines.some(
+        (line) => line.type === "session.pendingUserMessages" && line.state.messages.length === 1,
+      ),
+    );
+
+    await harness.server.handleLine(
+      request("cancel", "session.cancelPendingMessages", { sessionId: "session-1" }),
+    );
+    await queued;
+    expect(harness.lines.find((line) => line.id === "queue-1")).toMatchObject({
+      ok: false,
+      error: { code: SESSION_PROTOCOL_ERROR_CODES.cancelled },
+    });
+
+    harness.releaseTurn();
+    await firstSubmit;
+    await observer.close();
+  });
+
   it("starts recovered sessions without pending user messages", async () => {
     const harness = createHarness();
     const firstSubmit = harness.server.handleLine(
@@ -2346,6 +2394,68 @@ describe("rpc_server", () => {
         }),
       }),
     );
+  });
+
+  it("continues draining queued messages after one cannot be committed", async () => {
+    let recordCount = 0;
+    const harness = createHarness({
+      record: async (recordOptions, defaultRecord) => {
+        recordCount += 1;
+        if (recordCount === 2) {
+          throw new Error("first queued commit failed");
+        }
+        return await defaultRecord(recordOptions);
+      },
+    });
+
+    const firstSubmit = harness.server.handleLine(
+      request("submit-1", "session.submit", {
+        sessionId: "session-1",
+        text: "first turn",
+      }),
+    );
+    await waitFor(() => harness.lines.some((line) => deltaHasNotice(line, "streaming")));
+    await Promise.all([
+      harness.server.handleLine(
+        request("queue-1", "session.queue", {
+          sessionId: "session-1",
+          text: "first queued turn",
+        }),
+      ),
+      harness.server.handleLine(
+        request("queue-2", "session.queue", {
+          sessionId: "session-1",
+          text: "second queued turn",
+        }),
+      ),
+    ]);
+
+    harness.releaseTurn();
+    await firstSubmit;
+    await waitFor(() => harness.lines.some((line) => line.id === "queue-1"));
+    await waitFor(() =>
+      harness.seededSession.session.historyEntries.some(
+        (entry) => entry.message.content[0].text === "second queued turn",
+      ),
+    );
+    harness.releaseTurn();
+    await waitFor(() => harness.lines.some((line) => line.id === "queue-2"));
+
+    expect(harness.lines.find((line) => line.id === "queue-1")).toMatchObject({
+      ok: false,
+      error: {
+        code: SESSION_PROTOCOL_ERROR_CODES.internalError,
+        message: "failed to drain pending user message",
+        data: { cause: "first queued commit failed" },
+      },
+    });
+    expect(harness.lines.find((line) => line.id === "queue-2")).toMatchObject({
+      ok: true,
+      result: {
+        userHistoryEntryId: expect.any(String),
+        turn: { status: "completed", stopReason: "stop" },
+      },
+    });
   });
 
   it("runRpcServer processes lines concurrently and emits ndjson responses", async () => {

--- a/test/rpc_server.test.js
+++ b/test/rpc_server.test.js
@@ -2396,7 +2396,7 @@ describe("rpc_server", () => {
     );
   });
 
-  it("continues draining queued messages after one cannot be committed", async () => {
+  it("fails remaining queued messages after one cannot be committed", async () => {
     let recordCount = 0;
     const harness = createHarness({
       record: async (recordOptions, defaultRecord) => {
@@ -2432,30 +2432,29 @@ describe("rpc_server", () => {
 
     harness.releaseTurn();
     await firstSubmit;
-    await waitFor(() => harness.lines.some((line) => line.id === "queue-1"));
     await waitFor(() =>
+      ["queue-1", "queue-2"].every((id) => harness.lines.some((line) => line.id === id)),
+    );
+
+    for (const id of ["queue-1", "queue-2"]) {
+      expect(harness.lines.find((line) => line.id === id)).toMatchObject({
+        ok: false,
+        error: {
+          code: SESSION_PROTOCOL_ERROR_CODES.internalError,
+          message: "failed to drain pending user message",
+          data: { cause: "first queued commit failed" },
+        },
+      });
+    }
+    expect(recordCount).toBe(2);
+    expect(
       harness.seededSession.session.historyEntries.some(
         (entry) => entry.message.content[0].text === "second queued turn",
       ),
-    );
-    harness.releaseTurn();
-    await waitFor(() => harness.lines.some((line) => line.id === "queue-2"));
-
-    expect(harness.lines.find((line) => line.id === "queue-1")).toMatchObject({
-      ok: false,
-      error: {
-        code: SESSION_PROTOCOL_ERROR_CODES.internalError,
-        message: "failed to drain pending user message",
-        data: { cause: "first queued commit failed" },
-      },
-    });
-    expect(harness.lines.find((line) => line.id === "queue-2")).toMatchObject({
-      ok: true,
-      result: {
-        userHistoryEntryId: expect.any(String),
-        turn: { status: "completed", stopReason: "stop" },
-      },
-    });
+    ).toBe(false);
+    expect(
+      harness.lines.findLast((line) => line.type === "session.pendingUserMessages").state.messages,
+    ).toEqual([]);
   });
 
   it("runRpcServer processes lines concurrently and emits ndjson responses", async () => {

--- a/test/session_chat_controller.test.js
+++ b/test/session_chat_controller.test.js
@@ -13,6 +13,7 @@ import {
   applySessionProtocolDelta,
   SESSION_PROTOCOL_VERSION,
 } from "../dist/protocol/session_protocol.js";
+import { TauSessionProtocolResponseError } from "../dist/transport/errors.js";
 import { copyTextToClipboard } from "../dist/tui/clipboard.js";
 import { SessionChatController } from "../dist/tui/session_chat_controller.js";
 import {
@@ -1035,6 +1036,38 @@ describe("SessionChatController", () => {
     expect(view.status.footer.commandHint).toBeUndefined();
   });
 
+  it("shows the protocol cause when a submitted turn fails", async () => {
+    const session = new FakeSession();
+    session.submit = vi.fn(async () => {
+      throw new TauSessionProtocolResponseError({
+        requestId: "submit-1",
+        error: {
+          code: "internal_error",
+          message: "failed to run session turn",
+          data: { cause: "session snapshot is invalid" },
+        },
+      });
+    });
+    const view = new FakeView();
+    const controller = new SessionChatController({
+      view,
+      session,
+      snapshot: await session.snapshot(),
+      targetLabel: "ssh host tau rpc",
+    });
+
+    controller.start();
+    controller.getInputHandlers().onSubmit("hello session");
+    await flush();
+
+    expect(view.systems).toContainEqual(
+      expect.objectContaining({
+        text: "session turn failed: failed to run session turn: session snapshot is invalid",
+        kind: "error",
+      }),
+    );
+  });
+
   it("stops visible running state when submit fails before snapshot recovery returns", async () => {
     const session = new FakeSession();
     session.rejectSubmit = true;
@@ -1591,6 +1624,57 @@ describe("SessionChatController", () => {
 
     expect(session.steer).toHaveBeenCalledWith("change direction");
     expect(view.systems).toEqual([]);
+  });
+
+  it("shows protocol causes when queueing and steering fail", async () => {
+    const session = new FakeSession();
+    session.queue = vi.fn(async () => {
+      throw new TauSessionProtocolResponseError({
+        requestId: "queue-1",
+        error: {
+          code: "internal_error",
+          message: "failed to drain pending user message",
+          data: { cause: "queued commit failed" },
+        },
+      });
+    });
+    session.steer = vi.fn(async () => {
+      throw new TauSessionProtocolResponseError({
+        requestId: "steer-1",
+        error: {
+          code: "internal_error",
+          message: "steering turn failed",
+          data: { cause: "session snapshot is invalid" },
+        },
+      });
+    });
+    const view = new FakeView();
+    const controller = new SessionChatController({
+      view,
+      session,
+      snapshot: await session.snapshot(),
+      targetLabel: "in-process",
+    });
+    controller.start();
+    controller.isStreaming = true;
+    controller.submittedTurnInProgress = true;
+
+    controller.getInputHandlers().onSubmit("queue this");
+    controller.getInputHandlers().onSteerSubmit?.("steer this");
+    await flush();
+
+    expect(view.systems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          text: "queueing failed: failed to drain pending user message: queued commit failed",
+          kind: "error",
+        }),
+        expect.objectContaining({
+          text: "steering failed: steering turn failed: session snapshot is invalid",
+          kind: "error",
+        }),
+      ]),
+    );
   });
 
   it("does not dispatch or queue commands while a submitted turn response is pending", async () => {


### PR DESCRIPTION
## why

Successive steering messages could race protocol snapshot projection. Finishing one steering continuation rebuilt a full snapshot from runtime history after the next steering message had been appended but before its semantic event was projected. The later event then attempted to append the same message again, invalidating the snapshot and failing both the steering request and the original active submit.

Related pending-message failures were also opaque or could disrupt later work: the TUI hid the protocol cause, one failed queued commit stopped the remaining queue from draining, and a throwing observer could abort shared pending-state publication.

## what

Serialize steering outcome projection through the runtime event queue and persist it as an exact user-message replacement instead of rebuilding the full mutable runtime snapshot. Steering application now relies on the already-awaited durable user event rather than issuing a redundant snapshot write.

A queued commit failure now fails and clears every remaining queued request without starting another agent turn. Pending-message observer delivery is isolated from shared session state, and TUI submit, queue, and steering errors include the protocol-provided cause.

## details

Regression coverage reproduces the original failure with three controlled hosted-session subturns and two successive steering boundaries. Additional coverage verifies that a failed queued commit clears the remaining batch without running it, plus observer isolation and actionable TUI diagnostics.

fixes #371

