### PR TITLE
make Telegram messages read naturally

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,7 @@ Execution environments and tool backends are intentionally dumb target adapters.
   - `telegram/` - Telegram runner config, CLI, and runtime wiring for `tau telegram`
   - `telegram/session_manager.ts`, `telegram/adapter.ts`, `telegram/workspace.ts` - SDK-backed Telegram session manager, Telegram polling/media adapter, and workspace preparation helpers
     - `telegram/adapter.ts` handles DM and opt-in group commands with explicit bot mentions, group mention triggers with sender-attributed pending context (including attachments, audio transcripts, and processing errors) since the previous bot-triggering turn, voice/audio transcription with transcript echoes for submitted audio turns, steering-mode submission for text/audio while a session is running, immediate attachment materialization/queueing for text/voice-triggered turns, and splits oversized Telegram replies into chunks capped at 95% of each Telegram API method's byte limit and sent 1 second apart
+    - Programmatic Telegram replies and notifications must read as natural-language sentences. Integrate project and session identifiers into the prose instead of rendering metadata-style fields such as `project: tau`, and translate internal state identifiers before displaying them.
 
   - `debug.ts` - `--debug` output
   - `config/deps.ts` - Config loader dependencies

--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ The Telegram command surface is intentionally small:
 - `/compact` summarizes older conversation context to reduce context usage.
 - `/interrupt` interrupts the active run.
 
+Programmatic Telegram replies and notifications use natural-language sentences, with project and session identifiers included in the prose rather than shown as metadata-style fields.
+
 The runner keeps tool and lifecycle progress quiet: Telegram receives command acknowledgements/errors and assistant messages, including multiple assistant progress updates from a single active run. While work is active, it shows Telegram's typing indicator in DMs and groups. Assistant messages are sent as Telegram rich markdown.
 
 Telegram DM input supports plain text, voice/audio transcription with the transcript echoed back for verification, and attachment queueing (`image/*`, PDF, `.txt`, `.md`, `.json`, `.csv`, `.yaml`, `.yml`). allowed groups are opt-in via `allowedChatIds`; non-triggering group text/captions, attachments, audio transcripts, and processing errors are buffered as sender-attributed context and the most recent 50 messages since the previous bot-triggering turn are included when a bot mention triggers a turn. group commands accept explicit bot mentions on or around the command, such as `/status@botusername`, `/status @botusername`, or `@botusername /status`.

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -92,6 +92,8 @@ Supported slash commands:
 - `/compact` summarizes older conversation context to reduce context usage.
 - `/interrupt` interrupts the active run.
 
+Programmatic replies and notifications use natural-language sentences. Project and session identifiers are included in the prose rather than shown as metadata-style fields such as `project: tau`, and internal state identifiers are translated before display.
+
 The runner uses quiet mode for tool and lifecycle progress: it does not send tool or lifecycle progress messages to Telegram. It does send assistant messages as they are committed, so one active run can send multiple assistant progress updates before it finishes. While a run is active, it refreshes Telegram's typing indicator in DMs and groups. Assistant messages are sent as Telegram rich markdown.
 
 DM and group behavior matches the previous Telegram adapter:

--- a/src/core/telegram/adapter.ts
+++ b/src/core/telegram/adapter.ts
@@ -2675,7 +2675,7 @@ class TelegramAdapterImpl {
       this.notifySession(
         event.sessionId,
         [
-          `provisioning failed for your ${formatTelegramSessionName(event.sessionId, event.targetProjectId)}.`,
+          `provisioning ${event.targetProjectId} failed in your ${formatTelegramSessionName(event.sessionId, event.projectId)}.`,
           truncateText(event.diagnostic, MAX_PROVISION_DIAGNOSTIC_CHARS),
           "the session remains available.",
         ].join("\n"),

--- a/src/core/telegram/adapter.ts
+++ b/src/core/telegram/adapter.ts
@@ -664,10 +664,8 @@ function formatTelegramSender(user: TelegramUser | undefined): string {
   return `id ${user.id}`;
 }
 
-function formatTelegramSessionName(
-  session: Pick<TelegramSessionRecord, "id" | "projectId">,
-): string {
-  return `${session.projectId} session ${session.id}`;
+function formatTelegramSessionName(sessionId: string, projectLabel: string): string {
+  return `${projectLabel} session ${sessionId}`;
 }
 
 function formatProjectLabel(projectId: string, project: TelegramProjectConfig): string {
@@ -680,16 +678,26 @@ function formatSessionStatus(
   snapshot: SessionProtocolSnapshot | undefined,
   preferredProjectId: string | undefined,
 ): string {
-  const projectStatus = `project: ${formatProjectLabel(session.projectId, project)}.`;
+  const sessionName = formatTelegramSessionName(
+    session.id,
+    formatProjectLabel(session.projectId, project),
+  );
   const preferenceStatus =
     preferredProjectId && preferredProjectId !== session.projectId
-      ? ` new chats will use: ${preferredProjectId}.`
+      ? ` new chats will use ${preferredProjectId}.`
       : "";
-  if (session.state === "failed" && session.error) {
-    return `${projectStatus} your session ${session.id} failed. ${ensureTerminalPunctuation(session.error)}${preferenceStatus}`;
+  if (session.state === "failed") {
+    const errorStatus = session.error ? ` ${ensureTerminalPunctuation(session.error)}` : "";
+    return `your ${sessionName} failed.${errorStatus}${preferenceStatus}`;
   }
 
-  const status = `${projectStatus} your session ${session.id} is ${session.state}.`;
+  const state = {
+    queued: "queued",
+    "preparing-workspace": "preparing its workspace",
+    running: "running",
+    "waiting-input": "waiting for input",
+  }[session.state];
+  const status = `your ${sessionName} is ${state}.`;
   if (!snapshot) {
     return `${status}${preferenceStatus}`;
   }
@@ -2125,7 +2133,7 @@ class TelegramAdapterImpl {
       await this.reply(
         chatId,
         preferredProjectId
-          ? `new chats will use: ${preferredProjectId}.`
+          ? `new chats will use ${preferredProjectId}.`
           : "no active session. select a project with /use_<project>.",
       );
       return;
@@ -2182,12 +2190,15 @@ class TelegramAdapterImpl {
       if (!result.interrupted) {
         await this.reply(
           chatId,
-          `nothing is running in ${formatTelegramSessionName(result.session)}.`,
+          `nothing is running in ${formatTelegramSessionName(result.session.id, result.session.projectId)}.`,
         );
         return;
       }
 
-      await this.reply(chatId, `stopping ${formatTelegramSessionName(result.session)}.`);
+      await this.reply(
+        chatId,
+        `stopping ${formatTelegramSessionName(result.session.id, result.session.projectId)}.`,
+      );
     } catch (error) {
       await this.reply(chatId, this.formatManagerError(error));
     }
@@ -2664,8 +2675,7 @@ class TelegramAdapterImpl {
       this.notifySession(
         event.sessionId,
         [
-          formatSessionHeadline(event.sessionId, "provision failed"),
-          `project: ${event.targetProjectId}`,
+          `provisioning failed for your ${formatTelegramSessionName(event.sessionId, event.targetProjectId)}.`,
           truncateText(event.diagnostic, MAX_PROVISION_DIAGNOSTIC_CHARS),
           "the session remains available.",
         ].join("\n"),
@@ -2795,21 +2805,17 @@ class TelegramAdapterImpl {
     projectId: string,
     state: "started" | "finished" | "failed",
   ): void {
-    const stateLabel = {
-      started: "run started",
-      finished: "run finished",
-      failed: "run failed",
-    }[state];
-
+    const sessionName = formatTelegramSessionName(sessionId, projectId);
     if (state === "failed") {
-      this.notifySession(sessionId, `something went wrong in ${projectId} session ${sessionId}.`);
+      this.notifySession(sessionId, `something went wrong in your ${sessionName}.`);
       return;
     }
 
-    this.notifySession(
-      sessionId,
-      [formatSessionHeadline(sessionId, stateLabel), `project: ${projectId}`].join("\n"),
-    );
+    const stateLabel = {
+      started: "started a run",
+      finished: "finished its run",
+    }[state];
+    this.notifySession(sessionId, `your ${sessionName} ${stateLabel}.`);
   }
 
   private notifySession(sessionId: string, text: string, options: { rich?: boolean } = {}): void {
@@ -2914,7 +2920,7 @@ class TelegramAdapterImpl {
   }
 
   private formatSessionReady(sessionId: string, projectId: string): string {
-    return `all set, your ${projectId} session ${sessionId} is ready.`;
+    return `all set, your ${formatTelegramSessionName(sessionId, projectId)} is ready.`;
   }
 
   private formatMessageQueued(sessionId: string): string {

--- a/test/telegram_adapter.test.js
+++ b/test/telegram_adapter.test.js
@@ -324,7 +324,7 @@ describe("telegram adapter", () => {
     }
   });
 
-  it("reports composite project status with model, reasoning, context, and cost", async () => {
+  it("reports composite project status and provision failures", async () => {
     const apiHarness = createApiHarness([
       [
         {
@@ -373,6 +373,21 @@ describe("telegram adapter", () => {
       );
       expect(apiHarness.sendMessages.map((entry) => entry.text)).toContain(
         "your platform (alpha, beta) session s1 is waiting for input. it is using Claude Opus 4.6 with medium reasoning. context usage is 6.0% of 200k tokens. cumulative cost is $0.12.",
+      );
+
+      managerHarness.manager.emit({
+        type: "session-provision-failed",
+        sessionId: "s1",
+        projectId: "platform",
+        targetProjectId: "alpha",
+        diagnostic: "provision exited with code 17\ndependencies failed",
+      });
+      await waitFor(() =>
+        apiHarness.sendMessages.some(
+          (entry) =>
+            entry.text ===
+            "provisioning alpha failed in your platform session s1.\nprovision exited with code 17\ndependencies failed\nthe session remains available.",
+        ),
       );
     } finally {
       await adapter.close();
@@ -1128,7 +1143,7 @@ describe("telegram adapter", () => {
         apiHarness.sendMessages.some(
           (entry) =>
             entry.text ===
-            "provisioning failed for your demo session s1.\nprovision exited with code 17\ndependencies failed\nthe session remains available.",
+            "provisioning demo failed in your demo session s1.\nprovision exited with code 17\ndependencies failed\nthe session remains available.",
         ),
       );
 

--- a/test/telegram_adapter.test.js
+++ b/test/telegram_adapter.test.js
@@ -372,7 +372,7 @@ describe("telegram adapter", () => {
         apiHarness.sendMessages.some((entry) => String(entry.text).includes("context usage")),
       );
       expect(apiHarness.sendMessages.map((entry) => entry.text)).toContain(
-        "project: platform (alpha, beta). your session s1 is waiting-input. it is using Claude Opus 4.6 with medium reasoning. context usage is 6.0% of 200k tokens. cumulative cost is $0.12.",
+        "your platform (alpha, beta) session s1 is waiting for input. it is using Claude Opus 4.6 with medium reasoning. context usage is 6.0% of 200k tokens. cumulative cost is $0.12.",
       );
     } finally {
       await adapter.close();
@@ -450,7 +450,7 @@ describe("telegram adapter", () => {
       expect(managerHarness.manager.closeSession).toHaveBeenCalledTimes(1);
       expect(apiHarness.sendMessages.map((entry) => entry.text)).toEqual([
         "new chats will use beta.",
-        "project: alpha. your session s1 is waiting-input. new chats will use: beta.",
+        "your alpha session s1 is waiting for input. new chats will use beta.",
       ]);
     } finally {
       await adapter.close();
@@ -484,7 +484,7 @@ describe("telegram adapter", () => {
 
     try {
       await waitFor(() => apiHarness.sendMessages.length === 1);
-      expect(apiHarness.sendMessages[0].text).toBe("new chats will use: alpha.");
+      expect(apiHarness.sendMessages[0].text).toBe("new chats will use alpha.");
     } finally {
       await adapter.close();
     }
@@ -559,7 +559,7 @@ describe("telegram adapter", () => {
         { mode: "steer" },
       );
       expect(apiHarness.sendMessages.map((entry) => entry.text)).toContain(
-        "project: demo. your session restored-session is waiting-input. it is using Claude Opus 4.6 with medium reasoning. context usage is 6.0% of 200k tokens. cumulative cost is $0.12.",
+        "your demo session restored-session is waiting for input. it is using Claude Opus 4.6 with medium reasoning. context usage is 6.0% of 200k tokens. cumulative cost is $0.12.",
       );
       expect(apiHarness.sendMessages).toEqual(
         expect.arrayContaining([
@@ -1127,8 +1127,8 @@ describe("telegram adapter", () => {
       await waitFor(() =>
         apiHarness.sendMessages.some(
           (entry) =>
-            String(entry.text).includes("dependencies failed") &&
-            String(entry.text).includes("the session remains available"),
+            entry.text ===
+            "provisioning failed for your demo session s1.\nprovision exited with code 17\ndependencies failed\nthe session remains available.",
         ),
       );
 


### PR DESCRIPTION
## why

Telegram status messages exposed project context as metadata such as `project: tau` and leaked internal state names such as `waiting-input`. These bot-authored messages should read like natural conversation.

## what

Project and session identifiers are now folded into prose across status, preference, provisioning, interruption, readiness, and lifecycle messages. Status output also translates internal session states into user-facing language. The Telegram adapter tests cover the revised status and provisioning messages, and the presentation rule is documented in AGENTS.md, README.md, and the Telegram guide.

## details

I treated the request as applying to every programmatic Telegram message that combines project and session context, including currently quiet lifecycle paths, rather than only the `/status` literal. There are no remaining questions.

fixes #375
