### PR TITLE
continue retry from current conversation state

### DIFF
--- a/src/core/agent/agent_runtime.ts
+++ b/src/core/agent/agent_runtime.ts
@@ -565,28 +565,6 @@ export class AgentRuntime {
     return true;
   }
 
-  async retryFromHistoryEntryId(historyEntryId: string): Promise<boolean> {
-    this.assertActive();
-    if (this.status !== "idle") {
-      throw new Error("cannot retry a running agent");
-    }
-
-    const historyIndex = this.historyEntries.findIndex((entry) => entry.id === historyEntryId);
-    const entry = this.historyEntries[historyIndex];
-    if (historyIndex < 0 || entry?.message.role !== "user") return false;
-    const removedEntryIds = this.historyEntries.slice(historyIndex + 1).map((item) => item.id);
-    if (removedEntryIds.length === 0) return true;
-    this.replaceHistoryEntries(this.historyEntries.slice(0, historyIndex + 1));
-    await this.deliver({
-      type: "history_rewound",
-      historyEntryId: entry.id,
-      text: this.extractRewindUserText(entry.message),
-      removedEntryIds,
-      revision: this.revision,
-    });
-    return true;
-  }
-
   async rewindToHistoryEntryId(historyEntryId: string): Promise<RewindResult | undefined> {
     this.assertActive();
     if (this.status !== "idle") {

--- a/src/core/runtime/chat_runtime.ts
+++ b/src/core/runtime/chat_runtime.ts
@@ -242,13 +242,6 @@ export class ChatRuntime {
     return this.agent.listRewindCandidates();
   }
 
-  async prepareRetry(historyEntryId: string): Promise<boolean> {
-    if (this.supervisor.getActiveCount() > 0) {
-      throw new Error("cannot retry while subagents are running");
-    }
-    return await this.agent.retryFromHistoryEntryId(historyEntryId);
-  }
-
   async rewindToHistoryEntryId(historyEntryId: string): Promise<RewindResult | undefined> {
     if (this.supervisor.getActiveCount() > 0) {
       throw new Error("cannot rewind while subagents are running");

--- a/src/host/local_session_host.ts
+++ b/src/host/local_session_host.ts
@@ -854,7 +854,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
         "goal-controlled turns cannot be retried; resume a blocked goal or start a new goal",
       );
     }
-    if (!userMessage || !(await this.session.prepareRetry(userMessage.id))) {
+    if (!userMessage) {
       throw new SessionRetryUnavailableError("no user turn is available to retry");
     }
     return await this.runTurn();

--- a/test/agent_runtime.test.js
+++ b/test/agent_runtime.test.js
@@ -1142,24 +1142,6 @@ describe("AgentRuntime", () => {
     await turn;
   });
 
-  it("retains the user message while removing the superseded retry suffix", async () => {
-    const { runtime, persona, events } = createRuntime();
-    const userId = await runtime.commitUserText("try this");
-    const assistantId = "assistant-attempt-1";
-    await runtime.commitInterruptedAssistant(
-      createAssistant(persona, "old attempt", { stopReason: "aborted" }),
-      assistantId,
-    );
-
-    await expect(runtime.retryFromHistoryEntryId(userId)).resolves.toBe(true);
-    expect(runtime.state.historyEntries.map((entry) => entry.id)).toEqual([userId]);
-    expect(events.at(-1)).toMatchObject({
-      type: "history_rewound",
-      historyEntryId: userId,
-      removedEntryIds: [assistantId],
-    });
-  });
-
   it("interrupts active model streaming", async () => {
     const { runtime, persona } = createRuntime();
     runtime.spec.model.stream = vi.fn((_context, options) => ({

--- a/test/local_session_host.test.js
+++ b/test/local_session_host.test.js
@@ -548,6 +548,128 @@ describe("LocalSessionHost", () => {
     }
   });
 
+  it("continues retry from completed tool results without truncating history", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "tau-retry-tool-history-"));
+    const historyStore = new LocalHistoryStore(":memory:");
+    const truncateHistory = vi.spyOn(historyStore, "truncateFromSources");
+    const toolBackend = createLocalToolExecutionBackend();
+    const runBash = vi.spyOn(toolBackend, "runBash");
+    const executionEnvironment = createTestExecutionEnvironment(
+      { kind: "local", cwd, home: cwd },
+      toolBackend,
+    );
+    const host = createHostForEnvironment(new MemorySessionStore(), executionEnvironment, {
+      history: new HistoryManager(historyStore),
+    });
+
+    try {
+      const session = await host.createSession({
+        executionEnvironment: { kind: "local", cwd },
+        attributes: { source: "test" },
+      });
+      const toolCall = fauxToolCall("bash", { command: "printf once" }, { id: "retry-tool" });
+      const toolMessage = fauxAssistantMessage([toolCall], { stopReason: "toolUse" });
+      const interruptedMessage = fauxAssistantMessage("interrupted", { stopReason: "aborted" });
+      const completedMessage = fauxAssistantMessage("continued");
+      const secondSubturnStarted = deferred();
+      const contexts = [];
+      let subturn = 0;
+      session.runtime.agent.spec.model.stream = (context, options) => {
+        contexts.push(context);
+        subturn += 1;
+        if (subturn === 1) {
+          return {
+            async *[Symbol.asyncIterator]() {
+              yield { type: "toolcall_start", contentIndex: 0, partial: toolMessage };
+              yield {
+                type: "toolcall_end",
+                contentIndex: 0,
+                toolCall,
+                partial: toolMessage,
+              };
+            },
+            async result() {
+              return toolMessage;
+            },
+          };
+        }
+        if (subturn === 2) {
+          secondSubturnStarted.resolve();
+          return {
+            async *[Symbol.asyncIterator]() {
+              if (!options.signal.aborted) {
+                await new Promise((resolve) =>
+                  options.signal.addEventListener("abort", resolve, { once: true }),
+                );
+              }
+            },
+            async result() {
+              return interruptedMessage;
+            },
+          };
+        }
+        return {
+          async *[Symbol.asyncIterator]() {},
+          async result() {
+            return completedMessage;
+          },
+        };
+      };
+
+      await session.record({ text: "run the tool" });
+      const firstTurn = session.runTurn();
+      await secondSubturnStarted.promise;
+      expect(runBash).toHaveBeenCalledOnce();
+      expect(session.interruptTurn()).toBe(true);
+      await expect(firstTurn).resolves.toMatchObject({ status: "aborted" });
+
+      const snapshotBeforeRetry = await session.snapshot();
+      const runtimeIdsBeforeRetry = session.runtime.rawHistoryEntries.map((entry) => entry.id);
+      const transcriptBeforeRetry = await historyStore.read({
+        sessionId: session.sessionId,
+        limit: 10,
+      });
+
+      await expect(session.retryTurn()).resolves.toMatchObject({ status: "completed" });
+
+      const snapshotAfterRetry = await session.snapshot();
+      const transcriptAfterRetry = await historyStore.read({
+        sessionId: session.sessionId,
+        limit: 10,
+      });
+      expect(
+        snapshotAfterRetry.messages
+          .slice(0, snapshotBeforeRetry.messages.length)
+          .map((message) => message.id),
+      ).toEqual(snapshotBeforeRetry.messages.map((message) => message.id));
+      expect(
+        session.runtime.rawHistoryEntries
+          .slice(0, runtimeIdsBeforeRetry.length)
+          .map((entry) => entry.id),
+      ).toEqual(runtimeIdsBeforeRetry);
+      expect(transcriptAfterRetry.entries.slice(0, transcriptBeforeRetry.entries.length)).toEqual(
+        transcriptBeforeRetry.entries,
+      );
+      expect(truncateHistory).not.toHaveBeenCalled();
+      expect(runBash).toHaveBeenCalledOnce();
+      expect(contexts[2].messages.map((message) => message.role)).toEqual([
+        "user",
+        "assistant",
+        "toolResult",
+      ]);
+      expect(contexts[2].messages[1].content).toContainEqual(
+        expect.objectContaining({ type: "toolCall", id: toolCall.id }),
+      );
+      expect(contexts[2].messages[2]).toMatchObject({
+        role: "toolResult",
+        toolCallId: toolCall.id,
+      });
+    } finally {
+      await host.shutdown();
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("creates, attaches, lists, snapshots, and shuts down local sessions", async () => {
     const store = new MemorySessionStore();
     const host = createHost(store);


### PR DESCRIPTION
## why

Empty-input retry regressed into a rewind to the latest user message when durable searchable history was added. That discards completed assistant tool calls and tool results from the runtime snapshot and active transcript, so retrying an interrupted turn can execute already-completed tools again instead of continuing from their results.

## what

Retry now starts the next logical turn from the complete committed conversation state. The retry-only runtime rewind path is removed, while explicit rewind keeps its existing snapshot reconciliation and transcript truncation behavior.

A hosted-session regression test interrupts the model subturn after a real Bash tool result, retries, and verifies that the runtime history, protocol snapshot, and searchable transcript retain their existing prefixes. It also verifies that the tool executes only once and that the retry model context contains the completed tool call and result.

## details

Retry still requires an existing user turn and remains unavailable for goal-controlled continuations. Interrupted and failed assistant records remain durable but continue to be excluded from model context by the existing runtime projection, so the next request sees the latest valid committed state. Because retry no longer removes history or subagent origins, it now follows the same background-subagent behavior as an ordinary continuation rather than retaining the rewind-specific active-subagent restriction.

There are no remaining implementation questions.

fixes #396
