### PR TITLE
report stale auth refreshes

### DIFF
--- a/src/core/auth/cli.ts
+++ b/src/core/auth/cli.ts
@@ -273,6 +273,24 @@ export async function runListCommand(options: {
       const plan = account.plan ? `[${account.plan}]` : undefined;
       const headerSegments = [`  ${marker}`, label, plan].filter(Boolean);
       log(headerSegments.join(" "));
+      if (account.credentialRefreshStatus === "failed") {
+        log(
+          chalk.red(
+            account.credentialExpired
+              ? '    credentials expired; refresh failed, run "tau auth login codex" to re-authenticate'
+              : "    credential refresh failed; stored credentials have not expired",
+          ),
+        );
+      }
+      if (account.usageRefreshStatus === "failed") {
+        log(
+          chalk.yellow(
+            account.usage
+              ? "    usage refresh failed; showing stale cached usage"
+              : "    usage refresh failed; usage unavailable",
+          ),
+        );
+      }
       if (account.usage) {
         for (const window of account.usage.windows) {
           const labelText = formatWindowLabel(window.windowSeconds) ?? window.name;

--- a/src/core/auth/providers/openai_codex.ts
+++ b/src/core/auth/providers/openai_codex.ts
@@ -38,6 +38,15 @@ class UnexpectedUsageWindowError extends Error {
 type CodexAccount = StoredOAuthAccount;
 type UnknownRecord = Record<string, unknown>;
 type AccountPriorityCandidate = { usage?: AuthAccountUsage; index: number };
+type RefreshStatus = "not-requested" | "succeeded" | "failed";
+type AccountRefreshResult = {
+  account: CodexAccount;
+  refreshStatus: Exclude<RefreshStatus, "not-requested">;
+};
+type UsageSnapshotResult = {
+  usage?: AuthAccountUsage;
+  refreshStatus: RefreshStatus;
+};
 
 export class OpenAICodexAdapter implements AuthProviderAdapter {
   readonly id = PROVIDER_ID;
@@ -96,11 +105,11 @@ export class OpenAICodexAdapter implements AuthProviderAdapter {
 
     const accountInfo = await Promise.all(
       accounts.map(async (account): Promise<AuthAccountInfo | undefined> => {
-        const refreshedAccount = await this.refreshAccountIdentity(authStorage, account);
-        if (!refreshedAccount) {
+        const accountRefresh = await this.refreshAccountIdentity(authStorage, account);
+        if (!accountRefresh) {
           return undefined;
         }
-        const usage = await this.getUsageSnapshot(authStorage, refreshedAccount, {
+        const usageSnapshot = await this.getUsageSnapshot(authStorage, accountRefresh.account, {
           forceRefresh: true,
         });
         const currentAccount = getAccounts(authStorage).find(
@@ -110,12 +119,20 @@ export class OpenAICodexAdapter implements AuthProviderAdapter {
           return undefined;
         }
         const identity = decodeIdentity(currentAccount.access);
+        const credentialRefreshStatus =
+          accountRefresh.refreshStatus === "succeeded" ||
+          !hasSameCredentialGeneration(currentAccount, accountRefresh.account)
+            ? "succeeded"
+            : "failed";
         return {
           provider: PROVIDER_ID,
           accountId: currentAccount.accountId,
           email: identity.email,
           plan: identity.plan,
-          usage,
+          credentialExpired: Date.now() >= currentAccount.expires,
+          credentialRefreshStatus,
+          usage: usageSnapshot.usage,
+          usageRefreshStatus: usageSnapshot.refreshStatus === "succeeded" ? "succeeded" : "failed",
         } satisfies AuthAccountInfo;
       }),
     );
@@ -146,7 +163,7 @@ export class OpenAICodexAdapter implements AuthProviderAdapter {
           apiKey,
           forceRefresh: true,
         });
-        usage = refreshed ?? usage;
+        usage = refreshed.usage ?? usage;
       }
 
       if (isUsageUsable(usage, now)) {
@@ -209,12 +226,12 @@ export class OpenAICodexAdapter implements AuthProviderAdapter {
     const account = getAccounts(authStorage).find((entry) => entry.accountId === accountId);
     if (!account) return false;
 
-    const usage = await this.getUsageSnapshot(authStorage, account, {
+    const usageSnapshot = await this.getUsageSnapshot(authStorage, account, {
       apiKey: options?.apiKey,
       refreshIfExpired: true,
       refreshIfMissing: true,
     });
-    return isUsageUsable(usage, nowSeconds());
+    return isUsageUsable(usageSnapshot.usage, nowSeconds());
   }
 
   async handleProviderError(
@@ -232,7 +249,7 @@ export class OpenAICodexAdapter implements AuthProviderAdapter {
       forceRefresh: true,
       refreshIfMissing: true,
     });
-    if (!selectedUsage || !isUsageExhausted(selectedUsage)) return false;
+    if (!selectedUsage.usage || !isUsageExhausted(selectedUsage.usage)) return false;
 
     for (const account of accounts) {
       if (account.accountId === accountId) continue;
@@ -248,7 +265,7 @@ export class OpenAICodexAdapter implements AuthProviderAdapter {
   private async refreshAccountIdentity(
     authStorage: AuthStorage,
     account: CodexAccount,
-  ): Promise<CodexAccount | undefined> {
+  ): Promise<AccountRefreshResult | undefined> {
     try {
       const refreshedCredentials = await openaiCodexOAuth.refresh(toOAuthCredential(account));
       const updateResult = updateStoredOAuthAccount(authStorage, account, (current) =>
@@ -256,10 +273,15 @@ export class OpenAICodexAdapter implements AuthProviderAdapter {
           ? mergeUpdatedCredentials(current, refreshedCredentials)
           : current,
       );
-      return updateResult.status === "missing" ? undefined : updateResult.account;
+      return updateResult.status === "missing"
+        ? undefined
+        : { account: updateResult.account, refreshStatus: "succeeded" };
     } catch {
       authStorage.reload();
-      return getAccounts(authStorage).find((entry) => entry.accountId === account.accountId);
+      const currentAccount = getAccounts(authStorage).find(
+        (entry) => entry.accountId === account.accountId,
+      );
+      return currentAccount ? { account: currentAccount, refreshStatus: "failed" } : undefined;
     }
   }
 
@@ -272,38 +294,41 @@ export class OpenAICodexAdapter implements AuthProviderAdapter {
       refreshIfExpired?: boolean;
       refreshIfMissing?: boolean;
     },
-  ): Promise<AuthAccountUsage | undefined> {
+  ): Promise<UsageSnapshotResult> {
     const now = nowSeconds();
     const usage = account.usage;
     const shouldRefresh =
       Boolean(options?.forceRefresh) ||
       (Boolean(options?.refreshIfMissing) && !usage) ||
       (Boolean(options?.refreshIfExpired) && usage !== undefined && isUsageExpired(usage, now));
-    if (!shouldRefresh) return usage;
+    if (!shouldRefresh) return { usage, refreshStatus: "not-requested" };
 
     try {
       const apiKey =
         options?.apiKey ?? (await this.getApiKeyForAccount(authStorage, account.accountId));
-      if (!apiKey) return usage;
+      if (!apiKey) return { usage, refreshStatus: "failed" };
 
       const refreshedAccount =
         getAccounts(authStorage).find((entry) => entry.accountId === account.accountId) ?? account;
       const refreshedUsage = await fetchUsage(apiKey, refreshedAccount.providerAccountId);
-      if (!refreshedUsage) return usage;
+      if (!refreshedUsage) return { usage, refreshStatus: "failed" };
 
       const updateResult = updateStoredOAuthAccount(authStorage, refreshedAccount, (current) => ({
         ...current,
         usage: refreshedUsage,
       }));
       if (updateResult.status === "missing") {
-        return undefined;
+        return { refreshStatus: "failed" };
       }
-      return updateResult.status === "changed" ? updateResult.account.usage : refreshedUsage;
+      return {
+        usage: updateResult.status === "changed" ? updateResult.account.usage : refreshedUsage,
+        refreshStatus: "succeeded",
+      };
     } catch (error) {
       if (error instanceof UnexpectedUsageWindowError) {
         throw error;
       }
-      return usage;
+      return { usage, refreshStatus: "failed" };
     }
   }
 }

--- a/src/core/auth/providers/openai_codex.ts
+++ b/src/core/auth/providers/openai_codex.ts
@@ -281,7 +281,14 @@ export class OpenAICodexAdapter implements AuthProviderAdapter {
       const currentAccount = getAccounts(authStorage).find(
         (entry) => entry.accountId === account.accountId,
       );
-      return currentAccount ? { account: currentAccount, refreshStatus: "failed" } : undefined;
+      return currentAccount
+        ? {
+            account: currentAccount,
+            refreshStatus: hasSameCredentialGeneration(currentAccount, account)
+              ? "failed"
+              : "succeeded",
+          }
+        : undefined;
     }
   }
 
@@ -322,7 +329,7 @@ export class OpenAICodexAdapter implements AuthProviderAdapter {
       }
       return {
         usage: updateResult.status === "changed" ? updateResult.account.usage : refreshedUsage,
-        refreshStatus: "succeeded",
+        refreshStatus: updateResult.status === "changed" ? "failed" : "succeeded",
       };
     } catch (error) {
       if (error instanceof UnexpectedUsageWindowError) {

--- a/src/core/auth/types.ts
+++ b/src/core/auth/types.ts
@@ -42,5 +42,8 @@ export type AuthAccountInfo = {
   accountId: string;
   email?: string;
   plan?: string;
+  credentialExpired: boolean;
+  credentialRefreshStatus: "succeeded" | "failed";
   usage?: AuthAccountUsage;
+  usageRefreshStatus: "succeeded" | "failed";
 };

--- a/test/auth_cli.test.js
+++ b/test/auth_cli.test.js
@@ -1,10 +1,31 @@
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+const { codexRefresh } = vi.hoisted(() => ({
+  codexRefresh: vi.fn(),
+}));
+
+vi.mock("@earendil-works/pi-ai/providers/openai-codex", () => ({
+  openaiCodexProvider: () => ({
+    auth: {
+      oauth: {
+        login: vi.fn(),
+        refresh: codexRefresh,
+        toAuth: vi.fn(),
+      },
+    },
+  }),
+}));
 
 import { AuthStorage } from "../dist/core/auth/auth_storage.js";
-import { parseAuthCliArgs, runLoginCommand, runLogoutCommand } from "../dist/core/auth/cli.js";
+import {
+  parseAuthCliArgs,
+  runListCommand,
+  runLoginCommand,
+  runLogoutCommand,
+} from "../dist/core/auth/cli.js";
 
 function toBase64Url(value) {
   return Buffer.from(value, "utf-8")
@@ -109,6 +130,60 @@ describe("auth cli", () => {
 
       const removed = JSON.parse(readFileSync(fx.authPath, "utf-8"));
       expect(removed.providers["openai-codex"].accounts.length).toBe(0);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("warns when account and usage refreshes fail", async () => {
+    const fx = createTempAuthPath();
+    try {
+      writeFileSync(
+        fx.authPath,
+        JSON.stringify({
+          providers: {
+            "openai-codex": {
+              accounts: [
+                {
+                  type: "oauth",
+                  accountId: "acct-stale",
+                  providerAccountId: "acct-stale",
+                  access: createAccessToken({
+                    accountId: "acct-stale",
+                    email: "stale@example.com",
+                    plan: "pro",
+                  }),
+                  refresh: "refresh-stale",
+                  expires: 0,
+                  usage: {
+                    windows: [
+                      {
+                        name: "primary",
+                        usedPercent: 0,
+                        resetAt: 1,
+                        windowSeconds: 604800,
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        }),
+        { mode: 0o600 },
+      );
+      codexRefresh.mockRejectedValue(new Error("refresh token rejected"));
+      const output = [];
+
+      await runListCommand({
+        authStorage: new AuthStorage(fx.authPath),
+        log: (message) => output.push(message),
+      });
+
+      expect(output).toContain(
+        '    credentials expired; refresh failed, run "tau auth login codex" to re-authenticate',
+      );
+      expect(output).toContain("    usage refresh failed; showing stale cached usage");
     } finally {
       fx.cleanup();
     }

--- a/test/auth_storage.test.js
+++ b/test/auth_storage.test.js
@@ -572,6 +572,173 @@ describe("AuthManager and TauCredentialStore", () => {
     }
   });
 
+  it("accepts credentials replaced while a listing refresh fails", async () => {
+    const fx = createTempAuthPath();
+    try {
+      const originalAccess = createAccessToken({
+        accountId: "acct-credential-race",
+        email: "old@example.com",
+        plan: "plus",
+      });
+      const replacementAccess = createAccessToken({
+        accountId: "acct-credential-race",
+        email: "new@example.com",
+        plan: "pro",
+      });
+      writeFileSync(
+        fx.authPath,
+        JSON.stringify({
+          providers: {
+            "openai-codex": {
+              accounts: [
+                {
+                  type: "oauth",
+                  accountId: "acct-credential-race",
+                  providerAccountId: "acct-credential-race",
+                  access: originalAccess,
+                  refresh: "refresh-original",
+                  expires: 0,
+                },
+              ],
+            },
+          },
+        }),
+        { mode: 0o600 },
+      );
+      const refreshStarted = deferred();
+      const releaseRefresh = deferred();
+      codexRefresh.mockImplementation(async () => {
+        refreshStarted.resolve();
+        return await releaseRefresh.promise;
+      });
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => ({
+          ok: true,
+          json: async () => ({
+            rate_limit: {
+              primary_window: {
+                used_percent: 12,
+                reset_at: 4102444800,
+                limit_window_seconds: 18000,
+              },
+            },
+          }),
+        })),
+      );
+
+      const listing = new AuthManager(new AuthStorage(fx.authPath)).listProviderAccounts();
+      await refreshStarted.promise;
+
+      new AuthManager(new AuthStorage(fx.authPath)).addOAuthAccount("openai-codex", {
+        type: "oauth",
+        access: replacementAccess,
+        refresh: "refresh-replacement",
+        expires: Number.MAX_SAFE_INTEGER,
+        accountId: "acct-credential-race",
+      });
+      releaseRefresh.reject(new Error("refresh token rejected"));
+
+      await expect(listing).resolves.toEqual([
+        expect.objectContaining({
+          accounts: [
+            expect.objectContaining({
+              email: "new@example.com",
+              credentialRefreshStatus: "succeeded",
+              usageRefreshStatus: "succeeded",
+            }),
+          ],
+        }),
+      ]);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("reports usage as stale when a credential replacement discards its refresh", async () => {
+    const fx = createTempAuthPath();
+    try {
+      const originalAccess = createAccessToken({
+        accountId: "acct-usage-race",
+        email: "old@example.com",
+        plan: "plus",
+      });
+      const replacementAccess = createAccessToken({
+        accountId: "acct-usage-race",
+        email: "new@example.com",
+        plan: "pro",
+      });
+      writeFileSync(
+        fx.authPath,
+        JSON.stringify({
+          providers: {
+            "openai-codex": {
+              accounts: [
+                {
+                  type: "oauth",
+                  accountId: "acct-usage-race",
+                  providerAccountId: "acct-usage-race",
+                  access: originalAccess,
+                  refresh: "refresh-original",
+                  expires: Number.MAX_SAFE_INTEGER,
+                },
+              ],
+            },
+          },
+        }),
+        { mode: 0o600 },
+      );
+      const fetchStarted = deferred();
+      const releaseFetch = deferred();
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => {
+          fetchStarted.resolve();
+          await releaseFetch.promise;
+          return {
+            ok: true,
+            json: async () => ({
+              rate_limit: {
+                primary_window: {
+                  used_percent: 12,
+                  reset_at: 4102444800,
+                  limit_window_seconds: 18000,
+                },
+              },
+            }),
+          };
+        }),
+      );
+
+      const listing = new AuthManager(new AuthStorage(fx.authPath)).listProviderAccounts();
+      await fetchStarted.promise;
+
+      new AuthManager(new AuthStorage(fx.authPath)).addOAuthAccount("openai-codex", {
+        type: "oauth",
+        access: replacementAccess,
+        refresh: "refresh-replacement",
+        expires: Number.MAX_SAFE_INTEGER,
+        accountId: "acct-usage-race",
+      });
+      releaseFetch.resolve();
+
+      await expect(listing).resolves.toEqual([
+        expect.objectContaining({
+          accounts: [
+            expect.objectContaining({
+              email: "new@example.com",
+              credentialRefreshStatus: "succeeded",
+              usage: undefined,
+              usageRefreshStatus: "failed",
+            }),
+          ],
+        }),
+      ]);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
   it("uses codex failover selection in pi-ai credential store", async () => {
     const fx = createTempAuthPath();
     try {

--- a/test/auth_storage.test.js
+++ b/test/auth_storage.test.js
@@ -501,12 +501,72 @@ describe("AuthManager and TauCredentialStore", () => {
       const authManager = new AuthManager(storage);
 
       const providers = await authManager.listProviderAccounts();
-      expect(providers[0]?.accounts[0]?.plan).toBe("pro");
+      expect(providers[0]?.accounts[0]).toMatchObject({
+        plan: "pro",
+        credentialExpired: false,
+        credentialRefreshStatus: "succeeded",
+        usageRefreshStatus: "succeeded",
+      });
 
       const saved = JSON.parse(readFileSync(fx.authPath, "utf-8"));
       const account = saved.providers["openai-codex"].accounts[0];
       expect(account.access).toBe(refreshedAccess);
       expect(account.refresh).toBe("refresh-plan-next");
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("reports stale codex account data when listing refreshes fail", async () => {
+    const fx = createTempAuthPath();
+    try {
+      const access = createAccessToken({
+        accountId: "acct-stale",
+        email: "stale@example.com",
+        plan: "pro",
+      });
+      const usage = {
+        windows: [
+          {
+            name: "primary",
+            usedPercent: 0,
+            resetAt: 1,
+            windowSeconds: 604800,
+          },
+        ],
+      };
+      writeFileSync(
+        fx.authPath,
+        JSON.stringify({
+          providers: {
+            "openai-codex": {
+              accounts: [
+                {
+                  type: "oauth",
+                  accountId: "acct-stale",
+                  providerAccountId: "acct-stale",
+                  access,
+                  refresh: "refresh-stale",
+                  expires: 0,
+                  usage,
+                },
+              ],
+            },
+          },
+        }),
+        { mode: 0o600 },
+      );
+      codexRefresh.mockRejectedValue(new Error("refresh token rejected"));
+
+      const providers = await new AuthManager(new AuthStorage(fx.authPath)).listProviderAccounts();
+
+      expect(providers[0]?.accounts[0]).toMatchObject({
+        email: "stale@example.com",
+        credentialExpired: true,
+        credentialRefreshStatus: "failed",
+        usage,
+        usageRefreshStatus: "failed",
+      });
     } finally {
       fx.cleanup();
     }


### PR DESCRIPTION
## why

`tau auth list` silently fell back to cached Codex account and usage data when refreshes failed. Expired credentials could therefore appear alongside stale quota data without explaining that the account could no longer refresh.

## what

Track credential and usage refresh outcomes separately when listing Codex accounts. The CLI now identifies expired credentials that require re-authentication, warns about refresh failures for unexpired credentials, and labels cached usage as stale when its refresh fails.

Add provider and CLI regression coverage for successful refreshes and stale fallback behavior.
