### PR TITLE
show goal state in Telegram status

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ The Telegram command surface is intentionally small:
 
 - `/use_<projectId>` selects the configured project used by future `/new` sessions without changing the active session.
 - `/new` creates a session from the selected project, replacing the previous active session if one exists.
-- `/status` reports the active project and session details, plus a different next-session project preference when selected.
+- `/status` reports the active project and session details, including active or blocked goal state without the goal objective, plus a different next-session project preference when selected.
 - `/effort_low`, `/effort_medium`, `/effort_high`, and `/effort_xhigh` set the active session's reasoning effort.
 - `/compact` summarizes older conversation context to reduce context usage.
 - `/interrupt` interrupts the active run.

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -88,7 +88,7 @@ Supported slash commands:
 
 - `/use_<projectId>` stores the project to use for future `/new` sessions in that Telegram DM or group. It does not create, close, or switch the active session. The preference survives runner restarts. `defaultProjectId` provides the initial preference, and a sole allowed project is selected automatically.
 - `/new` closes the active session, if any, cleans its workspace, and creates its replacement using the stored project preference.
-- `/status` reports the active session's project, including composite members, plus model, reasoning effort, context usage, and cumulative cost when available. If the next-session preference differs, it reports both. With no active session, it reports the current preference.
+- `/status` reports the active session's project, including composite members, plus model, reasoning effort, context usage, and cumulative cost when available. When the session has a goal, it reports whether the goal is active or blocked without including its objective. If the next-session preference differs, it reports both. With no active session, it reports the current preference.
 - `/effort_low`, `/effort_medium`, `/effort_high`, and `/effort_xhigh` set the active session's reasoning effort. Changes made during a run apply to the next independently submitted or queued turn.
 - `/compact` summarizes older conversation context to reduce context usage.
 - `/interrupt` interrupts the active run.

--- a/src/core/telegram/adapter.ts
+++ b/src/core/telegram/adapter.ts
@@ -710,11 +710,16 @@ function formatSessionStatus(
     return `${status}${preferenceStatus}`;
   }
 
+  const goalStatus = snapshot.goal
+    ? snapshot.goal.status === "active"
+      ? " it is pursuing a goal."
+      : " its goal is blocked."
+    : "";
   const model = snapshot.bootstrap.model.name || snapshot.bootstrap.model.id;
   const reasoning = snapshot.settings.reasoning ?? "none";
   const context = formatTelegramContextUsage(snapshot);
   const cost = formatTelegramSessionCost(getTelegramSessionCostTotal(snapshot));
-  return `${status} it is using ${model} with ${reasoning} reasoning. context usage is ${context}. cumulative cost is ${cost}.${preferenceStatus}`;
+  return `${status}${goalStatus} it is using ${model} with ${reasoning} reasoning. context usage is ${context}. cumulative cost is ${cost}.${preferenceStatus}`;
 }
 
 function ensureTerminalPunctuation(text: string): string {

--- a/test/telegram_adapter.test.js
+++ b/test/telegram_adapter.test.js
@@ -425,6 +425,60 @@ describe("telegram adapter", () => {
     }
   });
 
+  it("preserves detailed status when there is no goal", async () => {
+    const chatId = 13;
+    const apiHarness = createApiHarness([
+      [
+        {
+          update_id: 1,
+          message: {
+            chat: { id: chatId, type: "private" },
+            from: { id: 7 },
+            text: "/status",
+          },
+        },
+      ],
+    ]);
+    const managerHarness = createSessionManagerHarness([
+      {
+        id: "s1",
+        projectId: "platform",
+        ownerId: ownerIdForChat(chatId),
+        state: "waiting-input",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+        snapshot: createStatusSnapshot(),
+      },
+    ]);
+
+    const adapter = await startAdapter({
+      botToken: "token",
+      projects: {
+        alpha: { repo: "owner/alpha" },
+        beta: { repo: "owner/beta" },
+        platform: {
+          projectIds: ["alpha", "beta"],
+          persona: "gpt-5.6-sol-coder:high",
+        },
+      },
+      sessionManager: managerHarness.manager,
+      api: apiHarness.api,
+      pollIntervalMs: 1,
+      requestTimeoutSeconds: 1,
+    });
+
+    try {
+      await waitFor(() =>
+        apiHarness.sendMessages.some((entry) => String(entry.text).includes("context usage")),
+      );
+      expect(apiHarness.sendMessages.map((entry) => entry.text)).toContain(
+        "your platform (alpha, beta) session s1 is waiting for input. it is using Claude Opus 4.6 with medium reasoning. context usage is 6.0% of 200k tokens. cumulative cost is $0.12.",
+      );
+    } finally {
+      await adapter.close();
+    }
+  });
+
   it("uses project selectors only for future sessions", async () => {
     const apiHarness = createApiHarness([
       [

--- a/test/telegram_adapter.test.js
+++ b/test/telegram_adapter.test.js
@@ -127,6 +127,7 @@ function createStatusSnapshot(overrides = {}) {
     sessionId: "tau-session",
     revision: 1,
     lifecycle: "idle",
+    goal: null,
     costTotal: 0.12345,
     settings: {
       personaId: "default",
@@ -348,7 +349,7 @@ describe("telegram adapter", () => {
     }
   });
 
-  it("reports composite project status and provision failures", async () => {
+  it("reports composite project status, active goal state, and provision failures", async () => {
     const apiHarness = createApiHarness([
       [
         {
@@ -371,7 +372,13 @@ describe("telegram adapter", () => {
     ]);
 
     const managerHarness = createSessionManagerHarness([], {
-      createSnapshot: () => createStatusSnapshot(),
+      createSnapshot: () =>
+        createStatusSnapshot({
+          goal: {
+            objective: "A very long goal objective that must not appear in Telegram status output",
+            status: "active",
+          },
+        }),
     });
 
     const adapter = await startAdapter({
@@ -396,7 +403,7 @@ describe("telegram adapter", () => {
         apiHarness.sendMessages.some((entry) => String(entry.text).includes("context usage")),
       );
       expect(apiHarness.sendMessages.map((entry) => entry.text)).toContain(
-        "your platform (alpha, beta) session s1 is waiting for input. it is using Claude Opus 4.6 with medium reasoning. context usage is 6.0% of 200k tokens. cumulative cost is $0.12.",
+        "your platform (alpha, beta) session s1 is waiting for input. it is pursuing a goal. it is using Claude Opus 4.6 with medium reasoning. context usage is 6.0% of 200k tokens. cumulative cost is $0.12.",
       );
 
       managerHarness.manager.emit({
@@ -757,7 +764,12 @@ describe("telegram adapter", () => {
           state: "waiting-input",
           createdAt: "2024-01-01T00:00:00.000Z",
           updatedAt: "2024-01-01T00:00:00.000Z",
-          snapshot: createStatusSnapshot(),
+          snapshot: createStatusSnapshot({
+            goal: {
+              objective: "A blocked goal objective that must not appear in Telegram status output",
+              status: "blocked",
+            },
+          }),
         },
       ],
       {
@@ -795,7 +807,7 @@ describe("telegram adapter", () => {
         { mode: "steer" },
       );
       expect(apiHarness.sendMessages.map((entry) => entry.text)).toContain(
-        "your demo session restored-session is waiting for input. it is using Claude Opus 4.6 with medium reasoning. context usage is 6.0% of 200k tokens. cumulative cost is $0.12.",
+        "your demo session restored-session is waiting for input. its goal is blocked. it is using Claude Opus 4.6 with medium reasoning. context usage is 6.0% of 200k tokens. cumulative cost is $0.12.",
       );
       expect(apiHarness.sendMessages).toEqual(
         expect.arrayContaining([


### PR DESCRIPTION
## why

Telegram `/status` reports whether a session is running or waiting, but it does not reveal when the session is autonomously pursuing a goal. That makes active goal work invisible outside the TUI.

The issue discussion established that the goal objective must not be included because it can be arbitrarily long.

## what

Telegram status replies now add a short goal-state sentence when the session snapshot has a goal. Active goals report that the session is pursuing a goal, while blocked goals report that its goal is blocked. Replies with no goal remain unchanged.

The Telegram adapter coverage exercises both goal states with objective text that is intentionally absent from the replies.

## details

This is derived directly from the canonical snapshot goal state, so no additional Telegram session state or protocol fields are introduced. There are no remaining implementation questions.

fixes #377
