### PR TITLE
correct gpt-5.6 terra and luna pricing

### DIFF
--- a/src/core/models/tau_model_overrides.ts
+++ b/src/core/models/tau_model_overrides.ts
@@ -1,15 +1,81 @@
-import type { Api, Model } from "@earendil-works/pi-ai";
+import { isDeepStrictEqual } from "node:util";
+import type { Api, Model, ModelCost } from "@earendil-works/pi-ai";
 
 const GPT_5_6_CODEX_MODEL_IDS = new Set(["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]);
 
+type BaseModelCost = Omit<ModelCost, "tiers">;
+
+function withLongContextPricing(cost: BaseModelCost): ModelCost {
+  const round = (value: number) => Number(value.toFixed(6));
+
+  return {
+    ...cost,
+    tiers: [
+      {
+        inputTokensAbove: 272_000,
+        input: round(cost.input * 2),
+        output: round(cost.output * 1.5),
+        cacheRead: round(cost.cacheRead * 2),
+        cacheWrite: round(cost.cacheWrite * 2),
+      },
+    ],
+  };
+}
+
+const GPT_5_6_COST_OVERRIDES: Record<string, { current: ModelCost; corrected: ModelCost }> = {
+  "gpt-5.6-luna": {
+    current: withLongContextPricing({
+      input: 1,
+      output: 6,
+      cacheRead: 0.1,
+      cacheWrite: 1.25,
+    }),
+    corrected: withLongContextPricing({
+      input: 0.2,
+      output: 1.2,
+      cacheRead: 0.02,
+      cacheWrite: 0.25,
+    }),
+  },
+  "gpt-5.6-terra": {
+    current: withLongContextPricing({
+      input: 2.5,
+      output: 15,
+      cacheRead: 0.25,
+      cacheWrite: 3.125,
+    }),
+    corrected: withLongContextPricing({
+      input: 2,
+      output: 12,
+      cacheRead: 0.2,
+      cacheWrite: 2.5,
+    }),
+  },
+};
+
 export function applyTauModelOverrides(model: Model<Api>): Model<Api> {
-  if (
-    model.provider !== "openai-codex" ||
-    model.contextWindow !== 272_000 ||
-    !GPT_5_6_CODEX_MODEL_IDS.has(model.id)
-  ) {
+  const costOverride =
+    model.provider === "openai" || model.provider === "openai-codex"
+      ? GPT_5_6_COST_OVERRIDES[model.id]
+      : undefined;
+  const cost =
+    costOverride && isDeepStrictEqual(model.cost, costOverride.current)
+      ? costOverride.corrected
+      : undefined;
+  const contextWindow =
+    model.provider === "openai-codex" &&
+    model.contextWindow === 272_000 &&
+    GPT_5_6_CODEX_MODEL_IDS.has(model.id)
+      ? 372_000
+      : undefined;
+
+  if (!cost && contextWindow === undefined) {
     return model;
   }
 
-  return { ...model, contextWindow: 372_000 };
+  return {
+    ...model,
+    ...(cost ? { cost } : {}),
+    ...(contextWindow !== undefined ? { contextWindow } : {}),
+  };
 }

--- a/test/model_catalog.test.js
+++ b/test/model_catalog.test.js
@@ -101,21 +101,62 @@ describe("model catalog", () => {
     expect(terra.provider).toBe("openai-codex");
     expect(terra.api).toBe("openai-codex-responses");
     expect(terra.cost).toEqual({
-      input: 2.5,
-      output: 15,
-      cacheRead: 0.25,
-      cacheWrite: 3.125,
+      input: 2,
+      output: 12,
+      cacheRead: 0.2,
+      cacheWrite: 2.5,
       tiers: [
         {
           inputTokensAbove: 272000,
-          input: 5,
-          output: 22.5,
-          cacheRead: 0.5,
-          cacheWrite: 6.25,
+          input: 4,
+          output: 18,
+          cacheRead: 0.4,
+          cacheWrite: 5,
         },
       ],
     });
     expect(terra.contextWindow).toBe(372000);
+  });
+
+  it("overrides GPT-5.6 Terra and Luna costs across OpenAI providers", () => {
+    const expectedCosts = {
+      "gpt-5.6-terra": {
+        input: 2,
+        output: 12,
+        cacheRead: 0.2,
+        cacheWrite: 2.5,
+        tiers: [
+          {
+            inputTokensAbove: 272000,
+            input: 4,
+            output: 18,
+            cacheRead: 0.4,
+            cacheWrite: 5,
+          },
+        ],
+      },
+      "gpt-5.6-luna": {
+        input: 0.2,
+        output: 1.2,
+        cacheRead: 0.02,
+        cacheWrite: 0.25,
+        tiers: [
+          {
+            inputTokensAbove: 272000,
+            input: 0.4,
+            output: 1.8,
+            cacheRead: 0.04,
+            cacheWrite: 0.5,
+          },
+        ],
+      },
+    };
+
+    for (const provider of ["openai", "openai-codex"]) {
+      for (const [modelId, expectedCost] of Object.entries(expectedCosts)) {
+        expect(resolveModel(provider, modelId)?.cost).toEqual(expectedCost);
+      }
+    }
   });
 
   it("overrides GPT-5.6 Codex context windows without changing OpenAI models", () => {


### PR DESCRIPTION
## why

Pi's bundled model catalog still carries the original GPT-5.6 Terra and Luna prices, so Tau overstates session costs for both direct OpenAI and ChatGPT-backed personas.

## what

Apply Tau's existing model override layer to replace those stale costs with OpenAI's reduced prices, including the long-context tiers. The correction is conditional on the complete stale cost shape, allowing a future pi catalog update to take precedence automatically.

Cover both `openai` and `openai-codex` variants in the model catalog tests.
