### PR TITLE
refine system prompt environment

### DIFF
--- a/src/core/agent/agent_runtime.ts
+++ b/src/core/agent/agent_runtime.ts
@@ -113,6 +113,7 @@ export type AgentSpec = {
 };
 
 type AgentRuntimeOptions = {
+  agentId?: string;
   spec: AgentSpec;
   eventSink: AgentEventSink;
   clock: CoreClock;
@@ -384,7 +385,7 @@ export class AgentRuntime {
           ? { ...recovered.usageCheckpoint }
           : undefined;
     } else {
-      this.agentId = randomUUID();
+      this.agentId = options.agentId ?? randomUUID();
       this.revision = 0;
       this.historyEntries = [];
       this.modelContextKey = modelContextKey;

--- a/src/core/debug.ts
+++ b/src/core/debug.ts
@@ -157,9 +157,9 @@ export function printDebugInfo(args: {
     persona: selectedPersona,
     cwd: promptContext.cwd,
     repoRoot: promptContext.repoRoot,
-    datetime,
+    repository: promptContext.repository,
+    sessionStartedAt: datetime,
     platform: promptContext.platform,
-    nodeVersion: promptContext.nodeVersion,
     skillsBlock: promptContext.skillsBlock,
     projectContextBlock: promptContext.projectContextBlock,
   });

--- a/src/core/runtime/chat_runtime.ts
+++ b/src/core/runtime/chat_runtime.ts
@@ -35,8 +35,8 @@ export type ChatRuntimePromptContext = {
   cwd: string;
   home: string;
   repoRoot?: string;
+  repository?: string;
   platform: NodeJS.Platform;
-  nodeVersion: string;
   includeAgentContext: boolean;
   projectContextBlock?: string;
   skillsBlock?: string;
@@ -45,13 +45,14 @@ export type ChatRuntimePromptContext = {
 export type ChatRuntimeEnvironment = { now: () => number };
 
 export type CreateChatRuntimeOptions = {
+  sessionId: string;
+  createdAt: number;
   persona: Persona;
   backend: ToolExecutionBackend;
   clientTools?: (agentId: string) => ReturnType<ToolRegistry["getEnabledTools"]>;
   modelResolver: ModelResolver;
   resolveSubagentPrompts?: ResolveSubagentPrompts;
   promptContext: ChatRuntimePromptContext;
-  environment: ChatRuntimeEnvironment;
   eventSink: AgentEventSink;
   subagentEventSink: (event: SubagentUiEvent) => void | Promise<void>;
   goalManager: GoalManager;
@@ -69,7 +70,7 @@ export class ChatRuntime {
   private currentConfig: Config;
   private currentModelResolver: ModelResolver;
   private promptContext: ChatRuntimePromptContext;
-  private readonly environment: ChatRuntimeEnvironment;
+  private readonly createdAt: number;
   private readonly backend: ToolExecutionBackend;
   private readonly deps: CoreDeps;
   private resolvedModel: ResolvedAgentModel;
@@ -84,11 +85,12 @@ export class ChatRuntime {
       options.initialPromptComposition ??
       composeSessionPrompts({
         persona: options.persona,
+        sessionId: options.sessionId,
         cwd: options.promptContext.cwd,
         repoRoot: options.promptContext.repoRoot,
-        datetime: new Date(options.environment.now()).toISOString(),
+        repository: options.promptContext.repository,
+        sessionStartedAt: new Date(options.createdAt).toISOString(),
         platform: options.promptContext.platform,
-        nodeVersion: options.promptContext.nodeVersion,
         skillsBlock: options.promptContext.skillsBlock,
         projectContextBlock: options.promptContext.projectContextBlock,
       });
@@ -100,7 +102,7 @@ export class ChatRuntime {
     this.currentConfig = options.config;
     this.currentModelResolver = options.modelResolver;
     this.promptContext = { ...options.promptContext };
-    this.environment = options.environment;
+    this.createdAt = options.createdAt;
     this.backend = options.backend;
     this.deps = options.deps ?? createDefaultCoreDeps();
     this.resolvedModel = resolveAgentModel(this.currentPersona, this.currentConfig, {
@@ -119,6 +121,7 @@ export class ChatRuntime {
     });
     const tools = this.buildToolRegistry(composition);
     this.agent = new AgentRuntime({
+      agentId: options.sessionId,
       spec: createAgentSpec({
         ...this.resolvedModel,
         systemPrompt: composition.baseSystemPrompt,
@@ -223,6 +226,7 @@ export class ChatRuntime {
   reset(): void {
     this.supervisor.reset();
     this.agent.reset();
+    this.rebuildSystemPrompts();
   }
 
   dispose(): void {
@@ -343,11 +347,12 @@ export class ChatRuntime {
   private composePromptSet(skillsBlock?: string): SessionPromptComposition {
     return composeSessionPrompts({
       persona: this.currentPersona,
+      sessionId: this.agent.agentIdValue,
       cwd: this.promptContext.cwd,
       repoRoot: this.promptContext.repoRoot,
-      datetime: new Date(this.environment.now()).toISOString(),
+      repository: this.promptContext.repository,
+      sessionStartedAt: new Date(this.createdAt).toISOString(),
       platform: this.promptContext.platform,
-      nodeVersion: this.promptContext.nodeVersion,
       skillsBlock: skillsBlock ?? this.promptContext.skillsBlock,
       projectContextBlock: this.promptContext.projectContextBlock,
     });

--- a/src/core/runtime/deps.ts
+++ b/src/core/runtime/deps.ts
@@ -16,7 +16,6 @@ export type CoreEnvironment = {
   cwd: () => string;
   home: () => string;
   platform: () => NodeJS.Platform;
-  nodeVersion: () => string;
   env: () => NodeJS.ProcessEnv;
 };
 
@@ -44,7 +43,6 @@ export function createDefaultCoreDeps(): CoreDeps {
       cwd: () => process.cwd(),
       home: () => homedir(),
       platform: () => process.platform,
-      nodeVersion: () => process.version,
       env: () => process.env,
     },
   };

--- a/src/core/runtime/runtime_bootstrap.ts
+++ b/src/core/runtime/runtime_bootstrap.ts
@@ -4,6 +4,7 @@ import {
 } from "../tools/execution_backend.js";
 import type { Persona, Skill } from "../types.js";
 import { buildProjectContextBlock, buildSkillsIndexBlock } from "../utils/context_builder.js";
+import { normalizeRepositoryReference } from "../utils/repository.js";
 import type { ChatRuntimePromptContext } from "./chat_runtime.js";
 
 export type ResolvedPersonaSkills = {
@@ -228,10 +229,23 @@ try {
   if (value) repoRoot = path.resolve(value);
 } catch {}
 
+let repositoryRemote;
+if (repoRoot) {
+  try {
+    const result = spawnSync("git", ["remote", "get-url", "origin"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const value = result.status === 0 ? String(result.stdout || "").trim() : "";
+    if (value) repositoryRemote = value;
+  } catch {}
+}
+
 process.stdout.write(JSON.stringify({
   platform: process.platform,
-  nodeVersion: process.version,
   repoRoot,
+  repositoryRemote,
   agentsFiles,
   childAgentsFiles: [...new Set(childAgentsFiles)].sort((a, b) => a.localeCompare(b)),
 }));
@@ -282,8 +296,8 @@ const RUNTIME_PROMPT_CONTEXT_TIMEOUT_MS = 15_000;
 
 type RuntimePromptContextInspection = {
   platform: NodeJS.Platform;
-  nodeVersion: string;
   repoRoot?: string;
+  repositoryRemote?: string;
   agentsFiles: Array<{ path: string; content: string }>;
   childAgentsFiles: string[];
 };
@@ -310,14 +324,17 @@ export async function resolveRuntimePromptBootstrap(
     persona: args.persona,
     discoveredSkills: args.discoveredSkills,
   });
+  const repository = inspection.repositoryRemote
+    ? normalizeRepositoryReference(inspection.repositoryRemote)
+    : undefined;
 
   return {
     promptContext: {
       cwd: args.cwd,
       home: args.home,
       repoRoot: inspection.repoRoot,
+      ...(repository ? { repository } : {}),
       platform: inspection.platform,
-      nodeVersion: inspection.nodeVersion,
       includeAgentContext: args.includeAgentContext,
       projectContextBlock,
       skillsBlock: resolvedSkills.skillsBlock,
@@ -373,8 +390,8 @@ async function inspectRuntimePromptContext(
   const value = parsed as Partial<RuntimePromptContextInspection>;
   if (
     typeof value.platform !== "string" ||
-    typeof value.nodeVersion !== "string" ||
     (value.repoRoot !== undefined && typeof value.repoRoot !== "string") ||
+    (value.repositoryRemote !== undefined && typeof value.repositoryRemote !== "string") ||
     !Array.isArray(value.agentsFiles) ||
     !Array.isArray(value.childAgentsFiles)
   ) {

--- a/src/core/runtime/session_prompt_composer.ts
+++ b/src/core/runtime/session_prompt_composer.ts
@@ -3,11 +3,12 @@ import type { Persona } from "../types.js";
 import { buildBaseSystemPrompt, buildEnvironmentTag } from "../utils/context.js";
 export type ComposeSessionPromptsArgs = {
   persona: Persona;
+  sessionId?: string;
   cwd: string;
   repoRoot?: string;
-  datetime: string;
+  repository?: string;
+  sessionStartedAt: string;
   platform: NodeJS.Platform;
-  nodeVersion: string;
   skillsBlock?: string;
   projectContextBlock?: string;
 };
@@ -20,11 +21,12 @@ export type SessionPromptComposition = {
 
 export function composeSessionPrompts(args: ComposeSessionPromptsArgs): SessionPromptComposition {
   const environmentTag = buildEnvironmentTag({
+    sessionId: args.sessionId,
     cwd: args.cwd,
     repoRoot: args.repoRoot,
-    datetime: args.datetime,
+    repository: args.repository,
+    sessionStartedAt: args.sessionStartedAt,
     platform: args.platform,
-    nodeVersion: args.nodeVersion,
   });
 
   const baseSystemPrompt = buildBaseSystemPrompt({
@@ -46,11 +48,12 @@ export function composeSessionPrompts(args: ComposeSessionPromptsArgs): SessionP
       });
 
       const subagentEnvironmentTag = buildEnvironmentTag({
+        sessionId: args.sessionId,
         cwd: args.cwd,
         repoRoot: args.repoRoot,
-        datetime: args.datetime,
+        repository: args.repository,
+        sessionStartedAt: args.sessionStartedAt,
         platform: args.platform,
-        nodeVersion: args.nodeVersion,
       });
 
       subagentPrompts[name] = buildBaseSystemPrompt({

--- a/src/core/utils/context_builder.ts
+++ b/src/core/utils/context_builder.ts
@@ -118,29 +118,33 @@ export function buildProjectContextBlock(args: {
 }
 
 export function buildEnvironmentTag(args: {
-  datetime: string;
+  sessionId?: string;
+  sessionStartedAt: string;
   cwd: string;
   repoRoot?: string;
+  repository?: string;
   platform: NodeJS.Platform;
-  nodeVersion: string;
 }): string {
-  const nodeVersion = args.nodeVersion;
-  const platform = args.platform;
-  const lines = [
-    "<environment>",
-    `  <datetime>${args.datetime}</datetime>`,
-    `  <cwd>${args.cwd}</cwd>`,
-  ];
+  const platform =
+    args.platform === "darwin" ? "macOS" : args.platform === "linux" ? "Linux" : args.platform;
+  const lines = ["<environment>"];
+  if (args.sessionId) {
+    lines.push(`- Session ID: \`${args.sessionId}\``);
+  }
+  lines.push(
+    `- Session started at: ${args.sessionStartedAt}`,
+    `- Platform: ${platform}`,
+    `- Current working directory: \`${args.cwd}\``,
+  );
 
   if (args.repoRoot) {
-    lines.push(`  <repo-root>${args.repoRoot}</repo-root>`);
+    if (args.repository) {
+      lines.push(`- Repository: \`${args.repository}\``);
+    }
+    lines.push(`- Repository root: \`${args.repoRoot}\``);
   }
 
-  lines.push(
-    `  <node>${nodeVersion}</node>`,
-    `  <platform>${platform}</platform>`,
-    "</environment>",
-  );
+  lines.push("</environment>");
 
   return lines.join("\n");
 }

--- a/src/host/execution_runtime.ts
+++ b/src/host/execution_runtime.ts
@@ -3,9 +3,10 @@ import type { ResolveSubagentPrompts } from "../core/tools/spawn_agent.js";
 import type { ExecutionEnvironment } from "../execution/execution_environment.js";
 
 export function createExecutionEnvironmentSubagentPromptResolver(options: {
+  sessionId: string;
   executionEnvironment: ExecutionEnvironment;
   includeAgentContext: boolean;
-  now: () => number;
+  sessionStartedAt: number;
 }): ResolveSubagentPrompts {
   return async ({ cwd, persona }) => {
     const { config, skills } = await options.executionEnvironment.resolveRuntimeConfig(cwd);
@@ -19,11 +20,12 @@ export function createExecutionEnvironmentSubagentPromptResolver(options: {
     const promptContext = runtimeContext.promptBootstrap.promptContext;
     return composeSessionPrompts({
       persona,
+      sessionId: options.sessionId,
       cwd: promptContext.cwd,
       repoRoot: promptContext.repoRoot,
-      datetime: new Date(options.now()).toISOString(),
+      repository: promptContext.repository,
+      sessionStartedAt: new Date(options.sessionStartedAt).toISOString(),
       platform: promptContext.platform,
-      nodeVersion: promptContext.nodeVersion,
       skillsBlock: promptContext.skillsBlock,
       projectContextBlock: promptContext.projectContextBlock,
     }).subagentPrompts;

--- a/src/host/hosted_ephemeral_agent_session.ts
+++ b/src/host/hosted_ephemeral_agent_session.ts
@@ -58,6 +58,8 @@ type EphemeralAgentThreadForkSource = {
 
 export type HostedEphemeralAgentSessionOptions = {
   contextId: string;
+  sessionId: string;
+  sessionStartedAt: number;
   persona: Persona;
   config: Config;
   discoveredSkills: Skill[];
@@ -146,11 +148,12 @@ export class HostedEphemeralAgentSession {
     const promptContext = runtimeContext.promptBootstrap.promptContext;
     const composition = composeSessionPrompts({
       persona: this.options.persona,
+      sessionId: this.options.sessionId,
       cwd: promptContext.cwd,
       repoRoot: promptContext.repoRoot,
-      datetime: new Date(deps.clock.now()).toISOString(),
+      repository: promptContext.repository,
+      sessionStartedAt: new Date(this.options.sessionStartedAt).toISOString(),
       platform: promptContext.platform,
-      nodeVersion: promptContext.nodeVersion,
       skillsBlock: promptContext.skillsBlock,
       projectContextBlock: promptContext.projectContextBlock,
     });

--- a/src/host/local_session_host.ts
+++ b/src/host/local_session_host.ts
@@ -297,18 +297,22 @@ export class LocalSessionHost implements TauSessionHost {
     forceNextSnapshotRevision = false,
   ): Promise<LocalHostedSessionHandle> {
     let hostedSession: LocalHostedSessionHandle;
+    const sessionId = committedSnapshot?.sessionId ?? randomUUID();
+    const createdAt = committedSnapshot?.createdAt ?? this.sessionOptions.environment.now();
     const runtime = ChatRuntime.create({
+      sessionId,
+      createdAt,
       persona: bootstrap.persona,
       backend: executionEnvironment.getToolExecutionBackend(),
       clientTools: (sessionId) => this.clientToolBroker.getToolDefinitions(sessionId),
       modelResolver: bootstrap.modelResolver,
       resolveSubagentPrompts: createExecutionEnvironmentSubagentPromptResolver({
+        sessionId,
         executionEnvironment,
         includeAgentContext: this.sessionOptions.includeAgentContext,
-        now: this.sessionOptions.environment.now,
+        sessionStartedAt: createdAt,
       }),
       promptContext: runtimeContext.promptBootstrap.promptContext,
-      environment: this.sessionOptions.environment,
       eventSink: async (event) => await hostedSession.enqueueRuntimeEvent(event),
       subagentEventSink: async (event) => await hostedSession.recordSubagentEvent(event),
       goalManager: {
@@ -329,7 +333,6 @@ export class LocalSessionHost implements TauSessionHost {
     if (!attributes) {
       throw new Error("session attributes are required");
     }
-    const createdAt = committedSnapshot?.createdAt ?? this.sessionOptions.environment.now();
     hostedSession = new LocalHostedSessionHandle(
       runtime,
       runtimeContext.promptBootstrap,
@@ -1474,6 +1477,8 @@ class LocalHostedSessionHandle implements LocalHostedSession {
     const contextId = `ephemeral-${randomUUID()}`;
     const session = new HostedEphemeralAgentSession({
       contextId,
+      sessionId: this.sessionId,
+      sessionStartedAt: this.createdAt,
       persona: this.runtime.persona,
       config: this.bootstrap.config ?? {},
       discoveredSkills: this.bootstrap.discoveredSkills,

--- a/test/chat_runtime.test.js
+++ b/test/chat_runtime.test.js
@@ -26,16 +26,13 @@ function createPersona(overrides = {}) {
   };
 }
 
-function createEnvironment(now = Date.parse("2026-01-01T00:00:00.000Z")) {
-  return { now: () => now };
-}
-
 function createPromptContext(overrides = {}) {
   return {
     cwd: "/repo",
     home: "/home/user",
+    repoRoot: "/repo",
+    repository: "github.com/example/repo",
     platform: "linux",
-    nodeVersion: "v24.0.0",
     includeAgentContext: true,
     ...overrides,
   };
@@ -43,11 +40,12 @@ function createPromptContext(overrides = {}) {
 
 function createRuntime(overrides = {}) {
   return ChatRuntime.create({
+    sessionId: "session-1",
+    createdAt: Date.parse("2026-01-01T00:00:00.000Z"),
     persona: createPersona(),
     backend: createLocalToolExecutionBackend(),
     modelResolver: resolveModel,
     promptContext: createPromptContext(),
-    environment: createEnvironment(),
     eventSink: async () => {},
     subagentEventSink: async () => {},
     goalManager: {
@@ -73,6 +71,8 @@ describe("ChatRuntime", () => {
     expect(runtime.agent).toBeInstanceOf(AgentRuntime);
     expect(runtime.agent.spec.tools.schemas.length).toBeGreaterThan(0);
     expect(runtime.agent.spec.systemPrompt).toBe(runtime.promptComposition.baseSystemPrompt);
+    expect(runtime.agent.spec.systemPrompt).toContain("- Session ID: `session-1`");
+    expect(runtime.agent.spec.systemPrompt).toContain("- Repository: `github.com/example/repo`");
   });
 
   it("uses method-specific goal action labels", () => {

--- a/test/cloudflare_sandbox_execution_environment.test.js
+++ b/test/cloudflare_sandbox_execution_environment.test.js
@@ -796,7 +796,6 @@ describe("Cloudflare Sandbox execution environment", () => {
         return {
           output: JSON.stringify({
             platform: "linux",
-            nodeVersion: "v24.1.0",
             repoRoot: "/workspace/repo",
             agentsFiles: [
               { path: "/workspace/repo/AGENTS.md", content: "repo instructions" },
@@ -871,7 +870,6 @@ describe("Cloudflare Sandbox execution environment", () => {
     expect(runtimeContext.promptBootstrap.promptContext).toMatchObject({
       repoRoot: "/workspace/repo",
       platform: "linux",
-      nodeVersion: "v24.1.0",
     });
     expect(nodeScriptCalls).toHaveLength(1);
     expect(nodeScriptCalls[0].args[0]).toBe("/workspace/repo");

--- a/test/core_runtime.test.js
+++ b/test/core_runtime.test.js
@@ -53,16 +53,22 @@ import {
 describe("context builder", () => {
   it("renders environment and project context blocks", () => {
     const tag = buildEnvironmentTag({
-      datetime: "2025-01-01T00:00:00.000Z",
+      sessionId: "session-1",
+      sessionStartedAt: "2025-01-01T00:00:00.000Z",
       cwd: "/repo",
       repoRoot: "/repo",
+      repository: "github.com/example/repo",
       platform: "darwin",
-      nodeVersion: "v20.0.0",
     });
 
-    expect(tag).toContain("<platform>darwin</platform>");
-    expect(tag).toContain("<node>v20.0.0</node>");
-    expect(tag).toContain("<repo-root>/repo</repo-root>");
+    expect(tag).toBe(`<environment>
+- Session ID: \`session-1\`
+- Session started at: 2025-01-01T00:00:00.000Z
+- Platform: macOS
+- Current working directory: \`/repo\`
+- Repository: \`github.com/example/repo\`
+- Repository root: \`/repo\`
+</environment>`);
 
     const readFile = (path) => (path === "/repo/AGENTS.md" ? "# Agents\n" : "");
     const block = buildProjectContextBlock({
@@ -119,8 +125,8 @@ describe("runtime prompt bootstrap", () => {
           return {
             output: JSON.stringify({
               platform: "linux",
-              nodeVersion: "v24.0.0",
               repoRoot: "/workspace/repo",
+              repositoryRemote: "git@GitHub.com:example/repo.git",
               agentsFiles: [
                 { path: "/workspace/repo/AGENTS.md", content: "repo instructions" },
                 { path: "/workspace/AGENTS.md", content: "workspace instructions" },
@@ -134,6 +140,7 @@ describe("runtime prompt bootstrap", () => {
     });
 
     expect(resolved.agentsFiles).toEqual(["/workspace/repo/AGENTS.md", "/workspace/AGENTS.md"]);
+    expect(resolved.promptContext.repository).toBe("github.com/example/repo");
     expect(resolved.promptContext.projectContextBlock).toContain("repo instructions");
     expect(resolved.promptContext.projectContextBlock).toContain("workspace instructions");
     expect(resolved.promptContext.projectContextBlock).toContain("/workspace/repo/src/AGENTS.md");
@@ -339,12 +346,12 @@ describe("session prompt composer", () => {
 
     const result = composeSessionPrompts({
       persona,
+      sessionId: "session-1",
       skillsBlock: "### Skills\n\n- skill-a",
       projectContextBlock: '### Project context\n\n<file path="/repo/AGENTS.md">ctx</file>',
       cwd: "/repo",
-      datetime: "2026-01-01T00:00:00.000Z",
+      sessionStartedAt: "2026-01-01T00:00:00.000Z",
       platform: "darwin",
-      nodeVersion: "v24.0.0",
     });
 
     expect(result.baseSystemPrompt).toContain("main system prompt");
@@ -363,6 +370,7 @@ describe("session prompt composer", () => {
 
     expect(result.subagentPrompts.default).toContain("<inherited-instructions>");
     expect(result.subagentPrompts.default).toContain("main system prompt");
+    expect(result.subagentPrompts.default).toContain("- Session ID: `session-1`");
     expect(result.subagentPrompts.default).not.toContain("{{inherited_instructions}}");
     expect(result.subagentPrompts.default).toContain(
       "You are a subagent supporting the main agent.",
@@ -396,12 +404,11 @@ describe("session prompt composer", () => {
       persona,
       cwd,
       repoRoot: gitRoot,
-      datetime: "2026-01-01T00:00:00.000Z",
+      sessionStartedAt: "2026-01-01T00:00:00.000Z",
       platform: "darwin",
-      nodeVersion: "v24.0.0",
     });
 
-    expect(result.environmentTag).toContain(`<repo-root>${gitRoot}</repo-root>`);
+    expect(result.environmentTag).toContain(`- Repository root: \`${gitRoot}\``);
   });
 
   it("omits subagent prompts when not applicable", () => {
@@ -417,9 +424,8 @@ describe("session prompt composer", () => {
     const result = composeSessionPrompts({
       persona,
       cwd: "/repo",
-      datetime: "2026-01-01T00:00:00.000Z",
+      sessionStartedAt: "2026-01-01T00:00:00.000Z",
       platform: "darwin",
-      nodeVersion: "v24.0.0",
     });
 
     expect(result.baseSystemPrompt).toContain("plain prompt");

--- a/test/execution_runtime.test.js
+++ b/test/execution_runtime.test.js
@@ -29,7 +29,6 @@ function createPromptBootstrap(cwd = "/workspace/repo") {
       home: "/workspace",
       repoRoot: "/workspace/repo",
       platform: "linux",
-      nodeVersion: "v24.1.0",
       includeAgentContext: true,
       skillsBlock: "### Skills\n\ntarget skill context",
       projectContextBlock: "### Project context\n\ntarget AGENTS context",
@@ -79,9 +78,10 @@ describe("execution environment subagent prompt resolver", () => {
       resolveRuntimeContext,
     };
     const resolvePrompts = createExecutionEnvironmentSubagentPromptResolver({
+      sessionId: "session-1",
       executionEnvironment,
       includeAgentContext: true,
-      now: () => Date.parse("2026-01-01T00:00:00.000Z"),
+      sessionStartedAt: Date.parse("2026-01-01T00:00:00.000Z"),
     });
 
     const prompts = await resolvePrompts({
@@ -101,8 +101,8 @@ describe("execution environment subagent prompt resolver", () => {
     expect(prompts.reviewer).not.toContain("conflicting target reviewer instructions");
     expect(prompts.reviewer).toContain("target AGENTS context");
     expect(prompts.reviewer).toContain("target skill context");
-    expect(prompts.reviewer).toContain("<cwd>/workspace/repo</cwd>");
-    expect(prompts.reviewer).toContain("<platform>linux</platform>");
+    expect(prompts.reviewer).toContain("- Current working directory: `/workspace/repo`");
+    expect(prompts.reviewer).toContain("- Platform: Linux");
   });
 
   it("does not require the source persona to exist in the target catalog", async () => {
@@ -123,9 +123,10 @@ describe("execution environment subagent prompt resolver", () => {
       resolveRuntimeContext,
     };
     const resolvePrompts = createExecutionEnvironmentSubagentPromptResolver({
+      sessionId: "session-1",
       executionEnvironment,
       includeAgentContext: true,
-      now: () => 0,
+      sessionStartedAt: 0,
     });
 
     await expect(

--- a/test/fly_sprite_execution_environment.test.js
+++ b/test/fly_sprite_execution_environment.test.js
@@ -264,7 +264,6 @@ describe("Fly Sprite execution environment", () => {
         return {
           output: JSON.stringify({
             platform: "linux",
-            nodeVersion: "v24.2.0",
             repoRoot: "/home/sprite/repo",
             agentsFiles: [
               { path: "/home/sprite/repo/AGENTS.md", content: "repo instructions" },
@@ -331,7 +330,6 @@ describe("Fly Sprite execution environment", () => {
     expect(runtimeContext.promptBootstrap.promptContext).toMatchObject({
       repoRoot: "/home/sprite/repo",
       platform: "linux",
-      nodeVersion: "v24.2.0",
     });
     expect(nodeScriptCalls).toHaveLength(1);
     expect(nodeScriptCalls[0].args[0]).toBe("/home/sprite/repo");

--- a/test/hosted_ephemeral_agent_session.test.js
+++ b/test/hosted_ephemeral_agent_session.test.js
@@ -59,7 +59,6 @@ function createSession(recordUsage = vi.fn(), config = { autoCompact: { enabled:
           home: "/home/user",
           repoRoot: "/repo",
           platform: "linux",
-          nodeVersion: "v24.0.0",
           includeAgentContext,
         },
         agentsFiles: [],
@@ -74,6 +73,8 @@ function createSession(recordUsage = vi.fn(), config = { autoCompact: { enabled:
     recordUsage,
     session: new HostedEphemeralAgentSession({
       contextId: "ephemeral-1",
+      sessionId: "session-1",
+      sessionStartedAt: 0,
       persona: personas[0],
       config,
       discoveredSkills: [],

--- a/test/local_execution_environment.test.js
+++ b/test/local_execution_environment.test.js
@@ -102,7 +102,6 @@ describe("LocalExecutionEnvironment", () => {
         cwd: () => "/repo",
         home: () => "/home/user",
         platform: () => process.platform,
-        nodeVersion: () => process.version,
         env: () => ({ PATH: process.env.PATH }),
       },
     });
@@ -144,7 +143,6 @@ describe("LocalExecutionEnvironment", () => {
           cwd: () => cwd,
           home: () => cwd,
           platform: () => process.platform,
-          nodeVersion: () => process.version,
           env: () => ({
             PATH: process.env.PATH,
             HOST_TOKEN: "host-secret",
@@ -193,7 +191,6 @@ describe("LocalExecutionEnvironment", () => {
     expect(promptBootstrap.promptContext.home).toBe(process.env.HOME ?? cwd);
     expect(promptBootstrap.promptContext.includeAgentContext).toBe(false);
     expect(promptBootstrap.promptContext.platform).toBe(process.platform);
-    expect(promptBootstrap.promptContext.nodeVersion).toBe(process.version);
     expect(environment.snapshot()).toEqual({
       kind: "local",
       cwd,

--- a/test/local_session_host.test.js
+++ b/test/local_session_host.test.js
@@ -68,7 +68,6 @@ function createTestExecutionEnvironment(
           home: snapshot.home,
           repoRoot: snapshot.cwd,
           platform: "linux",
-          nodeVersion: "v24.0.0",
           includeAgentContext,
         },
         agentsFiles: [],
@@ -348,6 +347,8 @@ describe("HostedEphemeralAgentSession", () => {
     };
     const session = new HostedEphemeralAgentSession({
       contextId: "context-1",
+      sessionId: "session-1",
+      sessionStartedAt: 0,
       persona: personas[0],
       config: {},
       discoveredSkills: [],
@@ -3536,7 +3537,6 @@ describe("LocalSessionHost", () => {
             home: "/home/user",
             repoRoot: "/repo",
             platform: "linux",
-            nodeVersion: "v24.0.0",
             includeAgentContext,
             projectContextBlock: "<project-context>live context</project-context>",
             skillsBlock: `<skills>${persona.id}:${discoveredSkills.length}</skills>`,
@@ -3679,7 +3679,6 @@ describe("LocalSessionHost", () => {
             home: "/home/user",
             repoRoot: "/repo",
             platform: "linux",
-            nodeVersion: "v24.0.0",
             includeAgentContext,
             projectContextBlock: "<project-context>reloaded</project-context>",
             skillsBlock: `<skills>${persona.id}:${discoveredSkills.length}</skills>`,
@@ -3746,7 +3745,7 @@ describe("LocalSessionHost", () => {
 
     expect(systemPrompt).toContain("target AGENTS instructions");
     expect(systemPrompt).toContain("target skill");
-    expect(systemPrompt).toContain("<cwd>/repo</cwd>");
+    expect(systemPrompt).toContain("- Current working directory: `/repo`");
     expect(systemPrompt).toContain("review instructions");
   });
 
@@ -3792,7 +3791,6 @@ describe("LocalSessionHost", () => {
             home: "/home/user",
             repoRoot: "/repo",
             platform: "linux",
-            nodeVersion: "v24.0.0",
             includeAgentContext,
             skillsBlock: `<skills>${persona.id}</skills>`,
           },
@@ -3848,7 +3846,6 @@ describe("LocalSessionHost", () => {
             home: "/home/user",
             repoRoot: "/repo",
             platform: "linux",
-            nodeVersion: "v24.0.0",
             includeAgentContext,
             projectContextBlock: "",
             skillsBlock: `<skills>${persona.id}:${discoveredSkills.length}</skills>`,
@@ -4222,7 +4219,7 @@ describe("LocalSessionHost", () => {
       subagentPrompts: storedSnapshot.bootstrap.prompt.subagentPrompts,
     });
     expect(recoveredSession.runtime.promptComposition.baseSystemPrompt).toContain(
-      "<datetime>2026-01-01T00:00:00.000Z</datetime>",
+      "- Session started at: 2026-01-01T00:00:00.000Z",
     );
   });
 
@@ -4253,7 +4250,6 @@ describe("LocalSessionHost", () => {
             home: "/home/user",
             repoRoot: "/repo",
             platform: "linux",
-            nodeVersion: "v24.0.0",
             includeAgentContext,
             skillsBlock: `<skills>${persona.id}</skills>`,
           },


### PR DESCRIPTION
## why

The system prompt's environment context used implementation-oriented XML fields, included an unhelpful Node version, and omitted session and repository identity that agents need for precise history lookups.

## what

Keep the top-level `<environment>` wrapper while presenting its contents as a concise natural-language list. Include the durable session ID and start time, platform, working directory, and normalized Git repository metadata when available, and remove Node version collection from prompt bootstrap.

Propagate the same session and repository context to main, subagent, and ephemeral prompts, including prompts rebuilt for another working directory.

fixes #414
