### PR TITLE
add telegram voice responses

### DIFF
--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -61,12 +61,12 @@ Several Tau features share provider credentials but intentionally prefer a fixed
 | Feature | Resolution order |
 | --- | --- |
 | Exa web search and fetch | `EXA_API_KEY`, then `apiKeys.exa` |
-| Google speech, Gemini speech-to-text, and Telegram Gemini transcription | `GEMINI_API_KEY`, then `apiKeys.google` |
+| Google speech, Gemini speech-to-text, Telegram Gemini transcription, and Telegram voice responses | `GEMINI_API_KEY`, then `apiKeys.google` |
 | Mistral speech-to-text, Telegram Mistral transcription, and PDF OCR | `MISTRAL_API_KEY`, then `apiKeys.mistral` |
 
 The Google and Mistral rows describe feature-specific helpers. Model calls follow the general model-authentication order instead, where the configured provider key wins over ambient environment authentication.
 
-`web.discover` does not require Exa. `web.search` and `web.fetch` do. `/speak` uses Google. `/listen` and Telegram audio use the configured `speechToText.provider`, which is `mistral` unless configuration selects `gemini`. PDF OCR through `tau tool pdf-unpack` uses Mistral.
+`web.discover` does not require Exa. `web.search` and `web.fetch` do. `/speak` and Telegram `/tts_on` voice responses use Google. `/listen` and incoming Telegram audio use the configured `speechToText.provider`, which is `mistral` unless configuration selects `gemini`. PDF OCR through `tau tool pdf-unpack` uses Mistral.
 
 Set these variables on the process that owns the feature. For example, a remote TUI's `/speak` reads the attached client's `GEMINI_API_KEY`, while a Google model selected by the session reads credentials at the host.
 

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -19,7 +19,7 @@ Common cases are:
 | Nook host tool | Session host |
 | Cloudflare Sandbox bridge and Fly Sprite API | Session host startup |
 | `/listen` and `/speak` | TUI client |
-| Telegram transcription | Telegram runner |
+| Telegram transcription and voice responses | Telegram runner |
 | `tau tool pdf-unpack` | The process running that command |
 
 With local `tau`, these roles normally share one machine. With `tau attach`, setting a key only in the attached client's shell does not authenticate the remote host. Run `tau auth` on the host machine and set host-owned environment variables where `tau serve` or the SDK host actually runs. See [ownership and scope](ownership-and-scope.md) for the full boundary.

--- a/docs/security.md
+++ b/docs/security.md
@@ -41,7 +41,7 @@ Prompt templates are inserted into the editor for review rather than submitted a
 
 ## Keep secrets with the process that needs them
 
-Most model and service credentials belong to the host because the host performs model calls, web search, history replication, and host-tool Nook requests. TUI speech credentials and command client-tool credentials belong to the client. Telegram bot and transcription credentials belong to the Telegram runner. Hosted-environment bridge and API credentials belong to host startup.
+Most model and service credentials belong to the host because the host performs model calls, web search, history replication, and host-tool Nook requests. TUI speech credentials and command client-tool credentials belong to the client. Telegram bot, transcription, and voice-response credentials belong to the Telegram runner. Hosted-environment bridge and API credentials belong to host startup.
 
 In a remote attachment, a credential exported on the laptop does not authenticate the remote host. Conversely, putting a host credential into the execution target's shell environment unnecessarily exposes it to target processes. Follow [credentials](credentials.md) for exact resolution precedence.
 

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -286,7 +286,7 @@ Mistral is the default provider. Configure credentials in the runner's normal Ta
 
 The environment variable wins for each speech provider. Audio without a usable key produces a user-facing error instead of entering a turn. See [credentials](credentials.md).
 
-`/tts_on` uses `gemini-3.1-flash-tts-preview`. It needs `GEMINI_API_KEY` or `apiKeys.google` plus runner-side `ffmpeg` for Ogg Opus encoding. Failures do not affect text delivery.
+`/tts_on` uses `gemini-3.6-flash`, `gemini-3.1-flash-tts-preview`, Despina, the Google key, and runner `ffmpeg` with Opus. Source and rewritten text each allow 10,000 Unicode characters; audio allows 32 MiB. Rewrite and job timeouts are one and five minutes. Jobs are ephemeral. Failure sends `voice response failed. please try again.` without affecting text; details stay in logs.
 
 ## Command client tools
 
@@ -304,7 +304,7 @@ If a referenced repository workspace is missing, Tau reconstructs it from the ca
 
 If the connection is lost after Telegram submits a message, startup checks whether Tau accepted and completed it. Running work remains interruptible until it settles. A confirmed unaccepted message prompts the user to resend it; failed or blocked outcomes remain queued until delivery succeeds.
 
-Tau does not resend earlier assistant messages, notices, or unrelated old outcomes just because the runner restarted. New warning and error notices are delivered after recovery. A restart clears short-lived network retries, but notifications waiting to be delivered remain pending.
+Restart does not replay responses. It clears voice jobs and short-lived retries, but pending notifications remain.
 
 If a failed session still has unresolved submitted work, Tau can reconnect to determine the outcome. Other failed sessions remain visible with their original diagnostic until the owning chat replaces or closes them. Do not edit runner state files to force recovery.
 

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -58,7 +58,7 @@ Unknown object fields are stripped, so a misspelled field can have no effect wit
 | `maxSessions` | No | Positive integer cap on active sessions across the whole runner. |
 | `systemMessage` | No | Non-empty model-facing instruction prepended to every Telegram turn. |
 
-A relative top-level `workspaceRoot` resolves from the Telegram config file's directory. Tau persists runner session records at `<workspaceRoot>-sessions.json` and per-chat project preferences at `<workspaceRoot>-project-preferences.json`. These are runner-owned state files, not operator editing surfaces. Session snapshots remain in the normal host store under the runner user's Tau home.
+A relative top-level `workspaceRoot` resolves from the Telegram config file's directory. Tau persists runner session records at `<workspaceRoot>-sessions.json` and per-chat preferences at `<workspaceRoot>-project-preferences.json`. These are runner-owned state files, not operator editing surfaces. Session snapshots remain in the normal host store under the runner user's Tau home.
 
 `maxSessions` counts queued, preparing, running, and waiting sessions across all configured bots. Failed records do not consume the active cap, but they remain visible to their owning chat until replaced or closed.
 
@@ -83,7 +83,7 @@ Use both lists for a private bot. `allowedUserIds` controls who can trigger work
 
 A bot sees only `allowedProjectIds`. If that field is omitted, it sees every configured project. A sole allowed project is selected automatically; otherwise a chat needs `defaultProjectId` or an explicit `/use_<project>` preference before `/new`.
 
-Tau registers eight built-in commands plus one `/use_<projectId>` command per visible project. A bot may expose at most 92 projects under Telegram's 100-command limit.
+Tau registers ten built-in commands plus one `/use_<projectId>` command per visible project. A bot may expose at most 90 projects under Telegram's 100-command limit.
 
 ## Project IDs and common fields
 
@@ -236,8 +236,10 @@ The runner's speech-to-text provider is loaded from normal Tau config at runner 
 | `/effort_xhigh` | Selects xhigh reasoning for later independent turns. |
 | `/compact` | Runs summary-only manual compaction while the session is idle. |
 | `/interrupt` | Interrupts the active Tau turn. |
+| `/tts_on` | Enables a Gemini-generated voice note after each final assistant response. |
+| `/tts_off` | Disables voice responses. |
 
-Project preferences are scoped to one bot and chat and survive restarts. A changed preference does not switch the active session; `/status` reports the difference.
+Preferences are scoped to one bot and chat and survive restarts, projects, and sessions. A new project choice does not switch the active session; `/status` reports the difference.
 
 In groups, commands must explicitly mention the bot. Accepted forms include:
 
@@ -283,6 +285,8 @@ Mistral is the default provider. Configure credentials in the runner's normal Ta
 - Gemini: set `speechToText.provider` to `gemini`, then use `GEMINI_API_KEY`, falling back to `apiKeys.google`
 
 The environment variable wins for each speech provider. Audio without a usable key produces a user-facing error instead of entering a turn. See [credentials](credentials.md).
+
+`/tts_on` uses `gemini-3.1-flash-tts-preview`. It needs `GEMINI_API_KEY` or `apiKeys.google` plus runner-side `ffmpeg` for Ogg Opus encoding. Failures do not affect text delivery.
 
 ## Command client tools
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -279,6 +279,8 @@ Distinguish download, materialization, format, and transcription errors. The rep
 
 Successful audio turns echo `transcribed: …` before submission. In groups, non-triggering audio can be buffered for later mentioned context. If that is inappropriate for the chat, narrow `allowedChatIds` or avoid enabling the group.
 
+Outgoing `/tts_on` voice responses always need `GEMINI_API_KEY` or `apiKeys.google`, even when incoming audio uses Mistral. They also require runner-side `ffmpeg` for Ogg Opus encoding. Voice generation and delivery failures appear only in runner logs; the original text response remains delivered.
+
 ## Telegram replies or notifications are delayed or missing
 
 Each outbound chunk has a deadline and retries retryable failures twice. Telegram `retry_after` is honored, and per-chat ordering holds later notifications. Large replies are split, so only a later chunk may have failed.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -279,7 +279,7 @@ Distinguish download, materialization, format, and transcription errors. The rep
 
 Successful audio turns echo `transcribed: …` before submission. In groups, non-triggering audio can be buffered for later mentioned context. If that is inappropriate for the chat, narrow `allowedChatIds` or avoid enabling the group.
 
-Outgoing `/tts_on` voice responses always need `GEMINI_API_KEY` or `apiKeys.google`, even when incoming audio uses Mistral. They also require runner-side `ffmpeg` for Ogg Opus encoding. Voice generation and delivery failures appear only in runner logs; the original text response remains delivered.
+Outgoing `/tts_on` voice responses always need `GEMINI_API_KEY` or `apiKeys.google`, even when incoming audio uses Mistral. They also require runner-side `ffmpeg` with Opus support. A generation or delivery failure sends `voice response failed. please try again.` while detailed diagnostics remain in runner logs. The original text response remains delivered.
 
 ## Telegram replies or notifications are delayed or missing
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -203,7 +203,7 @@ brew install ffmpeg
 
 Mistral is the default and needs `MISTRAL_API_KEY` or `apiKeys.mistral`. Set `speechToText.provider` to `gemini` to use `GEMINI_API_KEY` or `apiKeys.google` instead. These settings and credentials are read by the TUI process, including during remote attachment.
 
-`/speak` is also macOS-only. It rewrites the last assistant response for speech, generates audio with Gemini, and plays it through the local `afplay` command. It requires `GEMINI_API_KEY` or `apiKeys.google`, runs only while the session is idle, and can be stopped with Escape.
+`/speak` is also macOS-only. It rewrites the last assistant response for speech, generates audio with Gemini, and plays it through the local `afplay` command. It requires `GEMINI_API_KEY` or `apiKeys.google`, runs only while the session is idle, and can be stopped with Escape. Speech source and rewritten text are limited to 10,000 Unicode characters, and generation stops after 32 MiB of raw audio.
 
 ## Reload the right component
 

--- a/src/core/telegram/adapter.ts
+++ b/src/core/telegram/adapter.ts
@@ -255,6 +255,7 @@ const MAX_TELEGRAM_ATTACHMENTS_PER_TURN = 10;
 const MAX_TELEGRAM_ATTACHMENT_FILE_BYTES = 20 * 1024 * 1024;
 const MAX_TELEGRAM_ATTACHMENT_TOTAL_BYTES = 50 * 1024 * 1024;
 const MAX_TELEGRAM_VOICE_BYTES = 50 * 1024 * 1024;
+const TELEGRAM_TTS_JOB_TIMEOUT_MS = 5 * 60_000;
 const MAX_TELEGRAM_GROUP_PENDING_MESSAGES = 50;
 const TELEGRAM_ATTACHMENT_TEMP_DIR_PREFIX = "tau-telegram-attachments-";
 const TELEGRAM_REASONING_EFFORTS = [
@@ -951,10 +952,6 @@ class TelegramDeliveryError extends Error {
   }
 }
 
-function isAbortError(error: unknown): boolean {
-  return error instanceof Error && error.name === "AbortError";
-}
-
 function getErrorCode(error: unknown): string | undefined {
   if (typeof error !== "object" || error === null || !("code" in error)) {
     return undefined;
@@ -1292,7 +1289,6 @@ class TelegramAdapterImpl {
   private readonly chatTypesByChat = new Map<number, string>();
   private readonly typingIntervalsBySessionChat = new Map<string, ReturnType<typeof setInterval>>();
   private readonly lastCommandBySession = new Map<string, string>();
-  private readonly finalAssistantTextBySession = new Map<string, string>();
   private readonly pendingAttachmentsBySession = new Map<string, TelegramPendingAttachment[]>();
   private readonly pendingGroupMessagesByChat = new Map<number, TelegramGroupPendingMessage[]>();
   private readonly pendingAttachmentTempDirBySession = new Map<string, string>();
@@ -1301,6 +1297,7 @@ class TelegramAdapterImpl {
   private readonly inFlightUpdateTasks = new Set<Promise<void>>();
   private readonly notificationQueueTailByChat = new Map<number, Promise<void>>();
   private readonly inFlightNotificationTasks = new Set<Promise<void>>();
+  private readonly ttsQueueTailBySession = new Map<string, Promise<void>>();
   private readonly inFlightTtsTasks = new Set<Promise<void>>();
 
   private readonly unsubscribeSessionEvents: () => void;
@@ -1386,6 +1383,7 @@ class TelegramAdapterImpl {
       await this.loopPromise;
       await this.waitForInFlightUpdateTasks();
       await Promise.allSettled(Array.from(this.inFlightTtsTasks));
+      this.ttsQueueTailBySession.clear();
       await Promise.allSettled(Array.from(this.inFlightNotificationTasks));
 
       for (const sessionId of Array.from(this.chatsBySession.keys())) {
@@ -2962,6 +2960,13 @@ class TelegramAdapterImpl {
       return;
     }
 
+    if (event.type === "session-response-completed") {
+      if (this.chatsBySession.has(event.sessionId)) {
+        this.startTtsNotification(event.sessionId, event.text);
+      }
+      return;
+    }
+
     if (event.type === "session-turn-failed" || event.type === "session-turn-rejected") {
       if (!this.chatsBySession.has(event.sessionId)) {
         return;
@@ -3010,7 +3015,6 @@ class TelegramAdapterImpl {
     }
 
     if (event.state === "running") {
-      this.finalAssistantTextBySession.delete(event.sessionId);
       this.startTypingIndicators(event.sessionId);
       if (this.isVerboseSession(event.sessionId)) {
         this.notifyLifecycle(event.sessionId, event.projectId, "started");
@@ -3019,7 +3023,6 @@ class TelegramAdapterImpl {
     }
 
     if (event.state === "failed") {
-      this.finalAssistantTextBySession.delete(event.sessionId);
       this.stopTypingIndicators(event.sessionId);
       this.notifyLifecycle(event.sessionId, event.projectId, "failed");
       return;
@@ -3037,11 +3040,6 @@ class TelegramAdapterImpl {
       this.stopTypingIndicators(event.sessionId);
       if (this.isVerboseSession(event.sessionId)) {
         this.notifyLifecycle(event.sessionId, event.projectId, "finished");
-      }
-      const finalAssistantText = this.finalAssistantTextBySession.get(event.sessionId);
-      this.finalAssistantTextBySession.delete(event.sessionId);
-      if (finalAssistantText) {
-        this.startTtsNotification(event.sessionId, finalAssistantText);
       }
     }
   }
@@ -3091,10 +3089,6 @@ class TelegramAdapterImpl {
       return;
     }
 
-    if (event.progress.final) {
-      this.finalAssistantTextBySession.set(event.sessionId, event.progress.text);
-    }
-
     this.notifySession(
       event.sessionId,
       isVerbose
@@ -3118,9 +3112,20 @@ class TelegramAdapterImpl {
       return;
     }
 
-    const task = this.generateAndSendTtsNotification(sessionId, sourceText).finally(() => {
-      this.inFlightTtsTasks.delete(task);
-    });
+    const previousTask = this.ttsQueueTailBySession.get(sessionId) ?? Promise.resolve();
+    const task = previousTask
+      .then(async () => {
+        if (!this.abortController.signal.aborted) {
+          await this.generateAndSendTtsNotification(sessionId, sourceText);
+        }
+      })
+      .finally(() => {
+        this.inFlightTtsTasks.delete(task);
+        if (this.ttsQueueTailBySession.get(sessionId) === task) {
+          this.ttsQueueTailBySession.delete(sessionId);
+        }
+      });
+    this.ttsQueueTailBySession.set(sessionId, task);
     this.inFlightTtsTasks.add(task);
     void task;
   }
@@ -3129,12 +3134,20 @@ class TelegramAdapterImpl {
     sessionId: string,
     sourceText: string,
   ): Promise<void> {
+    let timedOut = false;
+    const timeoutController = new AbortController();
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      timeoutController.abort();
+    }, TELEGRAM_TTS_JOB_TIMEOUT_MS);
+    timeout.unref?.();
+
     try {
       const voice = await this.generateVoice({
         apiKey: this.geminiApiKey!,
         sourceText,
         fetchImpl: this.fetchImpl,
-        signal: this.abortController.signal,
+        signal: AbortSignal.any([this.abortController.signal, timeoutController.signal]),
       });
       if (voice.length > MAX_TELEGRAM_VOICE_BYTES) {
         throw new Error("generated voice response exceeds Telegram's 50 MB limit");
@@ -3147,17 +3160,68 @@ class TelegramAdapterImpl {
       await Promise.all(
         [...chatIds]
           .filter((chatId) => this.projectPreferences.isTtsEnabled(this.ownerIdForChat(chatId)))
-          .map(async (chatId) => await this.enqueueVoiceNotification(sessionId, chatId, voice)),
+          .map(async (chatId) => {
+            const result = await this.enqueueVoiceNotification(
+              sessionId,
+              chatId,
+              voice,
+              timeoutController.signal,
+            );
+            if (result === "timed-out") {
+              this.log("error", "Telegram voice response job timed out", {
+                sessionId,
+                chatId,
+                cause: "voice response job timed out after 5 minutes",
+              });
+            }
+            if (result === "failed" || result === "timed-out") {
+              await this.enqueueTtsFailureNotification(sessionId, chatId);
+            }
+          }),
       );
     } catch (error) {
-      if (this.abortController.signal.aborted || isAbortError(error)) {
+      if (this.abortController.signal.aborted) {
         return;
       }
       this.log("error", "failed to generate Telegram voice response", {
         sessionId,
-        cause: error instanceof Error ? error.message : String(error),
+        cause: timedOut
+          ? "voice generation timed out after 5 minutes"
+          : error instanceof Error
+            ? error.message
+            : String(error),
       });
+      await this.notifyTtsFailure(sessionId);
+    } finally {
+      clearTimeout(timeout);
     }
+  }
+
+  private async notifyTtsFailure(sessionId: string): Promise<void> {
+    const chatIds = this.chatsBySession.get(sessionId);
+    if (!chatIds) {
+      return;
+    }
+    await Promise.all(
+      [...chatIds]
+        .filter((chatId) => this.projectPreferences.isTtsEnabled(this.ownerIdForChat(chatId)))
+        .map(async (chatId) => await this.enqueueTtsFailureNotification(sessionId, chatId)),
+    );
+  }
+
+  private async enqueueTtsFailureNotification(sessionId: string, chatId: number): Promise<void> {
+    if (
+      this.abortController.signal.aborted ||
+      !this.projectPreferences.isTtsEnabled(this.ownerIdForChat(chatId))
+    ) {
+      return;
+    }
+    await this.enqueueNotification(
+      sessionId,
+      chatId,
+      "voice response failed. please try again.",
+      {},
+    );
   }
 
   private notifyLifecycle(
@@ -3255,7 +3319,8 @@ class TelegramAdapterImpl {
     sessionId: string,
     chatId: number,
     voice: Buffer,
-  ): Promise<boolean> {
+    jobSignal: AbortSignal,
+  ): Promise<"sent" | "skipped" | "failed" | "timed-out"> {
     const previousTask = this.notificationQueueTailByChat.get(chatId) ?? Promise.resolve();
     const deliveryTask = previousTask
       .then(async () => {
@@ -3263,17 +3328,26 @@ class TelegramAdapterImpl {
           this.abortController.signal.aborted ||
           !this.projectPreferences.isTtsEnabled(this.ownerIdForChat(chatId))
         ) {
-          return false;
+          return "skipped" as const;
+        }
+        if (jobSignal.aborted) {
+          return "timed-out" as const;
         }
 
         const result = await this.sendWithRetry(
           async (signal) => await this.api.sendVoice(chatId, voice, { signal }),
+          jobSignal,
         );
-        return result !== ABORTED;
+        if (result === ABORTED) {
+          return jobSignal.aborted && !this.abortController.signal.aborted
+            ? ("timed-out" as const)
+            : ("skipped" as const);
+        }
+        return "sent" as const;
       })
       .catch((error) => {
         if (this.abortController.signal.aborted) {
-          return false;
+          return "skipped" as const;
         }
 
         const deliveryError =
@@ -3292,7 +3366,7 @@ class TelegramAdapterImpl {
             cause: deliveryError.message,
           },
         );
-        return false;
+        return "failed" as const;
       });
 
     const trackedTask = deliveryTask
@@ -3494,16 +3568,17 @@ class TelegramAdapterImpl {
 
   private async sendWithRetry(
     send: (signal: AbortSignal) => Promise<void>,
+    externalSignal?: AbortSignal,
   ): Promise<typeof ABORTED | undefined> {
     for (let attempt = 1; ; attempt += 1) {
       try {
-        const result = await this.runDeliveryAttempt(send);
+        const result = await this.runDeliveryAttempt(send, externalSignal);
         if (result === ABORTED) {
           return ABORTED;
         }
         return;
       } catch (error) {
-        if (this.abortController.signal.aborted) {
+        if (this.abortController.signal.aborted || externalSignal?.aborted) {
           return ABORTED;
         }
 
@@ -3513,8 +3588,8 @@ class TelegramAdapterImpl {
           throw new TelegramDeliveryError(error, attempt, retryable);
         }
 
-        await this.wait(Math.max(retryDelayMs, error.retryAfterMs ?? 0));
-        if (this.abortController.signal.aborted) {
+        await this.wait(Math.max(retryDelayMs, error.retryAfterMs ?? 0), externalSignal);
+        if (this.abortController.signal.aborted || externalSignal?.aborted) {
           return ABORTED;
         }
       }
@@ -3523,8 +3598,12 @@ class TelegramAdapterImpl {
 
   private async runDeliveryAttempt(
     send: (signal: AbortSignal) => Promise<void>,
+    externalSignal?: AbortSignal,
   ): Promise<typeof ABORTED | undefined> {
-    if (this.abortController.signal.aborted) {
+    const deliverySignal = externalSignal
+      ? AbortSignal.any([this.abortController.signal, externalSignal])
+      : this.abortController.signal;
+    if (deliverySignal.aborted) {
       return ABORTED;
     }
 
@@ -3535,7 +3614,7 @@ class TelegramAdapterImpl {
         resolve(ABORTED);
         attemptController.abort();
       };
-      this.abortController.signal.addEventListener("abort", abortListener, { once: true });
+      deliverySignal.addEventListener("abort", abortListener, { once: true });
     });
 
     let timeout: ReturnType<typeof setTimeout> | undefined;
@@ -3564,7 +3643,7 @@ class TelegramAdapterImpl {
       clearTimeout(timeout);
     }
     if (abortListener) {
-      this.abortController.signal.removeEventListener("abort", abortListener);
+      deliverySignal.removeEventListener("abort", abortListener);
     }
 
     if (raceResult === ABORTED) {
@@ -3581,14 +3660,17 @@ class TelegramAdapterImpl {
     }
   }
 
-  private async wait(durationMs: number): Promise<void> {
-    if (durationMs <= 0 || this.abortController.signal.aborted) {
+  private async wait(durationMs: number, externalSignal?: AbortSignal): Promise<void> {
+    const waitSignal = externalSignal
+      ? AbortSignal.any([this.abortController.signal, externalSignal])
+      : this.abortController.signal;
+    if (durationMs <= 0 || waitSignal.aborted) {
       return;
     }
 
     await new Promise<void>((resolve) => {
       const timeout = setTimeout(() => {
-        this.abortController.signal.removeEventListener("abort", onAbort);
+        waitSignal.removeEventListener("abort", onAbort);
         resolve();
       }, durationMs);
       timeout.unref?.();
@@ -3598,7 +3680,7 @@ class TelegramAdapterImpl {
         resolve();
       };
 
-      this.abortController.signal.addEventListener("abort", onAbort, { once: true });
+      waitSignal.addEventListener("abort", onAbort, { once: true });
     });
   }
 }

--- a/src/core/telegram/adapter.ts
+++ b/src/core/telegram/adapter.ts
@@ -3103,7 +3103,6 @@ class TelegramAdapterImpl {
   private startTtsNotification(sessionId: string, sourceText: string): void {
     const chatIds = this.chatsBySession.get(sessionId);
     if (
-      !this.geminiApiKey ||
       !chatIds ||
       ![...chatIds].some((chatId) =>
         this.projectPreferences.isTtsEnabled(this.ownerIdForChat(chatId)),
@@ -3143,8 +3142,11 @@ class TelegramAdapterImpl {
     timeout.unref?.();
 
     try {
+      if (!this.geminiApiKey) {
+        throw new Error("missing Google credential for Telegram voice responses");
+      }
       const voice = await this.generateVoice({
-        apiKey: this.geminiApiKey!,
+        apiKey: this.geminiApiKey,
         sourceText,
         fetchImpl: this.fetchImpl,
         signal: AbortSignal.any([this.abortController.signal, timeoutController.signal]),

--- a/src/core/telegram/adapter.ts
+++ b/src/core/telegram/adapter.ts
@@ -25,6 +25,7 @@ import {
   type TelegramSessionManagerEvent,
   type TelegramSessionRecord,
 } from "./session_manager.js";
+import { type GenerateTelegramVoiceOptions, generateTelegramVoice } from "./tts.js";
 
 type TelegramChat = {
   id: number;
@@ -114,6 +115,7 @@ export type TelegramApi = {
   }): Promise<TelegramUpdate[]>;
   sendMessage(chatId: number, text: string, options: TelegramSendOptions): Promise<void>;
   sendRichMessage(chatId: number, markdown: string, options: TelegramSendOptions): Promise<void>;
+  sendVoice(chatId: number, voice: Buffer, options: TelegramSendOptions): Promise<void>;
   sendChatAction(chatId: number, action: string): Promise<void>;
   downloadFile(fileId: string): Promise<Buffer>;
   setCommands(commands: TelegramBotCommand[]): Promise<void>;
@@ -146,6 +148,7 @@ export type TelegramAdapterOptions = {
   projectPreferences: TelegramProjectPreferenceStore;
   api?: TelegramApi;
   fetchImpl?: typeof fetch;
+  generateVoice?: (options: GenerateTelegramVoiceOptions) => Promise<Buffer>;
   onLog?: (entry: TelegramLogEntry) => void;
 };
 
@@ -251,6 +254,7 @@ const CALLBACK_ACTION_PREFIX = "tau:action:";
 const MAX_TELEGRAM_ATTACHMENTS_PER_TURN = 10;
 const MAX_TELEGRAM_ATTACHMENT_FILE_BYTES = 20 * 1024 * 1024;
 const MAX_TELEGRAM_ATTACHMENT_TOTAL_BYTES = 50 * 1024 * 1024;
+const MAX_TELEGRAM_VOICE_BYTES = 50 * 1024 * 1024;
 const MAX_TELEGRAM_GROUP_PENDING_MESSAGES = 50;
 const TELEGRAM_ATTACHMENT_TEMP_DIR_PREFIX = "tau-telegram-attachments-";
 const TELEGRAM_REASONING_EFFORTS = [
@@ -947,6 +951,10 @@ class TelegramDeliveryError extends Error {
   }
 }
 
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
 function getErrorCode(error: unknown): string | undefined {
   if (typeof error !== "object" || error === null || !("code" in error)) {
     return undefined;
@@ -1014,6 +1022,13 @@ function asPermanentTelegramRequestError(error: unknown): TelegramRequestError {
   return new TelegramRequestError(message, { retryable: false, cause: error });
 }
 
+type TelegramUpload = {
+  field: string;
+  fileName: string;
+  mimeType: string;
+  data: Buffer;
+};
+
 function createTelegramApi(botToken: string): TelegramApi {
   const apiUrl = `https://api.telegram.org/bot${botToken}`;
 
@@ -1022,15 +1037,26 @@ function createTelegramApi(botToken: string): TelegramApi {
     payload: Record<string, unknown>,
     resultSchema: z.ZodType<Result>,
     signal?: AbortSignal,
+    upload?: TelegramUpload,
   ): Promise<Result> {
+    const body = upload ? new FormData() : JSON.stringify(payload);
+    if (body instanceof FormData && upload) {
+      for (const [key, value] of Object.entries(payload)) {
+        body.append(key, typeof value === "string" ? value : JSON.stringify(value));
+      }
+      body.append(
+        upload.field,
+        new Blob([Uint8Array.from(upload.data)], { type: upload.mimeType }),
+        upload.fileName,
+      );
+    }
+
     let response: Response;
     try {
       response = await fetch(`${apiUrl}/${method}`, {
         method: "POST",
-        headers: {
-          "content-type": "application/json",
-        },
-        body: JSON.stringify(payload),
+        ...(upload ? {} : { headers: { "content-type": "application/json" } }),
+        body,
         signal,
       });
     } catch (error) {
@@ -1161,6 +1187,14 @@ function createTelegramApi(botToken: string): TelegramApi {
         options.signal,
       );
     },
+    async sendVoice(chatId, voice, options) {
+      await callTelegramMethod("sendVoice", { chat_id: chatId }, z.unknown(), options.signal, {
+        field: "voice",
+        fileName: "response.ogg",
+        mimeType: "audio/ogg",
+        data: voice,
+      });
+    },
     async sendChatAction(chatId, action) {
       await callTelegramMethod(
         "sendChatAction",
@@ -1246,6 +1280,7 @@ class TelegramAdapterImpl {
   private readonly allowedProjectIds: string[];
   private readonly api: TelegramApi;
   private readonly fetchImpl?: typeof fetch;
+  private readonly generateVoice: (options: GenerateTelegramVoiceOptions) => Promise<Buffer>;
   private readonly onLog?: (entry: TelegramLogEntry) => void;
   private readonly commandDefinitions: TelegramCommandDefinition[];
   private readonly commandHandlers: Map<string, TelegramCommandHandler>;
@@ -1257,6 +1292,7 @@ class TelegramAdapterImpl {
   private readonly chatTypesByChat = new Map<number, string>();
   private readonly typingIntervalsBySessionChat = new Map<string, ReturnType<typeof setInterval>>();
   private readonly lastCommandBySession = new Map<string, string>();
+  private readonly finalAssistantTextBySession = new Map<string, string>();
   private readonly pendingAttachmentsBySession = new Map<string, TelegramPendingAttachment[]>();
   private readonly pendingGroupMessagesByChat = new Map<number, TelegramGroupPendingMessage[]>();
   private readonly pendingAttachmentTempDirBySession = new Map<string, string>();
@@ -1265,6 +1301,7 @@ class TelegramAdapterImpl {
   private readonly inFlightUpdateTasks = new Set<Promise<void>>();
   private readonly notificationQueueTailByChat = new Map<number, Promise<void>>();
   private readonly inFlightNotificationTasks = new Set<Promise<void>>();
+  private readonly inFlightTtsTasks = new Set<Promise<void>>();
 
   private readonly unsubscribeSessionEvents: () => void;
   private readonly loopPromise: Promise<void>;
@@ -1302,6 +1339,7 @@ class TelegramAdapterImpl {
     this.allowedProjectIds = Object.keys(options.projects);
     this.api = options.api;
     this.fetchImpl = options.fetchImpl;
+    this.generateVoice = options.generateVoice ?? generateTelegramVoice;
     this.onLog = options.onLog;
     this.commandDefinitions = this.createCommandDefinitions();
     this.commandHandlers = new Map();
@@ -1347,6 +1385,7 @@ class TelegramAdapterImpl {
     try {
       await this.loopPromise;
       await this.waitForInFlightUpdateTasks();
+      await Promise.allSettled(Array.from(this.inFlightTtsTasks));
       await Promise.allSettled(Array.from(this.inFlightNotificationTasks));
 
       for (const sessionId of Array.from(this.chatsBySession.keys())) {
@@ -1392,6 +1431,16 @@ class TelegramAdapterImpl {
         description: "interrupt active run",
         callbackAction: "interrupt",
         handler: async (chatId) => this.handleInterrupt(chatId),
+      },
+      {
+        command: "/tts_on",
+        description: "enable voice responses",
+        handler: async (chatId, args) => this.handleTtsPreference(chatId, true, args),
+      },
+      {
+        command: "/tts_off",
+        description: "disable voice responses",
+        handler: async (chatId, args) => this.handleTtsPreference(chatId, false, args),
       },
     ];
 
@@ -2252,6 +2301,32 @@ class TelegramAdapterImpl {
     }
   }
 
+  private async handleTtsPreference(
+    chatId: number,
+    enabled: boolean,
+    args: string[],
+  ): Promise<void> {
+    const command = enabled ? "/tts_on" : "/tts_off";
+    if (args.length > 0) {
+      await this.reply(chatId, `usage: ${command}`);
+      return;
+    }
+    if (enabled && !this.geminiApiKey) {
+      await this.reply(chatId, "set GEMINI_API_KEY or apiKeys.google to enable voice responses.");
+      return;
+    }
+
+    try {
+      await this.projectPreferences.setTtsEnabled(this.ownerIdForChat(chatId), enabled);
+      await this.reply(chatId, `voice responses ${enabled ? "enabled" : "disabled"}.`);
+    } catch (error) {
+      await this.reply(
+        chatId,
+        `failed to save voice response preference: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
   private async handleSetReasoning(
     chatId: number,
     reasoning: (typeof TELEGRAM_REASONING_EFFORTS)[number],
@@ -2935,6 +3010,7 @@ class TelegramAdapterImpl {
     }
 
     if (event.state === "running") {
+      this.finalAssistantTextBySession.delete(event.sessionId);
       this.startTypingIndicators(event.sessionId);
       if (this.isVerboseSession(event.sessionId)) {
         this.notifyLifecycle(event.sessionId, event.projectId, "started");
@@ -2943,6 +3019,7 @@ class TelegramAdapterImpl {
     }
 
     if (event.state === "failed") {
+      this.finalAssistantTextBySession.delete(event.sessionId);
       this.stopTypingIndicators(event.sessionId);
       this.notifyLifecycle(event.sessionId, event.projectId, "failed");
       return;
@@ -2960,6 +3037,11 @@ class TelegramAdapterImpl {
       this.stopTypingIndicators(event.sessionId);
       if (this.isVerboseSession(event.sessionId)) {
         this.notifyLifecycle(event.sessionId, event.projectId, "finished");
+      }
+      const finalAssistantText = this.finalAssistantTextBySession.get(event.sessionId);
+      this.finalAssistantTextBySession.delete(event.sessionId);
+      if (finalAssistantText) {
+        this.startTtsNotification(event.sessionId, finalAssistantText);
       }
     }
   }
@@ -3009,6 +3091,10 @@ class TelegramAdapterImpl {
       return;
     }
 
+    if (event.progress.final) {
+      this.finalAssistantTextBySession.set(event.sessionId, event.progress.text);
+    }
+
     this.notifySession(
       event.sessionId,
       isVerbose
@@ -3018,6 +3104,60 @@ class TelegramAdapterImpl {
         : event.progress.text,
       { rich: true, messageId: event.progress.messageId },
     );
+  }
+
+  private startTtsNotification(sessionId: string, sourceText: string): void {
+    const chatIds = this.chatsBySession.get(sessionId);
+    if (
+      !this.geminiApiKey ||
+      !chatIds ||
+      ![...chatIds].some((chatId) =>
+        this.projectPreferences.isTtsEnabled(this.ownerIdForChat(chatId)),
+      )
+    ) {
+      return;
+    }
+
+    const task = this.generateAndSendTtsNotification(sessionId, sourceText).finally(() => {
+      this.inFlightTtsTasks.delete(task);
+    });
+    this.inFlightTtsTasks.add(task);
+    void task;
+  }
+
+  private async generateAndSendTtsNotification(
+    sessionId: string,
+    sourceText: string,
+  ): Promise<void> {
+    try {
+      const voice = await this.generateVoice({
+        apiKey: this.geminiApiKey!,
+        sourceText,
+        fetchImpl: this.fetchImpl,
+        signal: this.abortController.signal,
+      });
+      if (voice.length > MAX_TELEGRAM_VOICE_BYTES) {
+        throw new Error("generated voice response exceeds Telegram's 50 MB limit");
+      }
+
+      const chatIds = this.chatsBySession.get(sessionId);
+      if (!chatIds) {
+        return;
+      }
+      await Promise.all(
+        [...chatIds]
+          .filter((chatId) => this.projectPreferences.isTtsEnabled(this.ownerIdForChat(chatId)))
+          .map(async (chatId) => await this.enqueueVoiceNotification(sessionId, chatId, voice)),
+      );
+    } catch (error) {
+      if (this.abortController.signal.aborted || isAbortError(error)) {
+        return;
+      }
+      this.log("error", "failed to generate Telegram voice response", {
+        sessionId,
+        cause: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   private notifyLifecycle(
@@ -3090,6 +3230,64 @@ class TelegramAdapterImpl {
             sessionId,
             chatId,
             ...(options.rich === true ? { messageId: options.messageId } : {}),
+            attempts: deliveryError.attempts,
+            cause: deliveryError.message,
+          },
+        );
+        return false;
+      });
+
+    const trackedTask = deliveryTask
+      .then(() => undefined)
+      .finally(() => {
+        this.inFlightNotificationTasks.delete(trackedTask);
+        if (this.notificationQueueTailByChat.get(chatId) === trackedTask) {
+          this.notificationQueueTailByChat.delete(chatId);
+        }
+      });
+
+    this.notificationQueueTailByChat.set(chatId, trackedTask);
+    this.inFlightNotificationTasks.add(trackedTask);
+    return deliveryTask;
+  }
+
+  private enqueueVoiceNotification(
+    sessionId: string,
+    chatId: number,
+    voice: Buffer,
+  ): Promise<boolean> {
+    const previousTask = this.notificationQueueTailByChat.get(chatId) ?? Promise.resolve();
+    const deliveryTask = previousTask
+      .then(async () => {
+        if (
+          this.abortController.signal.aborted ||
+          !this.projectPreferences.isTtsEnabled(this.ownerIdForChat(chatId))
+        ) {
+          return false;
+        }
+
+        const result = await this.sendWithRetry(
+          async (signal) => await this.api.sendVoice(chatId, voice, { signal }),
+        );
+        return result !== ABORTED;
+      })
+      .catch((error) => {
+        if (this.abortController.signal.aborted) {
+          return false;
+        }
+
+        const deliveryError =
+          error instanceof TelegramDeliveryError
+            ? error
+            : new TelegramDeliveryError(error, 1, false);
+        this.log(
+          "error",
+          deliveryError.retryable
+            ? "telegram voice response delivery retries exhausted"
+            : "failed to send Telegram voice response",
+          {
+            sessionId,
+            chatId,
             attempts: deliveryError.attempts,
             cause: deliveryError.message,
           },

--- a/src/core/telegram/config.ts
+++ b/src/core/telegram/config.ts
@@ -26,7 +26,7 @@ export class TelegramConfigError extends Error {
   }
 }
 
-const TELEGRAM_BUILTIN_COMMAND_COUNT = 8;
+const TELEGRAM_BUILTIN_COMMAND_COUNT = 10;
 const TELEGRAM_MAX_COMMAND_COUNT = 100;
 const TELEGRAM_PROJECT_COMMAND_PREFIX = "use_";
 const TELEGRAM_MAX_COMMAND_LENGTH = 32;

--- a/src/core/telegram/project_preferences.ts
+++ b/src/core/telegram/project_preferences.ts
@@ -6,14 +6,41 @@ export type TelegramProjectPreferenceStore = {
   initialize(): Promise<void>;
   get(ownerId: string): string | undefined;
   set(ownerId: string, projectId: string): Promise<void>;
+  isTtsEnabled(ownerId: string): boolean;
+  setTtsEnabled(ownerId: string, enabled: boolean): Promise<void>;
 };
 
-const telegramProjectPreferencesSchema = z
+type TelegramPreferences = {
+  projectId?: string;
+  ttsEnabled: boolean;
+};
+
+const telegramProjectPreferencesV1Schema = z
   .object({
     version: z.literal(1),
     preferences: z.record(z.string().min(1), z.string().min(1)),
   })
   .strip();
+
+const telegramPreferencesV2Schema = z
+  .object({
+    version: z.literal(2),
+    preferences: z.record(
+      z.string().min(1),
+      z
+        .object({
+          projectId: z.string().min(1).optional(),
+          ttsEnabled: z.boolean(),
+        })
+        .strip(),
+    ),
+  })
+  .strip();
+
+const telegramPreferencesSchema = z.discriminatedUnion("version", [
+  telegramProjectPreferencesV1Schema,
+  telegramPreferencesV2Schema,
+]);
 
 export function resolveTelegramProjectPreferencesPath(workspaceRoot: string): string {
   return `${resolve(workspaceRoot)}-project-preferences.json`;
@@ -21,7 +48,7 @@ export function resolveTelegramProjectPreferencesPath(workspaceRoot: string): st
 
 class FileTelegramProjectPreferenceStore implements TelegramProjectPreferenceStore {
   private readonly path: string;
-  private readonly preferences = new Map<string, string>();
+  private readonly preferences = new Map<string, TelegramPreferences>();
   private initializePromise?: Promise<void>;
   private writeQueue: Promise<void> = Promise.resolve();
 
@@ -37,23 +64,41 @@ class FileTelegramProjectPreferenceStore implements TelegramProjectPreferenceSto
   }
 
   get(ownerId: string): string | undefined {
-    return this.preferences.get(ownerId);
+    return this.preferences.get(ownerId)?.projectId;
   }
 
   async set(ownerId: string, projectId: string): Promise<void> {
+    await this.update(ownerId, (preferences) => ({ ...preferences, projectId }));
+  }
+
+  isTtsEnabled(ownerId: string): boolean {
+    return this.preferences.get(ownerId)?.ttsEnabled ?? false;
+  }
+
+  async setTtsEnabled(ownerId: string, enabled: boolean): Promise<void> {
+    await this.update(ownerId, (preferences) => ({ ...preferences, ttsEnabled: enabled }));
+  }
+
+  private async update(
+    ownerId: string,
+    updatePreferences: (preferences: TelegramPreferences) => TelegramPreferences,
+  ): Promise<void> {
     await this.initialize();
     const write = this.writeQueue
       .catch(() => undefined)
       .then(async () => {
-        const previousProjectId = this.preferences.get(ownerId);
-        this.preferences.set(ownerId, projectId);
+        const previousPreferences = this.preferences.get(ownerId);
+        this.preferences.set(
+          ownerId,
+          updatePreferences(previousPreferences ?? { ttsEnabled: false }),
+        );
         try {
           await this.writeState();
         } catch (error) {
-          if (previousProjectId === undefined) {
+          if (previousPreferences === undefined) {
             this.preferences.delete(ownerId);
           } else {
-            this.preferences.set(ownerId, previousProjectId);
+            this.preferences.set(ownerId, previousPreferences);
           }
           throw error;
         }
@@ -78,25 +123,32 @@ class FileTelegramProjectPreferenceStore implements TelegramProjectPreferenceSto
       parsedJson = JSON.parse(raw);
     } catch (error) {
       throw new Error(
-        `invalid telegram project preferences: ${error instanceof Error ? error.message : String(error)}`,
+        `invalid telegram preferences: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
 
-    const parsed = telegramProjectPreferencesSchema.safeParse(parsedJson);
+    const parsed = telegramPreferencesSchema.safeParse(parsedJson);
     if (!parsed.success) {
-      throw new Error(`invalid telegram project preferences: ${parsed.error.message}`);
+      throw new Error(`invalid telegram preferences: ${parsed.error.message}`);
     }
 
-    for (const [ownerId, projectId] of Object.entries(parsed.data.preferences)) {
-      this.preferences.set(ownerId, projectId);
+    if (parsed.data.version === 1) {
+      for (const [ownerId, projectId] of Object.entries(parsed.data.preferences)) {
+        this.preferences.set(ownerId, { projectId, ttsEnabled: false });
+      }
+      return;
+    }
+
+    for (const [ownerId, preferences] of Object.entries(parsed.data.preferences)) {
+      this.preferences.set(ownerId, preferences);
     }
   }
 
   private async writeState(): Promise<void> {
     await mkdir(dirname(this.path), { recursive: true });
     const temporaryPath = `${this.path}.tmp`;
-    const state: z.infer<typeof telegramProjectPreferencesSchema> = {
-      version: 1,
+    const state: z.infer<typeof telegramPreferencesV2Schema> = {
+      version: 2,
       preferences: Object.fromEntries(this.preferences),
     };
     await writeFile(temporaryPath, `${JSON.stringify(state, null, 2)}\n`, "utf8");

--- a/src/core/telegram/runtime.ts
+++ b/src/core/telegram/runtime.ts
@@ -12,6 +12,7 @@ import {
   type TelegramSessionClientOptions,
   type TelegramSessionManager,
 } from "./session_manager.js";
+import { sweepStaleTelegramTtsTempDirs } from "./tts.js";
 
 export type TelegramRuntimeDependencies = {
   startTelegramAdapter: typeof startTelegramAdapter;
@@ -152,7 +153,11 @@ export async function startTelegramRuntime(
   const telegramAdapters: TelegramAdapterHandle[] = [];
 
   try {
-    await Promise.all([sessionManager.initialize(), projectPreferences.initialize()]);
+    await Promise.all([
+      sessionManager.initialize(),
+      projectPreferences.initialize(),
+      sweepStaleTelegramTtsTempDirs(),
+    ]);
 
     for (const [botId, botConfig] of Object.entries(options.config.bots)) {
       if (!botConfig.botToken) {

--- a/src/core/telegram/session_manager.ts
+++ b/src/core/telegram/session_manager.ts
@@ -70,6 +70,7 @@ export type TelegramSessionProgress =
       type: "assistant-message";
       messageId: string;
       text: string;
+      final: boolean;
     };
 
 export type TelegramSessionRecord = {
@@ -2103,6 +2104,7 @@ class TelegramSessionManagerImpl implements TelegramSessionManager {
       type: "assistant-message",
       messageId: message.id,
       text,
+      final: message.message.stopReason === "stop" || message.message.stopReason === "length",
     });
   }
 

--- a/src/core/telegram/session_manager.ts
+++ b/src/core/telegram/session_manager.ts
@@ -70,7 +70,6 @@ export type TelegramSessionProgress =
       type: "assistant-message";
       messageId: string;
       text: string;
-      final: boolean;
     };
 
 export type TelegramSessionRecord = {
@@ -341,6 +340,8 @@ type SessionEntry = {
   consumedFacetEventCounts: Map<string, number>;
   emittedAssistantMessageIds: Set<string>;
   emittedNoticeIds: Set<string>;
+  finalAssistantResponse?: { messageId: string; text: string };
+  turnSequenceUnsuccessful: boolean;
   activeTurnIds: Set<string>;
   settledTurnIds: Set<string>;
   pendingTurnNotifications: Map<string, PersistedTelegramTurnNotification>;
@@ -413,6 +414,14 @@ export type TelegramSessionManagerEvent =
       state: TelegramSessionState;
       timestamp: string;
       progress: TelegramSessionProgress;
+    }
+  | {
+      type: "session-response-completed";
+      sessionId: string;
+      projectId: string;
+      timestamp: string;
+      messageId: string;
+      text: string;
     }
   | TelegramSessionProvisionFailure;
 
@@ -599,6 +608,7 @@ class TelegramSessionManagerImpl implements TelegramSessionManager {
       consumedFacetEventCounts: new Map(),
       emittedAssistantMessageIds: new Set(),
       emittedNoticeIds: new Set(),
+      turnSequenceUnsuccessful: false,
       activeTurnIds: new Set(),
       settledTurnIds: new Set(),
       pendingTurnNotifications: new Map(),
@@ -850,6 +860,7 @@ class TelegramSessionManagerImpl implements TelegramSessionManager {
         consumedFacetEventCounts: new Map(),
         emittedAssistantMessageIds: new Set(),
         emittedNoticeIds: new Set(),
+        turnSequenceUnsuccessful: false,
         activeTurnIds: new Set(activeTurnIds),
         settledTurnIds: new Set(),
         pendingTurnNotifications: new Map(
@@ -1263,6 +1274,10 @@ class TelegramSessionManagerImpl implements TelegramSessionManager {
       throw new TelegramSessionManagerError("busy", "session is running");
     }
 
+    if (entry.record.state !== "running") {
+      entry.finalAssistantResponse = undefined;
+      entry.turnSequenceUnsuccessful = false;
+    }
     this.setState(entry, "running");
     this.log(entry, "info", mode === "steer" ? "steering message" : "submitting message", {
       source,
@@ -1377,6 +1392,7 @@ class TelegramSessionManagerImpl implements TelegramSessionManager {
       .finally(() => {
         if (entry.activeSubmit === trackedSubmit) {
           entry.activeSubmit = undefined;
+          this.emitCompletedResponseIfReady(entry);
           if (
             !entry.cancelRequested &&
             entry.record.state === "running" &&
@@ -1443,6 +1459,7 @@ class TelegramSessionManagerImpl implements TelegramSessionManager {
       .finally(() => {
         if (entry.activeSubmit === trackedTurns) {
           entry.activeSubmit = undefined;
+          this.emitCompletedResponseIfReady(entry);
           if (!entry.cancelRequested && entry.record.state === "running") {
             this.setState(entry, "waiting-input");
           }
@@ -1529,8 +1546,16 @@ class TelegramSessionManagerImpl implements TelegramSessionManager {
       return false;
     }
     entry.turnChangeResolvers.get(historyEntryId)?.();
-    if (turn.outcome.status === "failed" || turn.outcome.status === "blocked") {
-      this.recordTurnFailure(entry, historyEntryId, turn.outcome);
+    if (turn.outcome.status === "completed") {
+      if (turn.outcome.stopReason === "stop" || turn.outcome.stopReason === "length") {
+        this.emitCompletedResponseIfReady(entry);
+      }
+    } else {
+      entry.turnSequenceUnsuccessful = true;
+      entry.finalAssistantResponse = undefined;
+      if (turn.outcome.status === "failed" || turn.outcome.status === "blocked") {
+        this.recordTurnFailure(entry, historyEntryId, turn.outcome);
+      }
     }
     if (
       entry.activeTurnIds.size === 0 &&
@@ -1560,6 +1585,8 @@ class TelegramSessionManagerImpl implements TelegramSessionManager {
   }
 
   private recordTurnRejection(entry: SessionEntry, historyEntryId: string): void {
+    entry.turnSequenceUnsuccessful = true;
+    entry.finalAssistantResponse = undefined;
     entry.activeTurnIds.delete(historyEntryId);
     entry.settledTurnIds.add(historyEntryId);
     entry.turnChangeResolvers.get(historyEntryId)?.();
@@ -2104,8 +2131,11 @@ class TelegramSessionManagerImpl implements TelegramSessionManager {
       type: "assistant-message",
       messageId: message.id,
       text,
-      final: message.message.stopReason === "stop" || message.message.stopReason === "length",
     });
+    if (message.message.stopReason === "stop" || message.message.stopReason === "length") {
+      entry.finalAssistantResponse = { messageId: message.id, text };
+      this.emitCompletedResponseIfReady(entry);
+    }
   }
 
   private handleFacetProgress(entry: SessionEntry, facet: SessionProtocolFacet): void {
@@ -2149,6 +2179,28 @@ class TelegramSessionManagerImpl implements TelegramSessionManager {
           break;
       }
     }
+  }
+
+  private emitCompletedResponseIfReady(entry: SessionEntry): void {
+    if (
+      entry.activeSubmit ||
+      entry.activeTurnIds.size > 0 ||
+      entry.turnSequenceUnsuccessful ||
+      !entry.finalAssistantResponse
+    ) {
+      return;
+    }
+
+    const response = entry.finalAssistantResponse;
+    entry.finalAssistantResponse = undefined;
+    this.emit({
+      type: "session-response-completed",
+      sessionId: entry.record.id,
+      projectId: entry.record.projectId,
+      timestamp: this.now().toISOString(),
+      messageId: response.messageId,
+      text: response.text,
+    });
   }
 
   private emitProgress(entry: SessionEntry, progress: TelegramSessionProgress): void {

--- a/src/core/telegram/session_manager.ts
+++ b/src/core/telegram/session_manager.ts
@@ -1354,6 +1354,7 @@ class TelegramSessionManagerImpl implements TelegramSessionManager {
             });
           }
         }
+        this.invalidateCompletedResponse(entry);
         if (!entry.cancelRequested) {
           const diagnostic = formatErrorDiagnostic(error);
           entry.record.error = diagnostic;
@@ -1551,8 +1552,7 @@ class TelegramSessionManagerImpl implements TelegramSessionManager {
         this.emitCompletedResponseIfReady(entry);
       }
     } else {
-      entry.turnSequenceUnsuccessful = true;
-      entry.finalAssistantResponse = undefined;
+      this.invalidateCompletedResponse(entry);
       if (turn.outcome.status === "failed" || turn.outcome.status === "blocked") {
         this.recordTurnFailure(entry, historyEntryId, turn.outcome);
       }
@@ -1585,8 +1585,7 @@ class TelegramSessionManagerImpl implements TelegramSessionManager {
   }
 
   private recordTurnRejection(entry: SessionEntry, historyEntryId: string): void {
-    entry.turnSequenceUnsuccessful = true;
-    entry.finalAssistantResponse = undefined;
+    this.invalidateCompletedResponse(entry);
     entry.activeTurnIds.delete(historyEntryId);
     entry.settledTurnIds.add(historyEntryId);
     entry.turnChangeResolvers.get(historyEntryId)?.();
@@ -1719,8 +1718,7 @@ class TelegramSessionManagerImpl implements TelegramSessionManager {
 
     for (const entry of entries) {
       if (this.isActiveState(entry.record.state)) {
-        entry.cancelRequested = true;
-        entry.abortController.abort();
+        this.requestCancellation(entry, "manager shutdown");
       }
       if (entry.record.state === "running") {
         this.setState(entry, "waiting-input");
@@ -1820,8 +1818,14 @@ class TelegramSessionManagerImpl implements TelegramSessionManager {
 
   private requestCancellation(entry: SessionEntry, message: string): void {
     entry.cancelRequested = true;
+    this.invalidateCompletedResponse(entry);
     entry.abortController.abort();
     this.log(entry, "info", message);
+  }
+
+  private invalidateCompletedResponse(entry: SessionEntry): void {
+    entry.turnSequenceUnsuccessful = true;
+    entry.finalAssistantResponse = undefined;
   }
 
   private async stopClient(entry: SessionEntry, reason: string): Promise<void> {
@@ -2185,6 +2189,8 @@ class TelegramSessionManagerImpl implements TelegramSessionManager {
     if (
       entry.activeSubmit ||
       entry.activeTurnIds.size > 0 ||
+      entry.cancelRequested ||
+      entry.record.state === "failed" ||
       entry.turnSequenceUnsuccessful ||
       !entry.finalAssistantResponse
     ) {

--- a/src/core/telegram/tts.ts
+++ b/src/core/telegram/tts.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { streamGeminiSpeechAudio } from "../utils/gemini_speech.js";
+import { GEMINI_SPEECH_PLAYBACK_RATE, streamGeminiSpeechAudio } from "../utils/gemini_speech.js";
 import { spawnWithCapture } from "../utils/spawn_capture.js";
 
 const TELEGRAM_TTS_TEMP_DIR_PREFIX = "tau-telegram-tts-";
@@ -53,6 +53,8 @@ export async function generateTelegramVoice(
         "-y",
         "-i",
         inputPath,
+        "-filter:a",
+        `atempo=${GEMINI_SPEECH_PLAYBACK_RATE}`,
         "-c:a",
         "libopus",
         "-b:a",

--- a/src/core/telegram/tts.ts
+++ b/src/core/telegram/tts.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { GEMINI_SPEECH_PLAYBACK_RATE, streamGeminiSpeechAudio } from "../utils/gemini_speech.js";
@@ -7,6 +7,25 @@ import { spawnWithCapture } from "../utils/spawn_capture.js";
 const TELEGRAM_TTS_TEMP_DIR_PREFIX = "tau-telegram-tts-";
 const TELEGRAM_TTS_CONVERSION_TIMEOUT_MS = 120_000;
 const WAVE_HEADER_BYTES = 44;
+
+export async function sweepStaleTelegramTtsTempDirs(): Promise<void> {
+  const systemTmpDir = tmpdir();
+  try {
+    const entries = await readdir(systemTmpDir, { withFileTypes: true, encoding: "utf8" });
+    await Promise.allSettled(
+      entries
+        .filter(
+          (entry) => entry.isDirectory() && entry.name.startsWith(TELEGRAM_TTS_TEMP_DIR_PREFIX),
+        )
+        .map(
+          async (entry) =>
+            await rm(join(systemTmpDir, entry.name), { recursive: true, force: true }),
+        ),
+    );
+  } catch {
+    return;
+  }
+}
 
 export type GenerateTelegramVoiceOptions = {
   apiKey: string;
@@ -24,25 +43,44 @@ export async function generateTelegramVoice(
 ): Promise<Buffer> {
   const streamSpeechAudio = options.deps?.streamSpeechAudio ?? streamGeminiSpeechAudio;
   const spawn = options.deps?.spawn ?? spawnWithCapture;
-  const chunks: Buffer[] = [];
-
-  for await (const chunk of streamSpeechAudio({
-    apiKey: options.apiKey,
-    sourceText: options.sourceText,
-    deliveryMode: "complete",
-    fetchImpl: options.fetchImpl,
-    signal: options.signal,
-  })) {
-    chunks.push(chunk.audio);
-  }
-
-  const waveAudio = concatenateWaveAudio(chunks);
   const temporaryDirectory = await mkdtemp(join(tmpdir(), TELEGRAM_TTS_TEMP_DIR_PREFIX));
-  const inputPath = join(temporaryDirectory, "speech.wav");
+  const manifestPath = join(temporaryDirectory, "speech.ffconcat");
   const outputPath = join(temporaryDirectory, "speech.ogg");
 
   try {
-    await writeFile(inputPath, waveAudio);
+    const chunkNames: string[] = [];
+    let waveFormat: Buffer | undefined;
+
+    for await (const chunk of streamSpeechAudio({
+      apiKey: options.apiKey,
+      sourceText: options.sourceText,
+      deliveryMode: "complete",
+      fetchImpl: options.fetchImpl,
+      signal: options.signal,
+    })) {
+      const header = parseWaveHeader(chunk.audio);
+      if (waveFormat && !header.format.equals(waveFormat)) {
+        throw new Error("Gemini TTS returned incompatible audio chunks");
+      }
+      waveFormat ??= Buffer.from(header.format);
+
+      const chunkName = `chunk-${String(chunkNames.length).padStart(3, "0")}.wav`;
+      await writeFile(
+        join(temporaryDirectory, chunkName),
+        chunk.audio.subarray(0, WAVE_HEADER_BYTES + header.dataBytes),
+      );
+      chunkNames.push(chunkName);
+    }
+
+    if (chunkNames.length === 0) {
+      throw new Error("Gemini TTS returned no audio");
+    }
+
+    await writeFile(
+      manifestPath,
+      `ffconcat version 1.0\n${chunkNames.map((name) => `file '${name}'`).join("\n")}\n`,
+      "utf8",
+    );
     const result = await spawn(
       "ffmpeg",
       [
@@ -51,8 +89,12 @@ export async function generateTelegramVoice(
         "-loglevel",
         "error",
         "-y",
+        "-f",
+        "concat",
+        "-safe",
+        "1",
         "-i",
-        inputPath,
+        "speech.ffconcat",
         "-filter:a",
         `atempo=${GEMINI_SPEECH_PLAYBACK_RATE}`,
         "-c:a",
@@ -63,9 +105,10 @@ export async function generateTelegramVoice(
         "on",
         "-application",
         "voip",
-        outputPath,
+        "speech.ogg",
       ],
       {
+        cwd: temporaryDirectory,
         detached: true,
         killProcessGroup: true,
         signal: options.signal,
@@ -102,31 +145,6 @@ export async function generateTelegramVoice(
   } finally {
     await rm(temporaryDirectory, { recursive: true, force: true });
   }
-}
-
-function concatenateWaveAudio(chunks: Buffer[]): Buffer {
-  if (chunks.length === 0) {
-    throw new Error("Gemini TTS returned no audio");
-  }
-
-  const firstHeader = parseWaveHeader(chunks[0]!);
-  const pcmChunks: Buffer[] = [];
-  let totalPcmBytes = 0;
-
-  for (const chunk of chunks) {
-    const header = parseWaveHeader(chunk);
-    if (!header.format.equals(firstHeader.format)) {
-      throw new Error("Gemini TTS returned incompatible audio chunks");
-    }
-    const pcm = chunk.subarray(WAVE_HEADER_BYTES, WAVE_HEADER_BYTES + header.dataBytes);
-    pcmChunks.push(pcm);
-    totalPcmBytes += pcm.length;
-  }
-
-  const header = Buffer.from(chunks[0]!.subarray(0, WAVE_HEADER_BYTES));
-  header.writeUInt32LE(WAVE_HEADER_BYTES - 8 + totalPcmBytes, 4);
-  header.writeUInt32LE(totalPcmBytes, 40);
-  return Buffer.concat([header, ...pcmChunks], WAVE_HEADER_BYTES + totalPcmBytes);
 }
 
 function parseWaveHeader(audio: Buffer): { format: Buffer; dataBytes: number } {

--- a/src/core/telegram/tts.ts
+++ b/src/core/telegram/tts.ts
@@ -29,6 +29,7 @@ export async function generateTelegramVoice(
   for await (const chunk of streamSpeechAudio({
     apiKey: options.apiKey,
     sourceText: options.sourceText,
+    deliveryMode: "complete",
     fetchImpl: options.fetchImpl,
     signal: options.signal,
   })) {

--- a/src/core/telegram/tts.ts
+++ b/src/core/telegram/tts.ts
@@ -1,0 +1,164 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { streamGeminiSpeechAudio } from "../utils/gemini_speech.js";
+import { spawnWithCapture } from "../utils/spawn_capture.js";
+
+const TELEGRAM_TTS_TEMP_DIR_PREFIX = "tau-telegram-tts-";
+const TELEGRAM_TTS_CONVERSION_TIMEOUT_MS = 120_000;
+const WAVE_HEADER_BYTES = 44;
+
+export type GenerateTelegramVoiceOptions = {
+  apiKey: string;
+  sourceText: string;
+  fetchImpl?: typeof fetch;
+  signal?: AbortSignal;
+  deps?: {
+    streamSpeechAudio?: typeof streamGeminiSpeechAudio;
+    spawn?: typeof spawnWithCapture;
+  };
+};
+
+export async function generateTelegramVoice(
+  options: GenerateTelegramVoiceOptions,
+): Promise<Buffer> {
+  const streamSpeechAudio = options.deps?.streamSpeechAudio ?? streamGeminiSpeechAudio;
+  const spawn = options.deps?.spawn ?? spawnWithCapture;
+  const chunks: Buffer[] = [];
+
+  for await (const chunk of streamSpeechAudio({
+    apiKey: options.apiKey,
+    sourceText: options.sourceText,
+    fetchImpl: options.fetchImpl,
+    signal: options.signal,
+  })) {
+    chunks.push(chunk.audio);
+  }
+
+  const waveAudio = concatenateWaveAudio(chunks);
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), TELEGRAM_TTS_TEMP_DIR_PREFIX));
+  const inputPath = join(temporaryDirectory, "speech.wav");
+  const outputPath = join(temporaryDirectory, "speech.ogg");
+
+  try {
+    await writeFile(inputPath, waveAudio);
+    const result = await spawn(
+      "ffmpeg",
+      [
+        "-nostdin",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-y",
+        "-i",
+        inputPath,
+        "-c:a",
+        "libopus",
+        "-b:a",
+        "48k",
+        "-vbr",
+        "on",
+        "-application",
+        "voip",
+        outputPath,
+      ],
+      {
+        detached: true,
+        killProcessGroup: true,
+        signal: options.signal,
+        timeoutMs: TELEGRAM_TTS_CONVERSION_TIMEOUT_MS,
+        maxCaptureBytes: 20_000,
+      },
+    );
+
+    if (result.aborted || options.signal?.aborted) {
+      throw abortError();
+    }
+    if (result.timedOut) {
+      throw new Error("ffmpeg timed out while encoding Telegram voice audio");
+    }
+    if (result.exitCode !== 0) {
+      const detail = result.stderr.trim();
+      throw new Error(
+        detail
+          ? `ffmpeg failed to encode Telegram voice audio: ${detail}`
+          : `ffmpeg exited with code ${result.exitCode ?? "unknown"}`,
+      );
+    }
+
+    const voice = await readFile(outputPath);
+    if (voice.length === 0) {
+      throw new Error("ffmpeg produced empty Telegram voice audio");
+    }
+    return voice;
+  } catch (error) {
+    if (isMissingExecutableError(error)) {
+      throw new Error("ffmpeg is required to encode Telegram voice notes");
+    }
+    throw error;
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+function concatenateWaveAudio(chunks: Buffer[]): Buffer {
+  if (chunks.length === 0) {
+    throw new Error("Gemini TTS returned no audio");
+  }
+
+  const firstHeader = parseWaveHeader(chunks[0]!);
+  const pcmChunks: Buffer[] = [];
+  let totalPcmBytes = 0;
+
+  for (const chunk of chunks) {
+    const header = parseWaveHeader(chunk);
+    if (!header.format.equals(firstHeader.format)) {
+      throw new Error("Gemini TTS returned incompatible audio chunks");
+    }
+    const pcm = chunk.subarray(WAVE_HEADER_BYTES, WAVE_HEADER_BYTES + header.dataBytes);
+    pcmChunks.push(pcm);
+    totalPcmBytes += pcm.length;
+  }
+
+  const header = Buffer.from(chunks[0]!.subarray(0, WAVE_HEADER_BYTES));
+  header.writeUInt32LE(WAVE_HEADER_BYTES - 8 + totalPcmBytes, 4);
+  header.writeUInt32LE(totalPcmBytes, 40);
+  return Buffer.concat([header, ...pcmChunks], WAVE_HEADER_BYTES + totalPcmBytes);
+}
+
+function parseWaveHeader(audio: Buffer): { format: Buffer; dataBytes: number } {
+  if (
+    audio.length < WAVE_HEADER_BYTES ||
+    audio.toString("ascii", 0, 4) !== "RIFF" ||
+    audio.toString("ascii", 8, 12) !== "WAVE" ||
+    audio.toString("ascii", 12, 16) !== "fmt " ||
+    audio.toString("ascii", 36, 40) !== "data"
+  ) {
+    throw new Error("Gemini TTS returned invalid WAV audio");
+  }
+
+  const dataBytes = audio.readUInt32LE(40);
+  if (dataBytes > audio.length - WAVE_HEADER_BYTES) {
+    throw new Error("Gemini TTS returned truncated WAV audio");
+  }
+
+  return {
+    format: audio.subarray(20, 36),
+    dataBytes,
+  };
+}
+
+function isMissingExecutableError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as NodeJS.ErrnoException).code === "ENOENT"
+  );
+}
+
+function abortError(): Error {
+  const error = new Error("Telegram TTS was aborted");
+  error.name = "AbortError";
+  return error;
+}

--- a/src/core/utils/gemini_speech.ts
+++ b/src/core/utils/gemini_speech.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 const GEMINI_GENERATE_CONTENT_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/models";
+export const GEMINI_SPEECH_PLAYBACK_RATE = 1.1;
 const DEFAULT_GEMINI_SPEECH_REWRITE_MODEL = "gemini-3.6-flash";
 const DEFAULT_GEMINI_SPEECH_REWRITE_THINKING_LEVEL = "minimal";
 const DEFAULT_GEMINI_SPEECH_TTS_MODEL = "gemini-3.1-flash-tts-preview";
@@ -114,7 +115,6 @@ export async function* streamGeminiSpeechAudio(
       model: ttsModel,
       voiceName,
       spokenChunks,
-      deliveryMode: options.deliveryMode,
       fetchImpl,
       signal: abortController.signal,
       maxAttempts: options.maxTtsAttempts ?? DEFAULT_TTS_MAX_ATTEMPTS,
@@ -191,7 +191,6 @@ type SynthesizeSpeechAudioChunksArgs = {
   model: string;
   voiceName: string;
   spokenChunks: string[];
-  deliveryMode: GeminiSpeechDeliveryMode;
   fetchImpl: typeof fetch;
   signal?: AbortSignal;
   maxAttempts: number;
@@ -260,7 +259,6 @@ async function* synthesizeSpeechAudioChunksInOrder(
           model: args.model,
           voiceName: args.voiceName,
           spokenText: args.spokenChunks[index]!,
-          deliveryMode: args.deliveryMode,
           fetchImpl: args.fetchImpl,
           signal: args.signal,
           maxAttempts: args.maxAttempts,
@@ -309,7 +307,6 @@ type SynthesizeSpeechAudioChunkArgs = {
   model: string;
   voiceName: string;
   spokenText: string;
-  deliveryMode: GeminiSpeechDeliveryMode;
   fetchImpl: typeof fetch;
   signal?: AbortSignal;
   maxAttempts: number;
@@ -331,7 +328,7 @@ async function synthesizeSpeechAudioChunk(args: SynthesizeSpeechAudioChunkArgs):
             {
               parts: [
                 {
-                  text: buildSpeechSynthesisPrompt(args.spokenText, args.deliveryMode),
+                  text: buildSpeechSynthesisPrompt(args.spokenText),
                 },
               ],
             },
@@ -551,19 +548,14 @@ function calculateTtsMaxOutputTokens(spokenText: string): number {
   return Math.min(MAX_TTS_OUTPUT_TOKENS, Math.max(MIN_TTS_OUTPUT_TOKENS, roundedTokens));
 }
 
-function buildSpeechSynthesisPrompt(
-  spokenText: string,
-  deliveryMode: GeminiSpeechDeliveryMode,
-): string {
+function buildSpeechSynthesisPrompt(spokenText: string): string {
   return [
     "Synthesize speech audio for the labeled transcript below.",
     "Speak only the transcript. Do not speak the instructions or section labels.",
     "",
     "### DIRECTOR'S NOTES",
     "Style: Clear, natural, conversational.",
-    deliveryMode === "progressive"
-      ? "Pacing: Slightly slower than conversational, with deliberate enunciation. The audio will be sped up during playback."
-      : "Pacing: Natural conversational speed with clear enunciation.",
+    "Pacing: Brisk conversational speed. Keep it clear, confident, and energetic without sounding rushed.",
     "",
     "### TRANSCRIPT",
     spokenText,

--- a/src/core/utils/gemini_speech.ts
+++ b/src/core/utils/gemini_speech.ts
@@ -9,8 +9,14 @@ const DEFAULT_TTS_SAMPLE_RATE_HZ = 24000;
 const DEFAULT_TTS_CHANNEL_COUNT = 1;
 const DEFAULT_TTS_BITS_PER_SAMPLE = 16;
 const DEFAULT_TTS_MAX_ATTEMPTS = 3;
-const DEFAULT_TTS_CONCURRENCY = 6;
-const MIN_SPEECH_CHUNK_CHARACTERS = 240;
+const PROGRESSIVE_TTS_CONCURRENCY = 6;
+const COMPLETE_TTS_CONCURRENCY = 3;
+const PROGRESSIVE_SPEECH_CHUNK_CHARACTERS = 500;
+const COMPLETE_SPEECH_CHUNK_CHARACTERS = 1000;
+const MIN_TTS_OUTPUT_TOKENS = 1024;
+const MAX_TTS_OUTPUT_TOKENS = 8192;
+const TTS_OUTPUT_TOKENS_PER_SPOKEN_UNIT = 24;
+const TTS_OUTPUT_TOKEN_STEP = 256;
 const RETRYABLE_TTS_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
 
 const errorPayloadSchema = z.object({
@@ -24,6 +30,7 @@ const errorPayloadSchema = z.object({
 });
 
 export type GeminiSpeechStage = "rewriting" | "generating";
+export type GeminiSpeechDeliveryMode = "progressive" | "complete";
 
 export type GeminiSpeechChunkProgress = {
   ready: number;
@@ -33,6 +40,7 @@ export type GeminiSpeechChunkProgress = {
 export type GeminiSpeechOptions = {
   apiKey: string;
   sourceText: string;
+  deliveryMode: GeminiSpeechDeliveryMode;
   rewriteModel?: string;
   ttsModel?: string;
   voiceName?: string;
@@ -97,7 +105,7 @@ export async function* streamGeminiSpeechAudio(
       signal: abortController.signal,
     });
 
-    const spokenChunks = splitSpeechChunks(spokenText);
+    const spokenChunks = splitSpeechChunks(spokenText, options.deliveryMode);
     await options.onStageChange?.("generating");
     await options.onChunkProgress?.({ ready: 0, total: spokenChunks.length });
 
@@ -106,10 +114,14 @@ export async function* streamGeminiSpeechAudio(
       model: ttsModel,
       voiceName,
       spokenChunks,
+      deliveryMode: options.deliveryMode,
       fetchImpl,
       signal: abortController.signal,
       maxAttempts: options.maxTtsAttempts ?? DEFAULT_TTS_MAX_ATTEMPTS,
-      concurrency: DEFAULT_TTS_CONCURRENCY,
+      concurrency:
+        options.deliveryMode === "progressive"
+          ? PROGRESSIVE_TTS_CONCURRENCY
+          : COMPLETE_TTS_CONCURRENCY,
       onChunkProgress: options.onChunkProgress,
       abortOnFailure: () => abortController.abort(),
     })) {
@@ -179,6 +191,7 @@ type SynthesizeSpeechAudioChunksArgs = {
   model: string;
   voiceName: string;
   spokenChunks: string[];
+  deliveryMode: GeminiSpeechDeliveryMode;
   fetchImpl: typeof fetch;
   signal?: AbortSignal;
   maxAttempts: number;
@@ -247,6 +260,7 @@ async function* synthesizeSpeechAudioChunksInOrder(
           model: args.model,
           voiceName: args.voiceName,
           spokenText: args.spokenChunks[index]!,
+          deliveryMode: args.deliveryMode,
           fetchImpl: args.fetchImpl,
           signal: args.signal,
           maxAttempts: args.maxAttempts,
@@ -295,6 +309,7 @@ type SynthesizeSpeechAudioChunkArgs = {
   model: string;
   voiceName: string;
   spokenText: string;
+  deliveryMode: GeminiSpeechDeliveryMode;
   fetchImpl: typeof fetch;
   signal?: AbortSignal;
   maxAttempts: number;
@@ -316,14 +331,14 @@ async function synthesizeSpeechAudioChunk(args: SynthesizeSpeechAudioChunkArgs):
             {
               parts: [
                 {
-                  text: buildSpeechSynthesisPrompt(args.spokenText),
+                  text: buildSpeechSynthesisPrompt(args.spokenText, args.deliveryMode),
                 },
               ],
             },
           ],
           generationConfig: {
             responseModalities: ["AUDIO"],
-            temperature: 1,
+            maxOutputTokens: calculateTtsMaxOutputTokens(args.spokenText),
             speechConfig: {
               voiceConfig: {
                 prebuiltVoiceConfig: {
@@ -463,14 +478,17 @@ function buildSpeechRewritePrompt(sourceText: string): string {
     "Things that typically need rewriting: file paths, shell commands, code identifiers, markdown structure, XML-like tags, long option lists, and code-heavy formatting.",
     "Remove formatting. Convert headings, lists, tables, and code blocks into plain spoken prose. Do not preserve markdown bullets, heading markers, table rows, fences, or standalone labels.",
     "For file references, keep the filename and any line or range info that was actually present. Do not add location detail that was not in the original.",
-    "Say code identifiers and version strings as natural words (for example, handleToolUiEvent as 'handle tool UI event', v5.4 as 'version 5.4'). Keep numbers and units natural (for example, 8,192 tokens as 'about eight thousand tokens').",
+    "Preserve numbers exactly as written, including separators, decimals, units, versions, line numbers, and ranges.",
+    "Preserve established technical names, acronyms, initialisms, commands, program names, filenames, and extensions exactly as written. Do not spell their letters apart, expand them, or change their capitalization. Examples that must remain unchanged include 24, PCM, ffmpeg, npm, v5.4, and config.json.",
+    "Rewrite a code identifier only when its literal form would be difficult to follow aloud, and preserve its exact meaning.",
     "",
     "Examples of good rewrites:",
     '- `src/core/utils/gemini_speech.ts:372` → "gemini_speech.ts, line 372"',
     '- `src/tui/session_chat_controller.ts:1819-1855` → "session_chat_controller.ts, lines 1819 to 1855"',
     '- `src/core/session/compaction.ts` → "compaction.ts"',
     '- `/Users/markus/.config/tau/config.json` → "the tau config.json in your home directory"',
-    '- `rg --heading -n -t ts "ToolRunPresentation" src` → "ripgrep for ToolRunPresentation in TypeScript files under src"',
+    '- `rg --heading -n -t ts "ToolRunPresentation" src` → "the rg command searching TypeScript files for ToolRunPresentation under src"',
+    '- `24 kHz PCM with ffmpeg` → "24 kHz PCM with ffmpeg"',
     '- `<available-skills>` → "the available-skills tag"',
     "- A markdown bullet list of short items → a natural comma-separated list or short sentences",
     "",
@@ -483,57 +501,69 @@ function buildSpeechRewritePrompt(sourceText: string): string {
   ].join("\n");
 }
 
-function splitSpeechChunks(spokenText: string): string[] {
-  const paragraphs = spokenText
-    .split(/\n\s*\n/g)
-    .map((paragraph) => normalizeSpeechParagraph(paragraph))
-    .filter((paragraph) => paragraph.length > 0);
-
-  if (paragraphs.length === 0) {
-    return [spokenText.trim()];
-  }
-
+function splitSpeechChunks(spokenText: string, deliveryMode: GeminiSpeechDeliveryMode): string[] {
+  const normalizedText = spokenText.replace(/\s+/g, " ").trim();
+  const maxCharacters =
+    deliveryMode === "progressive"
+      ? PROGRESSIVE_SPEECH_CHUNK_CHARACTERS
+      : COMPLETE_SPEECH_CHUNK_CHARACTERS;
   const chunks: string[] = [];
-  let current = "";
+  let remaining = normalizedText;
 
-  for (const paragraph of paragraphs) {
-    if (!current) {
-      current = paragraph;
-      continue;
-    }
-
-    if (current.length < MIN_SPEECH_CHUNK_CHARACTERS) {
-      current = joinSpeechParagraphs(current, paragraph);
-      continue;
-    }
-
-    chunks.push(current);
-    current = paragraph;
+  while (remaining.length > maxCharacters) {
+    const boundary = findSpeechChunkBoundary(remaining, maxCharacters);
+    chunks.push(remaining.slice(0, boundary).trim());
+    remaining = remaining.slice(boundary).trim();
   }
 
-  if (current) {
-    chunks.push(current);
+  if (remaining) {
+    chunks.push(remaining);
   }
 
-  return chunks;
+  return chunks.length > 0 ? chunks : [spokenText.trim()];
 }
 
-function normalizeSpeechParagraph(paragraph: string): string {
-  return paragraph.replace(/\s+/g, " ").trim();
+function findSpeechChunkBoundary(text: string, maxCharacters: number): number {
+  const preferredMinimum = Math.floor(maxCharacters * 0.6);
+  let fallbackBoundary = -1;
+
+  for (let index = maxCharacters; index >= 1; index -= 1) {
+    if (!/\s/.test(text[index] ?? "")) {
+      continue;
+    }
+    if (fallbackBoundary === -1) {
+      fallbackBoundary = index;
+    }
+    if (index >= preferredMinimum && /[.!?;:。！？]/u.test(text[index - 1] ?? "")) {
+      return index;
+    }
+  }
+
+  return fallbackBoundary === -1 ? maxCharacters : fallbackBoundary;
 }
 
-function joinSpeechParagraphs(first: string, second: string): string {
-  return `${first}\n\n${second}`;
+function calculateTtsMaxOutputTokens(spokenText: string): number {
+  const wordCount = spokenText.split(/\s+/u).filter(Boolean).length;
+  const characterUnits = Math.ceil(Array.from(spokenText).length / 6);
+  const spokenUnits = Math.max(wordCount, characterUnits);
+  const estimatedTokens = spokenUnits * TTS_OUTPUT_TOKENS_PER_SPOKEN_UNIT;
+  const roundedTokens = Math.ceil(estimatedTokens / TTS_OUTPUT_TOKEN_STEP) * TTS_OUTPUT_TOKEN_STEP;
+  return Math.min(MAX_TTS_OUTPUT_TOKENS, Math.max(MIN_TTS_OUTPUT_TOKENS, roundedTokens));
 }
 
-function buildSpeechSynthesisPrompt(spokenText: string): string {
+function buildSpeechSynthesisPrompt(
+  spokenText: string,
+  deliveryMode: GeminiSpeechDeliveryMode,
+): string {
   return [
     "Synthesize speech audio for the labeled transcript below.",
     "Speak only the transcript. Do not speak the instructions or section labels.",
     "",
     "### DIRECTOR'S NOTES",
     "Style: Clear, natural, conversational.",
-    "Pacing: Slightly slower than conversational, with deliberate enunciation. The audio will be sped up during playback.",
+    deliveryMode === "progressive"
+      ? "Pacing: Slightly slower than conversational, with deliberate enunciation. The audio will be sped up during playback."
+      : "Pacing: Natural conversational speed with clear enunciation.",
     "",
     "### TRANSCRIPT",
     spokenText,

--- a/src/core/utils/gemini_speech.ts
+++ b/src/core/utils/gemini_speech.ts
@@ -10,14 +10,15 @@ const DEFAULT_TTS_SAMPLE_RATE_HZ = 24000;
 const DEFAULT_TTS_CHANNEL_COUNT = 1;
 const DEFAULT_TTS_BITS_PER_SAMPLE = 16;
 const DEFAULT_TTS_MAX_ATTEMPTS = 3;
+const SPEECH_REWRITE_TIMEOUT_MS = 60_000;
 const PROGRESSIVE_TTS_CONCURRENCY = 6;
 const COMPLETE_TTS_CONCURRENCY = 3;
 const PROGRESSIVE_SPEECH_CHUNK_CHARACTERS = 500;
 const COMPLETE_SPEECH_CHUNK_CHARACTERS = 1000;
-const MIN_TTS_OUTPUT_TOKENS = 1024;
-const MAX_TTS_OUTPUT_TOKENS = 8192;
-const TTS_OUTPUT_TOKENS_PER_SPOKEN_UNIT = 24;
-const TTS_OUTPUT_TOKEN_STEP = 256;
+const MAX_SPEECH_SOURCE_CHARACTERS = 10_000;
+const MAX_SPOKEN_TEXT_CHARACTERS = 10_000;
+const MAX_SPEECH_PCM_BYTES = 32 * 1024 * 1024;
+const TTS_MAX_OUTPUT_TOKENS = 8192;
 const RETRYABLE_TTS_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
 
 const errorPayloadSchema = z.object({
@@ -76,12 +77,22 @@ class GeminiTtsResponseError extends Error {
   }
 }
 
+class GeminiTtsOutputLimitError extends Error {
+  constructor() {
+    super("Gemini TTS reached its output token limit");
+    this.name = "GeminiTtsOutputLimitError";
+  }
+}
+
 export async function* streamGeminiSpeechAudio(
   options: GeminiSpeechOptions,
 ): AsyncGenerator<GeminiSpeechAudioChunk> {
   const sourceText = options.sourceText.trim();
   if (!sourceText) {
     throw new Error("speech source text was empty");
+  }
+  if (exceedsUnicodeCharacterLimit(sourceText, MAX_SPEECH_SOURCE_CHARACTERS)) {
+    throw new Error("speech source text exceeds 10,000 characters");
   }
 
   const apiKey = options.apiKey.trim();
@@ -98,13 +109,30 @@ export async function* streamGeminiSpeechAudio(
 
   try {
     await options.onStageChange?.("rewriting");
-    const spokenText = await rewriteTextForSpeech({
-      apiKey,
-      model: rewriteModel,
-      sourceText,
-      fetchImpl,
-      signal: abortController.signal,
-    });
+    const rewriteController = createLinkedAbortController(abortController.signal);
+    const rewriteTimeout = setTimeout(() => rewriteController.abort(), SPEECH_REWRITE_TIMEOUT_MS);
+    rewriteTimeout.unref?.();
+    let spokenText: string;
+    try {
+      spokenText = await rewriteTextForSpeech({
+        apiKey,
+        model: rewriteModel,
+        sourceText,
+        fetchImpl,
+        signal: rewriteController.signal,
+      });
+    } catch (error) {
+      if (!abortController.signal.aborted && rewriteController.signal.aborted) {
+        throw new Error("speech rewrite timed out after 1 minute");
+      }
+      throw error;
+    } finally {
+      clearTimeout(rewriteTimeout);
+      rewriteController.dispose();
+    }
+    if (exceedsUnicodeCharacterLimit(spokenText, MAX_SPOKEN_TEXT_CHARACTERS)) {
+      throw new Error("rewritten speech text exceeds 10,000 characters");
+    }
 
     const spokenChunks = splitSpeechChunks(spokenText, options.deliveryMode);
     await options.onStageChange?.("generating");
@@ -216,6 +244,7 @@ async function* synthesizeSpeechAudioChunksInOrder(
   let nextIndex = 0;
   let nextYieldIndex = 0;
   let ready = 0;
+  let totalPcmBytes = 0;
   let failure: unknown;
   let notify: (() => void) | undefined;
 
@@ -254,7 +283,7 @@ async function* synthesizeSpeechAudioChunksInOrder(
       }
 
       try {
-        results[index] = await synthesizeSpeechAudioChunk({
+        const pcmAudio = await synthesizeSpeechAudioChunk({
           apiKey: args.apiKey,
           model: args.model,
           voiceName: args.voiceName,
@@ -263,6 +292,11 @@ async function* synthesizeSpeechAudioChunksInOrder(
           signal: args.signal,
           maxAttempts: args.maxAttempts,
         });
+        totalPcmBytes += pcmAudio.length;
+        if (totalPcmBytes > MAX_SPEECH_PCM_BYTES) {
+          throw new Error("generated speech audio exceeds the 32 MiB limit");
+        }
+        results[index] = pcmAudio;
         ready += 1;
         await args.onChunkProgress?.({ ready, total });
         wake();
@@ -284,6 +318,7 @@ async function* synthesizeSpeechAudioChunksInOrder(
     while (nextYieldIndex < total) {
       const nextResult = results[nextYieldIndex];
       if (nextResult) {
+        results[nextYieldIndex] = undefined;
         yield { index: nextYieldIndex, pcmAudio: nextResult };
         nextYieldIndex += 1;
         continue;
@@ -335,7 +370,7 @@ async function synthesizeSpeechAudioChunk(args: SynthesizeSpeechAudioChunkArgs):
           ],
           generationConfig: {
             responseModalities: ["AUDIO"],
-            maxOutputTokens: calculateTtsMaxOutputTokens(args.spokenText),
+            maxOutputTokens: TTS_MAX_OUTPUT_TOKENS,
             speechConfig: {
               voiceConfig: {
                 prebuiltVoiceConfig: {
@@ -347,6 +382,7 @@ async function synthesizeSpeechAudioChunk(args: SynthesizeSpeechAudioChunkArgs):
         },
       });
 
+      assertGeminiTtsDidNotReachOutputLimit(payload);
       const audioData = extractGeminiInlineAudioData(payload);
       if (!audioData) {
         throw new GeminiTtsResponseError("Gemini TTS response did not include audio data");
@@ -435,6 +471,20 @@ function extractGeminiText(payload: unknown): string {
   return "";
 }
 
+function assertGeminiTtsDidNotReachOutputLimit(payload: unknown): void {
+  if (!isObject(payload) || !Array.isArray(payload.candidates)) {
+    return;
+  }
+
+  if (
+    payload.candidates.some(
+      (candidate) => isObject(candidate) && candidate.finishReason === "MAX_TOKENS",
+    )
+  ) {
+    throw new GeminiTtsOutputLimitError();
+  }
+}
+
 function extractGeminiInlineAudioData(payload: unknown): string | undefined {
   if (!isObject(payload) || !Array.isArray(payload.candidates)) {
     return undefined;
@@ -498,54 +548,70 @@ function buildSpeechRewritePrompt(sourceText: string): string {
   ].join("\n");
 }
 
+function exceedsUnicodeCharacterLimit(text: string, limit: number): boolean {
+  let count = 0;
+  for (const _character of text) {
+    count += 1;
+    if (count > limit) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function splitSpeechChunks(spokenText: string, deliveryMode: GeminiSpeechDeliveryMode): string[] {
-  const normalizedText = spokenText.replace(/\s+/g, " ").trim();
+  const normalizedText = spokenText
+    .trim()
+    .split(/\n\s*\n/gu)
+    .map((paragraph) => paragraph.replace(/\s+/gu, " ").trim())
+    .filter(Boolean)
+    .join("\n\n");
   const maxCharacters =
     deliveryMode === "progressive"
       ? PROGRESSIVE_SPEECH_CHUNK_CHARACTERS
       : COMPLETE_SPEECH_CHUNK_CHARACTERS;
   const chunks: string[] = [];
-  let remaining = normalizedText;
+  let remaining = Array.from(normalizedText);
 
   while (remaining.length > maxCharacters) {
     const boundary = findSpeechChunkBoundary(remaining, maxCharacters);
-    chunks.push(remaining.slice(0, boundary).trim());
-    remaining = remaining.slice(boundary).trim();
+    chunks.push(remaining.slice(0, boundary).join("").trim());
+    remaining = Array.from(remaining.slice(boundary).join("").trim());
   }
 
-  if (remaining) {
-    chunks.push(remaining);
+  if (remaining.length > 0) {
+    chunks.push(remaining.join(""));
   }
 
   return chunks.length > 0 ? chunks : [spokenText.trim()];
 }
 
-function findSpeechChunkBoundary(text: string, maxCharacters: number): number {
+function findSpeechChunkBoundary(characters: string[], maxCharacters: number): number {
   const preferredMinimum = Math.floor(maxCharacters * 0.6);
-  let fallbackBoundary = -1;
 
-  for (let index = maxCharacters; index >= 1; index -= 1) {
-    if (!/\s/.test(text[index] ?? "")) {
-      continue;
-    }
-    if (fallbackBoundary === -1) {
-      fallbackBoundary = index;
-    }
-    if (index >= preferredMinimum && /[.!?;:。！？]/u.test(text[index - 1] ?? "")) {
+  for (let index = maxCharacters; index >= preferredMinimum; index -= 1) {
+    if (characters[index] === "\n" && characters[index + 1] === "\n") {
       return index;
     }
   }
 
-  return fallbackBoundary === -1 ? maxCharacters : fallbackBoundary;
+  for (let index = maxCharacters; index >= preferredMinimum; index -= 1) {
+    if (isSpeechSentenceBoundary(characters[index - 1] ?? "", characters[index] ?? "")) {
+      return index;
+    }
+  }
+
+  for (let index = maxCharacters; index >= 1; index -= 1) {
+    if (/\s/u.test(characters[index] ?? "")) {
+      return index;
+    }
+  }
+
+  return maxCharacters;
 }
 
-function calculateTtsMaxOutputTokens(spokenText: string): number {
-  const wordCount = spokenText.split(/\s+/u).filter(Boolean).length;
-  const characterUnits = Math.ceil(Array.from(spokenText).length / 6);
-  const spokenUnits = Math.max(wordCount, characterUnits);
-  const estimatedTokens = spokenUnits * TTS_OUTPUT_TOKENS_PER_SPOKEN_UNIT;
-  const roundedTokens = Math.ceil(estimatedTokens / TTS_OUTPUT_TOKEN_STEP) * TTS_OUTPUT_TOKEN_STEP;
-  return Math.min(MAX_TTS_OUTPUT_TOKENS, Math.max(MIN_TTS_OUTPUT_TOKENS, roundedTokens));
+function isSpeechSentenceBoundary(previous: string, next: string): boolean {
+  return /[。！？]/u.test(previous) || (/[.!?;:]/u.test(previous) && /\s/u.test(next));
 }
 
 function buildSpeechSynthesisPrompt(spokenText: string): string {
@@ -563,6 +629,10 @@ function buildSpeechSynthesisPrompt(spokenText: string): string {
 }
 
 function isRetryableTtsError(error: unknown): boolean {
+  if (error instanceof GeminiTtsOutputLimitError) {
+    return false;
+  }
+
   if (error instanceof GeminiTtsResponseError) {
     return true;
   }

--- a/src/tui/speech_playback.ts
+++ b/src/tui/speech_playback.ts
@@ -31,6 +31,7 @@ export async function runSpeechPlaybackTask(args: {
     for await (const chunk of streamGeminiSpeechAudio({
       apiKey: args.apiKey,
       sourceText: args.sourceText,
+      deliveryMode: "progressive",
       signal: args.signal,
       onStageChange: (stage) => {
         args.onActivityLabel(stage === "rewriting" ? "rewriting for speech" : "generating speech");

--- a/src/tui/speech_playback.ts
+++ b/src/tui/speech_playback.ts
@@ -1,9 +1,11 @@
 import { unlink, writeFile } from "node:fs/promises";
 import type { CoreDeps } from "../core/runtime/deps.js";
-import { streamGeminiSpeechAudio } from "../core/utils/gemini_speech.js";
+import {
+  GEMINI_SPEECH_PLAYBACK_RATE,
+  streamGeminiSpeechAudio,
+} from "../core/utils/gemini_speech.js";
 
 export const SPEAK_TEMP_FILE_TEMPLATE = "/tmp/tau-speak.XXXXXX";
-const SPEAK_PLAYBACK_RATE = 1.4;
 
 export async function runSpeechPlaybackTask(args: {
   deps: CoreDeps;
@@ -55,7 +57,7 @@ export async function runSpeechPlaybackTask(args: {
 
       const playback = await args.deps.spawn(
         "afplay",
-        ["-r", String(SPEAK_PLAYBACK_RATE), audioPath],
+        ["-r", String(GEMINI_SPEECH_PLAYBACK_RATE), audioPath],
         {
           detached: true,
           killProcessGroup: true,

--- a/test/gemini_speech.test.js
+++ b/test/gemini_speech.test.js
@@ -46,6 +46,7 @@ describe("gemini speech", () => {
     for await (const chunk of streamGeminiSpeechAudio({
       apiKey: "gemini-key",
       sourceText: "Use src/app.ts:42 for the fix.",
+      deliveryMode: "progressive",
       fetchImpl: fetchMock,
       onStageChange: (stage) => {
         stages.push(stage);
@@ -94,7 +95,13 @@ describe("gemini speech", () => {
       "Do not add location detail that was not in the original",
     );
     expect(rewriteRequest.contents[0].parts[0].text).toContain(
-      "Say code identifiers and version strings as natural words",
+      "Preserve numbers exactly as written",
+    );
+    expect(rewriteRequest.contents[0].parts[0].text).toContain(
+      "Preserve established technical names, acronyms, initialisms, commands, program names",
+    );
+    expect(rewriteRequest.contents[0].parts[0].text).toContain(
+      '`24 kHz PCM with ffmpeg` → "24 kHz PCM with ffmpeg"',
     );
     expect(rewriteRequest.contents[0].parts[0].text).toContain("Examples of good rewrites:");
     expect(rewriteRequest.contents[0].parts[0].text).toContain(
@@ -105,7 +112,8 @@ describe("gemini speech", () => {
 
     const ttsRequest = JSON.parse(fetchMock.mock.calls[1][1].body);
     expect(ttsRequest.generationConfig.responseModalities).toEqual(["AUDIO"]);
-    expect(ttsRequest.generationConfig.temperature).toBe(1);
+    expect(ttsRequest.generationConfig.temperature).toBeUndefined();
+    expect(ttsRequest.generationConfig.maxOutputTokens).toBe(1024);
     expect(ttsRequest.generationConfig.speechConfig.voiceConfig.prebuiltVoiceConfig.voiceName).toBe(
       "Despina",
     );
@@ -164,6 +172,7 @@ describe("gemini speech", () => {
     for await (const chunk of streamGeminiSpeechAudio({
       apiKey: "gemini-key",
       sourceText: "## Setup\n\n- First short point.\n- Second short point.",
+      deliveryMode: "progressive",
       fetchImpl: fetchMock,
       onChunkProgress: (progress) => {
         chunkProgress.push(progress);
@@ -180,7 +189,85 @@ describe("gemini speech", () => {
     ]);
 
     const ttsRequest = JSON.parse(fetchMock.mock.calls[1][1].body);
-    expect(ttsRequest.contents[0].parts[0].text).toContain(rewrittenText);
+    expect(ttsRequest.contents[0].parts[0].text).toContain(rewrittenText.replace(/\s+/g, " "));
+  });
+
+  it.each([
+    {
+      name: "short",
+      rewrittenText: "A short response stays in one complete-audio chunk.",
+      expectedChunks: 1,
+    },
+    {
+      name: "medium",
+      rewrittenText: Array.from(
+        { length: 14 },
+        (_, index) =>
+          `Sentence ${index + 1} explains a distinct implementation detail while keeping the transcript natural and complete.`,
+      ).join(" "),
+      expectedChunks: 2,
+    },
+    {
+      name: "long",
+      rewrittenText: Array.from(
+        { length: 30 },
+        (_, index) =>
+          `Sentence ${index + 1} explains a distinct implementation detail while keeping the transcript natural and complete.`,
+      ).join(" "),
+      expectedChunks: 4,
+    },
+  ])("bounds complete-audio chunks for $name responses", async (testCase) => {
+    let requestIndex = 0;
+    const fetchMock = vi.fn(async () => {
+      if (requestIndex++ === 0) {
+        return new Response(
+          JSON.stringify({
+            candidates: [{ content: { parts: [{ text: testCase.rewrittenText }] } }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      return new Response(
+        JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [{ inlineData: { data: Buffer.from([1, 2]).toString("base64") } }],
+              },
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+
+    const chunks = [];
+    for await (const chunk of streamGeminiSpeechAudio({
+      apiKey: "gemini-key",
+      sourceText: "Original response.",
+      deliveryMode: "complete",
+      fetchImpl: fetchMock,
+    })) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toHaveLength(testCase.expectedChunks);
+    const ttsRequests = fetchMock.mock.calls.slice(1).map(([, init]) => JSON.parse(init.body));
+    const transcripts = ttsRequests.map((request) =>
+      request.contents[0].parts[0].text.split("### TRANSCRIPT\n")[1].trim(),
+    );
+    expect(transcripts.every((transcript) => transcript.length <= 1000)).toBe(true);
+    expect(transcripts.join(" ")).toBe(testCase.rewrittenText);
+    for (const request of ttsRequests) {
+      expect(request.contents[0].parts[0].text).toContain(
+        "Pacing: Natural conversational speed with clear enunciation.",
+      );
+      expect(request.generationConfig.maxOutputTokens).toBeGreaterThanOrEqual(1024);
+      expect(request.generationConfig.maxOutputTokens).toBeLessThanOrEqual(8192);
+      expect(request.generationConfig.maxOutputTokens % 256).toBe(0);
+      expect(request.generationConfig.temperature).toBeUndefined();
+    }
   });
 
   it("retries transient TTS failures", async () => {
@@ -235,6 +322,7 @@ describe("gemini speech", () => {
     for await (const chunk of streamGeminiSpeechAudio({
       apiKey: "gemini-key",
       sourceText: "Original text.",
+      deliveryMode: "progressive",
       fetchImpl: fetchMock,
       maxTtsAttempts: 2,
     })) {

--- a/test/gemini_speech.test.js
+++ b/test/gemini_speech.test.js
@@ -119,6 +119,9 @@ describe("gemini speech", () => {
     );
     expect(ttsRequest.contents[0].parts[0].text).toContain("### TRANSCRIPT");
     expect(ttsRequest.contents[0].parts[0].text).toContain(
+      "Pacing: Brisk conversational speed. Keep it clear, confident, and energetic without sounding rushed.",
+    );
+    expect(ttsRequest.contents[0].parts[0].text).toContain(
       "Use src slash app dot t s, line 42, for the fix.",
     );
   });
@@ -261,7 +264,7 @@ describe("gemini speech", () => {
     expect(transcripts.join(" ")).toBe(testCase.rewrittenText);
     for (const request of ttsRequests) {
       expect(request.contents[0].parts[0].text).toContain(
-        "Pacing: Natural conversational speed with clear enunciation.",
+        "Pacing: Brisk conversational speed. Keep it clear, confident, and energetic without sounding rushed.",
       );
       expect(request.generationConfig.maxOutputTokens).toBeGreaterThanOrEqual(1024);
       expect(request.generationConfig.maxOutputTokens).toBeLessThanOrEqual(8192);

--- a/test/gemini_speech.test.js
+++ b/test/gemini_speech.test.js
@@ -113,7 +113,7 @@ describe("gemini speech", () => {
     const ttsRequest = JSON.parse(fetchMock.mock.calls[1][1].body);
     expect(ttsRequest.generationConfig.responseModalities).toEqual(["AUDIO"]);
     expect(ttsRequest.generationConfig.temperature).toBeUndefined();
-    expect(ttsRequest.generationConfig.maxOutputTokens).toBe(1024);
+    expect(ttsRequest.generationConfig.maxOutputTokens).toBe(8192);
     expect(ttsRequest.generationConfig.speechConfig.voiceConfig.prebuiltVoiceConfig.voiceName).toBe(
       "Despina",
     );
@@ -192,7 +192,110 @@ describe("gemini speech", () => {
     ]);
 
     const ttsRequest = JSON.parse(fetchMock.mock.calls[1][1].body);
-    expect(ttsRequest.contents[0].parts[0].text).toContain(rewrittenText.replace(/\s+/g, " "));
+    expect(ttsRequest.contents[0].parts[0].text).toContain(rewrittenText);
+  });
+
+  it("prefers paragraph boundaries over later sentence endings", async () => {
+    const firstParagraph = `${"A".repeat(348)}.`;
+    const secondParagraph = `${"B".repeat(100)}. ${"C".repeat(100)}`;
+    const rewrittenText = `${firstParagraph}\n\n${secondParagraph}`;
+    let requestIndex = 0;
+    const fetchMock = vi.fn(async () => {
+      if (requestIndex++ === 0) {
+        return new Response(
+          JSON.stringify({
+            candidates: [{ content: { parts: [{ text: rewrittenText }] } }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      return new Response(
+        JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [{ inlineData: { data: Buffer.from([1, 2]).toString("base64") } }],
+              },
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+
+    for await (const _chunk of streamGeminiSpeechAudio({
+      apiKey: "gemini-key",
+      sourceText: "Original response.",
+      deliveryMode: "progressive",
+      fetchImpl: fetchMock,
+    })) {
+      void _chunk;
+    }
+
+    const transcripts = fetchMock.mock.calls
+      .slice(1)
+      .map(([, init]) =>
+        JSON.parse(init.body).contents[0].parts[0].text.split("### TRANSCRIPT\n")[1].trim(),
+      );
+    expect(transcripts).toEqual([firstParagraph, secondParagraph]);
+  });
+
+  it.each([
+    {
+      name: "no-space sentence punctuation",
+      rewrittenText: `${"語".repeat(449)}。${"文".repeat(100)}`,
+      expectedChunkLengths: [450, 100],
+    },
+    {
+      name: "supplementary Unicode characters",
+      rewrittenText: "😀".repeat(501),
+      expectedChunkLengths: [500, 1],
+    },
+  ])("uses Unicode-safe progressive chunk boundaries for $name", async (testCase) => {
+    let requestIndex = 0;
+    const fetchMock = vi.fn(async () => {
+      if (requestIndex++ === 0) {
+        return new Response(
+          JSON.stringify({
+            candidates: [{ content: { parts: [{ text: testCase.rewrittenText }] } }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      return new Response(
+        JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [{ inlineData: { data: Buffer.from([1, 2]).toString("base64") } }],
+              },
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+
+    for await (const _chunk of streamGeminiSpeechAudio({
+      apiKey: "gemini-key",
+      sourceText: "Original response.",
+      deliveryMode: "progressive",
+      fetchImpl: fetchMock,
+    })) {
+      void _chunk;
+    }
+
+    const transcripts = fetchMock.mock.calls
+      .slice(1)
+      .map(([, init]) =>
+        JSON.parse(init.body).contents[0].parts[0].text.split("### TRANSCRIPT\n")[1].trim(),
+      );
+    expect(transcripts.map((transcript) => Array.from(transcript).length)).toEqual(
+      testCase.expectedChunkLengths,
+    );
+    expect(transcripts.join("")).toBe(testCase.rewrittenText);
   });
 
   it.each([
@@ -266,11 +369,160 @@ describe("gemini speech", () => {
       expect(request.contents[0].parts[0].text).toContain(
         "Pacing: Brisk conversational speed. Keep it clear, confident, and energetic without sounding rushed.",
       );
-      expect(request.generationConfig.maxOutputTokens).toBeGreaterThanOrEqual(1024);
-      expect(request.generationConfig.maxOutputTokens).toBeLessThanOrEqual(8192);
-      expect(request.generationConfig.maxOutputTokens % 256).toBe(0);
+      expect(request.generationConfig.maxOutputTokens).toBe(8192);
       expect(request.generationConfig.temperature).toBeUndefined();
     }
+  });
+
+  it("aborts speech rewriting after one minute", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchMock = vi.fn(async (_url, init) => {
+        await new Promise((_, reject) => {
+          init.signal.addEventListener(
+            "abort",
+            () => {
+              const error = new Error("aborted");
+              error.name = "AbortError";
+              reject(error);
+            },
+            { once: true },
+          );
+        });
+      });
+      const nextChunk = streamGeminiSpeechAudio({
+        apiKey: "gemini-key",
+        sourceText: "Original text.",
+        deliveryMode: "progressive",
+        fetchImpl: fetchMock,
+      }).next();
+      const rejection = expect(nextChunk).rejects.toThrow(
+        "speech rewrite timed out after 1 minute",
+      );
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      await rejection;
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("rejects oversized source and rewritten speech text", async () => {
+    const sourceFetch = vi.fn();
+    await expect(async () => {
+      for await (const _chunk of streamGeminiSpeechAudio({
+        apiKey: "gemini-key",
+        sourceText: "😀".repeat(10_001),
+        deliveryMode: "progressive",
+        fetchImpl: sourceFetch,
+      })) {
+        void _chunk;
+      }
+    }).rejects.toThrow("speech source text exceeds 10,000 characters");
+    expect(sourceFetch).not.toHaveBeenCalled();
+
+    const rewrittenFetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            candidates: [{ content: { parts: [{ text: "語".repeat(10_001) }] } }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+    await expect(async () => {
+      for await (const _chunk of streamGeminiSpeechAudio({
+        apiKey: "gemini-key",
+        sourceText: "Original text.",
+        deliveryMode: "complete",
+        fetchImpl: rewrittenFetch,
+      })) {
+        void _chunk;
+      }
+    }).rejects.toThrow("rewritten speech text exceeds 10,000 characters");
+    expect(rewrittenFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects generated speech above the cumulative PCM limit", async () => {
+    const oversizedAudio = Buffer.alloc(32 * 1024 * 1024 + 1).toString("base64");
+    const ttsPayload = JSON.stringify({
+      candidates: [{ content: { parts: [{ inlineData: { data: oversizedAudio } }] } }],
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            candidates: [{ content: { parts: [{ text: "Spoken version." }] } }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => ttsPayload,
+      });
+
+    await expect(async () => {
+      for await (const _chunk of streamGeminiSpeechAudio({
+        apiKey: "gemini-key",
+        sourceText: "Original text.",
+        deliveryMode: "complete",
+        fetchImpl: fetchMock,
+        maxTtsAttempts: 1,
+      })) {
+        void _chunk;
+      }
+    }).rejects.toThrow("generated speech audio exceeds the 32 MiB limit");
+  });
+
+  it("rejects audio truncated by the TTS output token limit", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            candidates: [{ content: { parts: [{ text: "Spoken version." }] } }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            candidates: [
+              {
+                finishReason: "MAX_TOKENS",
+                content: {
+                  parts: [
+                    {
+                      inlineData: {
+                        data: Buffer.from([1, 2]).toString("base64"),
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+    await expect(async () => {
+      for await (const _chunk of streamGeminiSpeechAudio({
+        apiKey: "gemini-key",
+        sourceText: "Original text.",
+        deliveryMode: "progressive",
+        fetchImpl: fetchMock,
+        maxTtsAttempts: 3,
+      })) {
+        void _chunk;
+      }
+    }).rejects.toThrow("Gemini TTS reached its output token limit");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it("retries transient TTS failures", async () => {

--- a/test/session_chat_controller.test.js
+++ b/test/session_chat_controller.test.js
@@ -5554,7 +5554,7 @@ describe("SessionChatController", () => {
     expect(spawn).toHaveBeenNthCalledWith(
       2,
       "afplay",
-      ["-r", "1.4", mktempPath],
+      ["-r", "1.1", mktempPath],
       expect.objectContaining({
         detached: true,
         killProcessGroup: true,

--- a/test/telegram_adapter.test.js
+++ b/test/telegram_adapter.test.js
@@ -466,7 +466,6 @@ describe("telegram adapter", () => {
           type: "assistant-message",
           messageId: "assistant-intermediate",
           text: "working on it",
-          final: false,
         },
       });
       managerHarness.manager.emit({
@@ -479,8 +478,15 @@ describe("telegram adapter", () => {
           type: "assistant-message",
           messageId: "assistant-final",
           text: "final answer",
-          final: true,
         },
+      });
+      managerHarness.manager.emit({
+        type: "session-response-completed",
+        sessionId: "s-tts",
+        projectId: "demo",
+        timestamp: "2024-01-01T00:02:30.000Z",
+        messageId: "assistant-final",
+        text: "final answer",
       });
       managerHarness.manager.emit({
         type: "session-state-changed",
@@ -508,6 +514,359 @@ describe("telegram adapter", () => {
       expect(apiHarness.sendVoices[0].sentAt).toBeGreaterThanOrEqual(
         apiHarness.sendRichMessages[1].sentAt,
       );
+    } finally {
+      await adapter.close();
+    }
+  });
+
+  it("serializes voice generation for responses from the same session", async () => {
+    const chatId = 15;
+    const ownerId = ownerIdForChat(chatId);
+    const apiHarness = createApiHarness([]);
+    const managerHarness = createSessionManagerHarness([
+      {
+        id: "s-tts-order",
+        projectId: "demo",
+        ownerId,
+        state: "waiting-input",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+    ]);
+    const firstVoice = deferred();
+    const generateVoice = vi
+      .fn()
+      .mockImplementationOnce(async () => await firstVoice.promise)
+      .mockResolvedValueOnce(Buffer.from("voice B"));
+    const adapter = await startAdapter({
+      botToken: "token",
+      projects: { demo: { repo: "git@example.com:demo.git" } },
+      sessionManager: managerHarness.manager,
+      projectPreferences: {
+        initialize: vi.fn(async () => {}),
+        get: vi.fn(() => undefined),
+        set: vi.fn(async () => {}),
+        isTtsEnabled: vi.fn((id) => id === ownerId),
+        setTtsEnabled: vi.fn(async () => {}),
+      },
+      api: apiHarness.api,
+      geminiApiKey: "gemini-key",
+      generateVoice,
+      pollIntervalMs: 1,
+      requestTimeoutSeconds: 1,
+    });
+
+    try {
+      managerHarness.manager.emit({
+        type: "session-response-completed",
+        sessionId: "s-tts-order",
+        projectId: "demo",
+        timestamp: "2024-01-01T00:01:00.000Z",
+        messageId: "assistant-a",
+        text: "response A",
+      });
+      managerHarness.manager.emit({
+        type: "session-response-completed",
+        sessionId: "s-tts-order",
+        projectId: "demo",
+        timestamp: "2024-01-01T00:02:00.000Z",
+        messageId: "assistant-b",
+        text: "response B",
+      });
+
+      await waitFor(() => generateVoice.mock.calls.length === 1);
+      expect(generateVoice.mock.calls[0][0].sourceText).toBe("response A");
+      firstVoice.resolve(Buffer.from("voice A"));
+      await waitFor(() => apiHarness.sendVoices.length === 2);
+
+      expect(generateVoice.mock.calls.map(([options]) => options.sourceText)).toEqual([
+        "response A",
+        "response B",
+      ]);
+      expect(apiHarness.sendVoices.map(({ voice }) => voice.toString())).toEqual([
+        "voice A",
+        "voice B",
+      ]);
+    } finally {
+      await adapter.close();
+    }
+  });
+
+  it("aborts a Telegram voice job after five minutes and continues the session queue", async () => {
+    vi.useFakeTimers();
+    const chatId = 16;
+    const ownerId = ownerIdForChat(chatId);
+    const apiHarness = createApiHarness([]);
+    const managerHarness = createSessionManagerHarness([
+      {
+        id: "s-tts-timeout",
+        projectId: "demo",
+        ownerId,
+        state: "waiting-input",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+    ]);
+    const logs = [];
+    const generateVoice = vi
+      .fn()
+      .mockImplementationOnce(
+        async ({ signal }) =>
+          await new Promise((_, reject) => {
+            signal.addEventListener(
+              "abort",
+              () => {
+                const error = new Error("aborted");
+                error.name = "AbortError";
+                reject(error);
+              },
+              { once: true },
+            );
+          }),
+      )
+      .mockResolvedValueOnce(Buffer.from("voice B"));
+    const adapter = await startAdapter({
+      botToken: "token",
+      projects: { demo: { repo: "git@example.com:demo.git" } },
+      sessionManager: managerHarness.manager,
+      projectPreferences: {
+        initialize: vi.fn(async () => {}),
+        get: vi.fn(() => undefined),
+        set: vi.fn(async () => {}),
+        isTtsEnabled: vi.fn((id) => id === ownerId),
+        setTtsEnabled: vi.fn(async () => {}),
+      },
+      api: apiHarness.api,
+      geminiApiKey: "gemini-key",
+      generateVoice,
+      pollIntervalMs: 1,
+      requestTimeoutSeconds: 1,
+      onLog: (entry) => logs.push(entry),
+    });
+
+    try {
+      for (const [messageId, text] of [
+        ["assistant-a", "response A"],
+        ["assistant-b", "response B"],
+      ]) {
+        managerHarness.manager.emit({
+          type: "session-response-completed",
+          sessionId: "s-tts-timeout",
+          projectId: "demo",
+          timestamp: "2024-01-01T00:01:00.000Z",
+          messageId,
+          text,
+        });
+      }
+
+      await vi.advanceTimersByTimeAsync(5 * 60_000);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(generateVoice.mock.calls.map(([options]) => options.sourceText)).toEqual([
+        "response A",
+        "response B",
+      ]);
+      expect(apiHarness.sendVoices.map(({ voice }) => voice.toString())).toEqual(["voice B"]);
+      expect(apiHarness.sendMessages.map(({ text }) => text)).toEqual([
+        "voice response failed. please try again.",
+      ]);
+      expect(logs).toContainEqual(
+        expect.objectContaining({
+          level: "error",
+          message: "failed to generate Telegram voice response",
+          data: expect.objectContaining({ cause: "voice generation timed out after 5 minutes" }),
+        }),
+      );
+    } finally {
+      vi.useRealTimers();
+      await adapter.close();
+    }
+  });
+
+  it("aborts voice delivery retries at the complete job deadline", async () => {
+    vi.useFakeTimers();
+    const chatId = 19;
+    const ownerId = ownerIdForChat(chatId);
+    const apiHarness = createApiHarness([]);
+    apiHarness.api.sendVoice.mockRejectedValue(
+      new TelegramRequestError("telegram rate limited voice", {
+        retryable: true,
+        retryAfterMs: 10 * 60_000,
+      }),
+    );
+    const managerHarness = createSessionManagerHarness([
+      {
+        id: "s-tts-upload-timeout",
+        projectId: "demo",
+        ownerId,
+        state: "waiting-input",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+    ]);
+    const logs = [];
+    const adapter = await startAdapter({
+      botToken: "token",
+      projects: { demo: { repo: "git@example.com:demo.git" } },
+      sessionManager: managerHarness.manager,
+      projectPreferences: {
+        initialize: vi.fn(async () => {}),
+        get: vi.fn(() => undefined),
+        set: vi.fn(async () => {}),
+        isTtsEnabled: vi.fn((id) => id === ownerId),
+        setTtsEnabled: vi.fn(async () => {}),
+      },
+      api: apiHarness.api,
+      geminiApiKey: "gemini-key",
+      generateVoice: vi.fn(async () => Buffer.from("voice")),
+      pollIntervalMs: 1,
+      requestTimeoutSeconds: 1,
+      onLog: (entry) => logs.push(entry),
+    });
+
+    try {
+      managerHarness.manager.emit({
+        type: "session-response-completed",
+        sessionId: "s-tts-upload-timeout",
+        projectId: "demo",
+        timestamp: "2024-01-01T00:01:00.000Z",
+        messageId: "assistant-final",
+        text: "final answer",
+      });
+
+      await vi.advanceTimersByTimeAsync(5 * 60_000);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(apiHarness.api.sendVoice).toHaveBeenCalledTimes(1);
+      expect(apiHarness.sendMessages.map(({ text }) => text)).toEqual([
+        "voice response failed. please try again.",
+      ]);
+      expect(logs).toContainEqual({
+        level: "error",
+        message: "Telegram voice response job timed out",
+        data: {
+          sessionId: "s-tts-upload-timeout",
+          chatId,
+          cause: "voice response job timed out after 5 minutes",
+        },
+      });
+    } finally {
+      vi.useRealTimers();
+      await adapter.close();
+    }
+  });
+
+  it("notifies the user after voice delivery fails", async () => {
+    const chatId = 17;
+    const ownerId = ownerIdForChat(chatId);
+    const apiHarness = createApiHarness([]);
+    apiHarness.api.sendVoice.mockRejectedValue(
+      new TelegramRequestError("telegram rejected voice", { retryable: false }),
+    );
+    const managerHarness = createSessionManagerHarness([
+      {
+        id: "s-tts-delivery-failure",
+        projectId: "demo",
+        ownerId,
+        state: "waiting-input",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+    ]);
+    const logs = [];
+    const adapter = await startAdapter({
+      botToken: "token",
+      projects: { demo: { repo: "git@example.com:demo.git" } },
+      sessionManager: managerHarness.manager,
+      projectPreferences: {
+        initialize: vi.fn(async () => {}),
+        get: vi.fn(() => undefined),
+        set: vi.fn(async () => {}),
+        isTtsEnabled: vi.fn((id) => id === ownerId),
+        setTtsEnabled: vi.fn(async () => {}),
+      },
+      api: apiHarness.api,
+      geminiApiKey: "gemini-key",
+      generateVoice: vi.fn(async () => Buffer.from("voice")),
+      pollIntervalMs: 1,
+      requestTimeoutSeconds: 1,
+      onLog: (entry) => logs.push(entry),
+    });
+
+    try {
+      managerHarness.manager.emit({
+        type: "session-response-completed",
+        sessionId: "s-tts-delivery-failure",
+        projectId: "demo",
+        timestamp: "2024-01-01T00:01:00.000Z",
+        messageId: "assistant-final",
+        text: "final answer",
+      });
+
+      await waitFor(() => apiHarness.sendMessages.length === 1);
+      expect(apiHarness.sendMessages[0].text).toBe("voice response failed. please try again.");
+      expect(logs).toContainEqual({
+        level: "error",
+        message: "failed to send Telegram voice response",
+        data: {
+          sessionId: "s-tts-delivery-failure",
+          chatId,
+          attempts: 1,
+          cause: "telegram rejected voice",
+        },
+      });
+    } finally {
+      await adapter.close();
+    }
+  });
+
+  it("does not report a voice failure after TTS is disabled before delivery", async () => {
+    const chatId = 18;
+    const ownerId = ownerIdForChat(chatId);
+    let enabled = true;
+    const apiHarness = createApiHarness([]);
+    const managerHarness = createSessionManagerHarness([
+      {
+        id: "s-tts-disabled",
+        projectId: "demo",
+        ownerId,
+        state: "waiting-input",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+    ]);
+    const voice = deferred();
+    const adapter = await startAdapter({
+      botToken: "token",
+      projects: { demo: { repo: "git@example.com:demo.git" } },
+      sessionManager: managerHarness.manager,
+      projectPreferences: {
+        initialize: vi.fn(async () => {}),
+        get: vi.fn(() => undefined),
+        set: vi.fn(async () => {}),
+        isTtsEnabled: vi.fn((id) => id === ownerId && enabled),
+        setTtsEnabled: vi.fn(async () => {}),
+      },
+      api: apiHarness.api,
+      geminiApiKey: "gemini-key",
+      generateVoice: vi.fn(async () => await voice.promise),
+      pollIntervalMs: 1,
+      requestTimeoutSeconds: 1,
+    });
+
+    try {
+      managerHarness.manager.emit({
+        type: "session-response-completed",
+        sessionId: "s-tts-disabled",
+        projectId: "demo",
+        timestamp: "2024-01-01T00:01:00.000Z",
+        messageId: "assistant-final",
+        text: "final answer",
+      });
+      enabled = false;
+      voice.resolve(Buffer.from("voice"));
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(apiHarness.sendVoices).toHaveLength(0);
+      expect(apiHarness.sendMessages).toHaveLength(0);
     } finally {
       await adapter.close();
     }
@@ -3055,8 +3414,15 @@ describe("telegram adapter", () => {
           type: "assistant-message",
           messageId: "assistant-final",
           text: "final answer",
-          final: true,
         },
+      });
+      managerHarness.manager.emit({
+        type: "session-response-completed",
+        sessionId: "s-voice-upload",
+        projectId: "demo",
+        timestamp: "2024-01-01T00:01:30.000Z",
+        messageId: "assistant-final",
+        text: "final answer",
       });
       managerHarness.manager.emit({
         type: "session-state-changed",

--- a/test/telegram_adapter.test.js
+++ b/test/telegram_adapter.test.js
@@ -519,6 +519,66 @@ describe("telegram adapter", () => {
     }
   });
 
+  it("reports a persisted TTS opt-in when the Google credential is missing", async () => {
+    const chatId = 20;
+    const ownerId = ownerIdForChat(chatId);
+    const apiHarness = createApiHarness([]);
+    const managerHarness = createSessionManagerHarness([
+      {
+        id: "s-tts-missing-credential",
+        projectId: "demo",
+        ownerId,
+        state: "waiting-input",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+    ]);
+    const logs = [];
+    const generateVoice = vi.fn();
+    const adapter = await startAdapter({
+      botToken: "token",
+      projects: { demo: { repo: "git@example.com:demo.git" } },
+      sessionManager: managerHarness.manager,
+      projectPreferences: {
+        initialize: vi.fn(async () => {}),
+        get: vi.fn(() => undefined),
+        set: vi.fn(async () => {}),
+        isTtsEnabled: vi.fn((id) => id === ownerId),
+        setTtsEnabled: vi.fn(async () => {}),
+      },
+      api: apiHarness.api,
+      generateVoice,
+      pollIntervalMs: 1,
+      requestTimeoutSeconds: 1,
+      onLog: (entry) => logs.push(entry),
+    });
+
+    try {
+      managerHarness.manager.emit({
+        type: "session-response-completed",
+        sessionId: "s-tts-missing-credential",
+        projectId: "demo",
+        timestamp: "2024-01-01T00:01:00.000Z",
+        messageId: "assistant-final",
+        text: "final answer",
+      });
+
+      await waitFor(() => apiHarness.sendMessages.length === 1);
+      expect(apiHarness.sendMessages[0].text).toBe("voice response failed. please try again.");
+      expect(generateVoice).not.toHaveBeenCalled();
+      expect(logs).toContainEqual({
+        level: "error",
+        message: "failed to generate Telegram voice response",
+        data: {
+          sessionId: "s-tts-missing-credential",
+          cause: "missing Google credential for Telegram voice responses",
+        },
+      });
+    } finally {
+      await adapter.close();
+    }
+  });
+
   it("serializes voice generation for responses from the same session", async () => {
     const chatId = 15;
     const ownerId = ownerIdForChat(chatId);

--- a/test/telegram_adapter.test.js
+++ b/test/telegram_adapter.test.js
@@ -6,11 +6,16 @@ import { TauSessionProtocolResponseError } from "../dist/transport/errors.js";
 
 async function startAdapter(options) {
   const preferences = new Map();
+  const ttsPreferences = new Map();
   const projectPreferences = options.projectPreferences ?? {
     initialize: vi.fn(async () => {}),
     get: vi.fn((ownerId) => preferences.get(ownerId)),
     set: vi.fn(async (ownerId, projectId) => {
       preferences.set(ownerId, projectId);
+    }),
+    isTtsEnabled: vi.fn((ownerId) => ttsPreferences.get(ownerId) ?? false),
+    setTtsEnabled: vi.fn(async (ownerId, enabled) => {
+      ttsPreferences.set(ownerId, enabled);
     }),
   };
   await projectPreferences.initialize();
@@ -62,6 +67,7 @@ function createApiHarness(updateBatches, options = {}) {
   const queue = [...updateBatches];
   const sendMessages = [];
   const sendRichMessages = [];
+  const sendVoices = [];
   const richMessageDrafts = [];
   const chatActions = [];
   const downloadFileCalls = [];
@@ -83,6 +89,9 @@ function createApiHarness(updateBatches, options = {}) {
     }),
     sendRichMessage: vi.fn(async (chatId, markdown, options) => {
       sendRichMessages.push({ chatId, markdown, options, sentAt: Date.now() });
+    }),
+    sendVoice: vi.fn(async (chatId, voice, options) => {
+      sendVoices.push({ chatId, voice, options, sentAt: Date.now() });
     }),
     sendRichMessageDraft: vi.fn(async (chatId, draftId, markdown) => {
       richMessageDrafts.push({ chatId, draftId, markdown, sentAt: Date.now() });
@@ -109,6 +118,7 @@ function createApiHarness(updateBatches, options = {}) {
     api,
     sendMessages,
     sendRichMessages,
+    sendVoices,
     richMessageDrafts,
     chatActions,
     downloadFileCalls,
@@ -380,12 +390,170 @@ describe("telegram adapter", () => {
         { command: "status", description: "show active session status" },
         { command: "compact", description: "compact session context" },
         { command: "interrupt", description: "interrupt active run" },
+        { command: "tts_on", description: "enable voice responses" },
+        { command: "tts_off", description: "disable voice responses" },
         { command: "effort_low", description: "set reasoning effort to low" },
         { command: "effort_medium", description: "set reasoning effort to medium" },
         { command: "effort_high", description: "set reasoning effort to high" },
         { command: "effort_xhigh", description: "set reasoning effort to xhigh" },
         { command: "use_demo", description: "use demo for new sessions" },
       ]);
+    } finally {
+      await adapter.close();
+    }
+  });
+
+  it("persists TTS enablement and sends the final response as a voice note", async () => {
+    const chatId = 13;
+    const ownerId = ownerIdForChat(chatId);
+    const ttsPreferences = new Map();
+    const projectPreferences = {
+      initialize: vi.fn(async () => {}),
+      get: vi.fn(() => undefined),
+      set: vi.fn(async () => {}),
+      isTtsEnabled: vi.fn((id) => ttsPreferences.get(id) ?? false),
+      setTtsEnabled: vi.fn(async (id, enabled) => {
+        ttsPreferences.set(id, enabled);
+      }),
+    };
+    const apiHarness = createApiHarness([
+      [
+        {
+          update_id: 1,
+          message: {
+            chat: { id: chatId, type: "private" },
+            from: { id: 7 },
+            text: "/tts_on",
+          },
+        },
+      ],
+    ]);
+    const managerHarness = createSessionManagerHarness([
+      {
+        id: "s-tts",
+        projectId: "demo",
+        ownerId,
+        state: "running",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+    ]);
+    const generateVoice = vi.fn(async () => Buffer.from("ogg voice"));
+    const adapter = await startAdapter({
+      botToken: "token",
+      projects: { demo: { repo: "git@example.com:demo.git" } },
+      sessionManager: managerHarness.manager,
+      projectPreferences,
+      api: apiHarness.api,
+      geminiApiKey: "gemini-key",
+      generateVoice,
+      pollIntervalMs: 1,
+      requestTimeoutSeconds: 1,
+    });
+
+    try {
+      await waitFor(() => apiHarness.sendMessages.length === 1);
+      expect(apiHarness.sendMessages[0].text).toBe("voice responses enabled.");
+      expect(projectPreferences.setTtsEnabled).toHaveBeenCalledWith(ownerId, true);
+
+      managerHarness.manager.emit({
+        type: "session-progress",
+        sessionId: "s-tts",
+        projectId: "demo",
+        state: "running",
+        timestamp: "2024-01-01T00:01:00.000Z",
+        progress: {
+          type: "assistant-message",
+          messageId: "assistant-intermediate",
+          text: "working on it",
+          final: false,
+        },
+      });
+      managerHarness.manager.emit({
+        type: "session-progress",
+        sessionId: "s-tts",
+        projectId: "demo",
+        state: "running",
+        timestamp: "2024-01-01T00:02:00.000Z",
+        progress: {
+          type: "assistant-message",
+          messageId: "assistant-final",
+          text: "final answer",
+          final: true,
+        },
+      });
+      managerHarness.manager.emit({
+        type: "session-state-changed",
+        sessionId: "s-tts",
+        projectId: "demo",
+        previousState: "running",
+        state: "waiting-input",
+        updatedAt: "2024-01-01T00:03:00.000Z",
+      });
+
+      await waitFor(() => apiHarness.sendVoices.length === 1);
+      expect(generateVoice).toHaveBeenCalledWith({
+        apiKey: "gemini-key",
+        sourceText: "final answer",
+        fetchImpl: undefined,
+        signal: expect.any(AbortSignal),
+      });
+      expect(apiHarness.sendVoices[0]).toEqual(
+        expect.objectContaining({ chatId, voice: Buffer.from("ogg voice") }),
+      );
+      expect(apiHarness.sendRichMessages.map((message) => message.markdown)).toEqual([
+        "working on it",
+        "final answer",
+      ]);
+      expect(apiHarness.sendVoices[0].sentAt).toBeGreaterThanOrEqual(
+        apiHarness.sendRichMessages[1].sentAt,
+      );
+    } finally {
+      await adapter.close();
+    }
+  });
+
+  it("disables persisted voice responses with /tts_off", async () => {
+    const chatId = 14;
+    const ownerId = ownerIdForChat(chatId);
+    const ttsPreferences = new Map([[ownerId, true]]);
+    const projectPreferences = {
+      initialize: vi.fn(async () => {}),
+      get: vi.fn(() => undefined),
+      set: vi.fn(async () => {}),
+      isTtsEnabled: vi.fn((id) => ttsPreferences.get(id) ?? false),
+      setTtsEnabled: vi.fn(async (id, enabled) => {
+        ttsPreferences.set(id, enabled);
+      }),
+    };
+    const apiHarness = createApiHarness([
+      [
+        {
+          update_id: 1,
+          message: {
+            chat: { id: chatId, type: "private" },
+            from: { id: 7 },
+            text: "/tts_off",
+          },
+        },
+      ],
+    ]);
+    const managerHarness = createSessionManagerHarness();
+    const adapter = await startAdapter({
+      botToken: "token",
+      projects: { demo: { repo: "git@example.com:demo.git" } },
+      sessionManager: managerHarness.manager,
+      projectPreferences,
+      api: apiHarness.api,
+      pollIntervalMs: 1,
+      requestTimeoutSeconds: 1,
+    });
+
+    try {
+      await waitFor(() => apiHarness.sendMessages.length === 1);
+      expect(apiHarness.sendMessages[0].text).toBe("voice responses disabled.");
+      expect(projectPreferences.setTtsEnabled).toHaveBeenCalledWith(ownerId, false);
+      expect(projectPreferences.isTtsEnabled(ownerId)).toBe(false);
     } finally {
       await adapter.close();
     }
@@ -1847,7 +2015,7 @@ describe("telegram adapter", () => {
     try {
       await waitFor(() => apiHarness.sendMessages.length === 1);
       expect(apiHarness.sendMessages[0].text).toBe(
-        "unsupported command. supported commands: /new, /status, /compact, /interrupt, /effort_low, /effort_medium, /effort_high, /effort_xhigh, /use_demo",
+        "unsupported command. supported commands: /new, /status, /compact, /interrupt, /tts_on, /tts_off, /effort_low, /effort_medium, /effort_high, /effort_xhigh, /use_demo",
       );
       expect(managerHarness.manager.closeSession).not.toHaveBeenCalled();
     } finally {
@@ -2833,6 +3001,86 @@ describe("telegram adapter", () => {
       return handler({ call: count, init });
     });
   }
+
+  it("uploads generated voice notes with Telegram multipart form data", async () => {
+    const chatId = 991;
+    const ownerId = ownerIdForChat(chatId);
+    const managerHarness = createSessionManagerHarness([
+      {
+        id: "s-voice-upload",
+        projectId: "demo",
+        ownerId,
+        state: "running",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+    ]);
+    const sendVoiceCalls = [];
+    const telegramFetch = createTelegramFetchStub({
+      setMyCommands: async () => createJsonResponse({ ok: true, result: true }),
+      getUpdates: async () => pendingTelegramCall(),
+      sendRichMessage: async () => createJsonResponse({ ok: true, result: { message_id: 1 } }),
+      sendVoice: async ({ init }) => {
+        sendVoiceCalls.push(init);
+        return createJsonResponse({ ok: true, result: { message_id: 1 } });
+      },
+    });
+    vi.stubGlobal("fetch", telegramFetch);
+
+    const adapter = await startAdapter({
+      botToken: "token",
+      projects: { demo: { repo: "git@example.com:demo.git" } },
+      sessionManager: managerHarness.manager,
+      projectPreferences: {
+        initialize: vi.fn(async () => {}),
+        get: vi.fn(() => undefined),
+        set: vi.fn(async () => {}),
+        isTtsEnabled: vi.fn((id) => id === ownerId),
+        setTtsEnabled: vi.fn(async () => {}),
+      },
+      geminiApiKey: "gemini-key",
+      generateVoice: vi.fn(async () => Buffer.from("OggS voice")),
+      pollIntervalMs: 1,
+      requestTimeoutSeconds: 1,
+    });
+
+    try {
+      managerHarness.manager.emit({
+        type: "session-progress",
+        sessionId: "s-voice-upload",
+        projectId: "demo",
+        state: "running",
+        timestamp: "2024-01-01T00:01:00.000Z",
+        progress: {
+          type: "assistant-message",
+          messageId: "assistant-final",
+          text: "final answer",
+          final: true,
+        },
+      });
+      managerHarness.manager.emit({
+        type: "session-state-changed",
+        sessionId: "s-voice-upload",
+        projectId: "demo",
+        previousState: "running",
+        state: "waiting-input",
+        updatedAt: "2024-01-01T00:02:00.000Z",
+      });
+
+      await waitFor(() => sendVoiceCalls.length === 1);
+      const form = sendVoiceCalls[0].body;
+      expect(form).toBeInstanceOf(FormData);
+      expect(form.get("chat_id")).toBe(String(chatId));
+      const voice = form.get("voice");
+      expect(voice).toBeInstanceOf(File);
+      expect(voice.name).toBe("response.ogg");
+      expect(voice.type).toBe("audio/ogg");
+      expect(Buffer.from(await voice.arrayBuffer())).toEqual(Buffer.from("OggS voice"));
+    } finally {
+      await adapter.close();
+      vi.unstubAllGlobals();
+    }
+  });
 
   it.each([
     {

--- a/test/telegram_cli.test.js
+++ b/test/telegram_cli.test.js
@@ -148,27 +148,27 @@ describe("telegram cli", () => {
     );
   });
 
-  it("reserves eight Telegram commands when validating the project command limit", () => {
+  it("reserves ten Telegram commands when validating the project command limit", () => {
     const projects = Object.fromEntries(
-      Array.from({ length: 93 }, (_, index) => [`project_${index}`, { repo: "owner/repo" }]),
+      Array.from({ length: 91 }, (_, index) => [`project_${index}`, { repo: "owner/repo" }]),
     );
     const accepted = writeConfig({
       bots: {
         ops: {
           botToken: "token",
-          allowedProjectIds: Object.keys(projects).slice(0, 92),
+          allowedProjectIds: Object.keys(projects).slice(0, 90),
         },
       },
       projects,
     });
-    expect(loadTelegramConfig(accepted.path).bots.ops.allowedProjectIds).toHaveLength(92);
+    expect(loadTelegramConfig(accepted.path).bots.ops.allowedProjectIds).toHaveLength(90);
 
     const rejected = writeConfig({
       bots: { ops: { botToken: "token" } },
       projects,
     });
     expect(() => loadTelegramConfig(rejected.path)).toThrow(
-      "bots.ops exposes 93 projects, exceeding Telegram's 100-command limit with built-in commands",
+      "bots.ops exposes 91 projects, exceeding Telegram's 100-command limit with built-in commands",
     );
   });
 

--- a/test/telegram_runtime.test.js
+++ b/test/telegram_runtime.test.js
@@ -1,7 +1,11 @@
-import { rm } from "node:fs/promises";
+import { readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, describe, expect, it, vi } from "vitest";
+import {
+  createTelegramProjectPreferenceStore,
+  resolveTelegramProjectPreferencesPath,
+} from "../dist/core/telegram/project_preferences.js";
 import { startTelegramRuntime } from "../dist/core/telegram/runtime.js";
 
 const workspaceRoot = join(tmpdir(), `tau-telegram-runtime-${process.pid}`);
@@ -147,7 +151,35 @@ describe("telegram runtime", () => {
     await runtime.close();
   });
 
-  it("persists project preferences across runtime restarts", async () => {
+  it("preserves version 1 project preferences when saving TTS settings", async () => {
+    const preferenceRoot = `${workspaceRoot}-migration`;
+    const preferencePath = resolveTelegramProjectPreferencesPath(preferenceRoot);
+    const ownerId = "telegram:bot-one:chat:42";
+    await writeFile(
+      preferencePath,
+      `${JSON.stringify({ version: 1, preferences: { [ownerId]: "beta" } })}\n`,
+      "utf8",
+    );
+
+    try {
+      const store = createTelegramProjectPreferenceStore(preferencePath);
+      await store.initialize();
+      expect(store.get(ownerId)).toBe("beta");
+      expect(store.isTtsEnabled(ownerId)).toBe(false);
+
+      await store.setTtsEnabled(ownerId, true);
+      expect(JSON.parse(await readFile(preferencePath, "utf8"))).toEqual({
+        version: 2,
+        preferences: {
+          [ownerId]: { projectId: "beta", ttsEnabled: true },
+        },
+      });
+    } finally {
+      await rm(preferencePath, { force: true });
+    }
+  });
+
+  it("persists project and TTS preferences across runtime restarts", async () => {
     const ownerId = "telegram:bot-one:chat:42";
     const config = createTelegramConfig({
       bots: { "bot-one": { botToken: "token-1" } },
@@ -165,6 +197,7 @@ describe("telegram runtime", () => {
     });
 
     await firstStore.set(ownerId, "beta");
+    await firstStore.setTtsEnabled(ownerId, true);
     await firstRuntime.close();
 
     const secondRuntime = await startTelegramRuntime({
@@ -173,6 +206,7 @@ describe("telegram runtime", () => {
       deps: {
         startTelegramAdapter: vi.fn(async (options) => {
           expect(options.projectPreferences.get(ownerId)).toBe("beta");
+          expect(options.projectPreferences.isTtsEnabled(ownerId)).toBe(true);
           return { close: vi.fn(async () => {}) };
         }),
       },

--- a/test/telegram_session_manager.test.js
+++ b/test/telegram_session_manager.test.js
@@ -803,6 +803,85 @@ describe("telegram session manager", () => {
     expect(events.filter((event) => event.type === "session-turn-failed")).toHaveLength(1);
   });
 
+  it("does not complete an earlier response when steering is rejected before acceptance", async () => {
+    const clientHarness = createClientHarness();
+    const firstSubmit = deferred();
+    const steeringSubmit = deferred();
+    clientHarness.session.submit = vi.fn(async (_text, options) =>
+      applyRequestedHistoryEntryId(await firstSubmit.promise, options),
+    );
+    clientHarness.session.steer = vi.fn(async () => await steeringSubmit.promise);
+    const manager = createDemoSessionManager(clientHarness);
+    const events = [];
+    manager.onEvent((event) => events.push(event));
+
+    const created = await manager.createSession({ projectId: "demo" });
+    await waitFor(() => manager.getSession(created.id)?.state === "waiting-input");
+
+    await manager.sendMessage(created.id, "start work");
+    await manager.sendMessage(created.id, "steer it", { mode: "steer" });
+    clientHarness.emitDelta(
+      createPatchDelta(
+        [
+          {
+            type: "message.append",
+            message: createAssistantProtocolMessage("assistant-stale", [
+              { type: "text", text: "earlier answer" },
+            ]),
+          },
+        ],
+        1,
+        "assistant-message",
+      ),
+    );
+
+    firstSubmit.resolve({
+      userHistoryEntryId: "history-first",
+      turn: { status: "completed", stopReason: "stop" },
+    });
+    steeringSubmit.reject(new Error("steering transport disconnected"));
+    await waitFor(() => manager.getSession(created.id)?.state === "failed");
+
+    expect(assistantProgressTexts(events)).toEqual(["earlier answer"]);
+    expect(events.filter((event) => event.type === "session-response-completed")).toEqual([]);
+  });
+
+  it("does not complete a response after the session is cancelled", async () => {
+    const clientHarness = createClientHarness();
+    const manager = createDemoSessionManager(clientHarness);
+    const events = [];
+    manager.onEvent((event) => events.push(event));
+
+    const created = await manager.createSession({ projectId: "demo" });
+    await waitFor(() => manager.getSession(created.id)?.state === "waiting-input");
+
+    await manager.sendMessage(created.id, "start work");
+    clientHarness.emitDelta(
+      createPatchDelta(
+        [
+          {
+            type: "message.append",
+            message: createAssistantProtocolMessage("assistant-cancelled", [
+              { type: "text", text: "answer before cancellation" },
+            ]),
+          },
+        ],
+        1,
+        "assistant-message",
+      ),
+    );
+
+    const close = manager.closeSession(created.id);
+    clientHarness.submitDeferred.resolve({
+      userHistoryEntryId: "history-cancelled",
+      turn: { status: "completed", stopReason: "stop" },
+    });
+    await close;
+
+    expect(assistantProgressTexts(events)).toEqual(["answer before cancellation"]);
+    expect(events.filter((event) => event.type === "session-response-completed")).toEqual([]);
+  });
+
   it("emits one failure event for a batched steering turn", async () => {
     const clientHarness = createClientHarness();
     const steeringTurn = deferred();

--- a/test/telegram_session_manager.test.js
+++ b/test/telegram_session_manager.test.js
@@ -752,6 +752,57 @@ describe("telegram session manager", () => {
     await waitFor(() => manager.getSession(created.id)?.state === "waiting-input");
   });
 
+  it("does not complete an earlier assistant response when later steering fails", async () => {
+    const clientHarness = createClientHarness();
+    const firstSubmit = deferred();
+    const steeringSubmit = deferred();
+    clientHarness.session.submit = vi.fn(async (_text, options) =>
+      applyRequestedHistoryEntryId(await firstSubmit.promise, options),
+    );
+    clientHarness.session.steer = vi.fn(async () => await steeringSubmit.promise);
+    const manager = createDemoSessionManager(clientHarness);
+    const events = [];
+    manager.onEvent((event) => events.push(event));
+
+    const created = await manager.createSession({ projectId: "demo" });
+    await waitFor(() => manager.getSession(created.id)?.state === "waiting-input");
+
+    await manager.sendMessage(created.id, "start work");
+    await manager.sendMessage(created.id, "steer it", { mode: "steer" });
+    clientHarness.emitDelta(
+      createPatchDelta(
+        [
+          {
+            type: "message.append",
+            message: createAssistantProtocolMessage("assistant-stale", [
+              { type: "text", text: "earlier answer" },
+            ]),
+          },
+        ],
+        1,
+        "assistant-message",
+      ),
+    );
+
+    firstSubmit.resolve({
+      userHistoryEntryId: "history-first",
+      turn: { status: "completed", stopReason: "stop" },
+    });
+    steeringSubmit.resolve({
+      userHistoryEntryId: "history-steering",
+      turn: {
+        status: "failed",
+        stopReason: "error",
+        errorMessage: "OpenAI is unavailable",
+      },
+    });
+    await waitFor(() => manager.getSession(created.id)?.state === "waiting-input");
+
+    expect(assistantProgressTexts(events)).toEqual(["earlier answer"]);
+    expect(events.filter((event) => event.type === "session-response-completed")).toEqual([]);
+    expect(events.filter((event) => event.type === "session-turn-failed")).toHaveLength(1);
+  });
+
   it("emits one failure event for a batched steering turn", async () => {
     const clientHarness = createClientHarness();
     const steeringTurn = deferred();
@@ -2422,7 +2473,7 @@ describe("telegram session manager", () => {
     manager.onEvent((event) => {
       events.push(event);
     });
-    const { sendPromise } = await startRunningSession(manager);
+    const { created, sendPromise } = await startRunningSession(manager);
 
     clientHarness.emitDelta(
       createPatchDelta(
@@ -2491,16 +2542,16 @@ describe("telegram session manager", () => {
       turn: { status: "completed", stopReason: "stop" },
     });
     await sendPromise;
+    await waitFor(() => events.some((event) => event.type === "session-response-completed"));
 
     expect(assistantProgressTexts(events)).toEqual(["I’ll inspect that now.", "final answer"]);
-    expect(
-      events
-        .filter(
-          (event) =>
-            event.type === "session-progress" && event.progress.type === "assistant-message",
-        )
-        .map((event) => event.progress.final),
-    ).toEqual([false, true]);
+    expect(events.filter((event) => event.type === "session-response-completed")).toEqual([
+      expect.objectContaining({
+        sessionId: created.id,
+        messageId: "assistant-2",
+        text: "final answer",
+      }),
+    ]);
   });
 
   it("emits committed assistant progress from assistant-message snapshot resets once", async () => {

--- a/test/telegram_session_manager.test.js
+++ b/test/telegram_session_manager.test.js
@@ -2493,6 +2493,14 @@ describe("telegram session manager", () => {
     await sendPromise;
 
     expect(assistantProgressTexts(events)).toEqual(["I’ll inspect that now.", "final answer"]);
+    expect(
+      events
+        .filter(
+          (event) =>
+            event.type === "session-progress" && event.progress.type === "assistant-message",
+        )
+        .map((event) => event.progress.final),
+    ).toEqual([false, true]);
   });
 
   it("emits committed assistant progress from assistant-message snapshot resets once", async () => {

--- a/test/telegram_tts.test.js
+++ b/test/telegram_tts.test.js
@@ -67,7 +67,14 @@ describe("telegram TTS", () => {
     expect(combinedWave.readUInt32LE(40)).toBe(8);
     expect(spawn).toHaveBeenCalledWith(
       "ffmpeg",
-      expect.arrayContaining(["-c:a", "libopus", "-application", "voip"]),
+      expect.arrayContaining([
+        "-filter:a",
+        "atempo=1.1",
+        "-c:a",
+        "libopus",
+        "-application",
+        "voip",
+      ]),
       expect.objectContaining({ detached: true, killProcessGroup: true }),
     );
   });

--- a/test/telegram_tts.test.js
+++ b/test/telegram_tts.test.js
@@ -60,6 +60,9 @@ describe("telegram TTS", () => {
     });
 
     expect(voice).toEqual(Buffer.from("OggS voice"));
+    expect(streamSpeechAudio).toHaveBeenCalledWith(
+      expect.objectContaining({ deliveryMode: "complete" }),
+    );
     expect(combinedWave.subarray(44)).toEqual(Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]));
     expect(combinedWave.readUInt32LE(40)).toBe(8);
     expect(spawn).toHaveBeenCalledWith(

--- a/test/telegram_tts.test.js
+++ b/test/telegram_tts.test.js
@@ -1,0 +1,71 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { describe, expect, it, vi } from "vitest";
+import { generateTelegramVoice } from "../dist/core/telegram/tts.js";
+
+function createWaveAudio(pcm) {
+  const header = Buffer.alloc(44);
+  header.write("RIFF", 0);
+  header.writeUInt32LE(36 + pcm.length, 4);
+  header.write("WAVE", 8);
+  header.write("fmt ", 12);
+  header.writeUInt32LE(16, 16);
+  header.writeUInt16LE(1, 20);
+  header.writeUInt16LE(1, 22);
+  header.writeUInt32LE(24_000, 24);
+  header.writeUInt32LE(48_000, 28);
+  header.writeUInt16LE(2, 32);
+  header.writeUInt16LE(16, 34);
+  header.write("data", 36);
+  header.writeUInt32LE(pcm.length, 40);
+  return Buffer.concat([header, pcm]);
+}
+
+describe("telegram TTS", () => {
+  it("combines Gemini WAV chunks and encodes an Ogg Opus voice note", async () => {
+    const streamSpeechAudio = vi.fn(async function* () {
+      yield {
+        index: 0,
+        total: 2,
+        audio: createWaveAudio(Buffer.from([1, 2, 3, 4])),
+        mimeType: "audio/wav",
+      };
+      yield {
+        index: 1,
+        total: 2,
+        audio: createWaveAudio(Buffer.from([5, 6, 7, 8])),
+        mimeType: "audio/wav",
+      };
+    });
+    let combinedWave;
+    const spawn = vi.fn(async (_command, args) => {
+      const inputPath = args[args.indexOf("-i") + 1];
+      const outputPath = args.at(-1);
+      combinedWave = await readFile(inputPath);
+      await writeFile(outputPath, Buffer.from("OggS voice"));
+      return {
+        stdout: "",
+        stderr: "",
+        exitCode: 0,
+        captureLimitExceeded: false,
+        timedOut: false,
+        aborted: false,
+        closeSignal: null,
+      };
+    });
+
+    const voice = await generateTelegramVoice({
+      apiKey: "gemini-key",
+      sourceText: "final answer",
+      deps: { streamSpeechAudio, spawn },
+    });
+
+    expect(voice).toEqual(Buffer.from("OggS voice"));
+    expect(combinedWave.subarray(44)).toEqual(Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]));
+    expect(combinedWave.readUInt32LE(40)).toBe(8);
+    expect(spawn).toHaveBeenCalledWith(
+      "ffmpeg",
+      expect.arrayContaining(["-c:a", "libopus", "-application", "voip"]),
+      expect.objectContaining({ detached: true, killProcessGroup: true }),
+    );
+  });
+});

--- a/test/telegram_tts.test.js
+++ b/test/telegram_tts.test.js
@@ -1,6 +1,8 @@
-import { readFile, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import { generateTelegramVoice } from "../dist/core/telegram/tts.js";
+import { generateTelegramVoice, sweepStaleTelegramTtsTempDirs } from "../dist/core/telegram/tts.js";
 
 function createWaveAudio(pcm) {
   const header = Buffer.alloc(44);
@@ -21,27 +23,35 @@ function createWaveAudio(pcm) {
 }
 
 describe("telegram TTS", () => {
-  it("combines Gemini WAV chunks and encodes an Ogg Opus voice note", async () => {
+  it("removes stale Telegram TTS directories", async () => {
+    const staleDirectory = await mkdtemp(join(tmpdir(), "tau-telegram-tts-"));
+    await writeFile(join(staleDirectory, "speech.wav"), Buffer.from("assistant audio"));
+
+    await sweepStaleTelegramTtsTempDirs();
+
+    await expect(stat(staleDirectory)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("writes ordered Gemini WAV chunks and encodes one Ogg Opus voice note", async () => {
+    const waves = [
+      createWaveAudio(Buffer.from([1, 2, 3, 4])),
+      createWaveAudio(Buffer.from([5, 6, 7, 8])),
+    ];
     const streamSpeechAudio = vi.fn(async function* () {
-      yield {
-        index: 0,
-        total: 2,
-        audio: createWaveAudio(Buffer.from([1, 2, 3, 4])),
-        mimeType: "audio/wav",
-      };
-      yield {
-        index: 1,
-        total: 2,
-        audio: createWaveAudio(Buffer.from([5, 6, 7, 8])),
-        mimeType: "audio/wav",
-      };
+      for (const [index, audio] of waves.entries()) {
+        yield { index, total: waves.length, audio, mimeType: "audio/wav" };
+      }
     });
-    let combinedWave;
-    const spawn = vi.fn(async (_command, args) => {
-      const inputPath = args[args.indexOf("-i") + 1];
-      const outputPath = args.at(-1);
-      combinedWave = await readFile(inputPath);
-      await writeFile(outputPath, Buffer.from("OggS voice"));
+    let manifest;
+    let writtenWaves;
+    const spawn = vi.fn(async (_command, args, options) => {
+      manifest = await readFile(join(options.cwd, args[args.indexOf("-i") + 1]), "utf8");
+      writtenWaves = await Promise.all(
+        ["chunk-000.wav", "chunk-001.wav"].map(
+          async (name) => await readFile(join(options.cwd, name)),
+        ),
+      );
+      await writeFile(join(options.cwd, args.at(-1)), Buffer.from("OggS voice"));
       return {
         stdout: "",
         stderr: "",
@@ -63,11 +73,15 @@ describe("telegram TTS", () => {
     expect(streamSpeechAudio).toHaveBeenCalledWith(
       expect.objectContaining({ deliveryMode: "complete" }),
     );
-    expect(combinedWave.subarray(44)).toEqual(Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]));
-    expect(combinedWave.readUInt32LE(40)).toBe(8);
+    expect(manifest).toBe("ffconcat version 1.0\nfile 'chunk-000.wav'\nfile 'chunk-001.wav'\n");
+    expect(writtenWaves).toEqual(waves);
     expect(spawn).toHaveBeenCalledWith(
       "ffmpeg",
       expect.arrayContaining([
+        "-f",
+        "concat",
+        "-safe",
+        "1",
         "-filter:a",
         "atempo=1.1",
         "-c:a",
@@ -75,7 +89,11 @@ describe("telegram TTS", () => {
         "-application",
         "voip",
       ]),
-      expect.objectContaining({ detached: true, killProcessGroup: true }),
+      expect.objectContaining({
+        cwd: expect.stringContaining("tau-telegram-tts-"),
+        detached: true,
+        killProcessGroup: true,
+      }),
     );
   });
 });


### PR DESCRIPTION
## why

Telegram users can read final assistant responses in chat, but there is no persistent way to receive those responses as audio when listening is more convenient.

## what

Add `/tts_on` and `/tts_off` with a per-bot, per-chat preference that survives project changes, new sessions, and runner restarts. After a successful logical response settles, the runner keeps text authoritative and asynchronously sends a Gemini-generated Telegram voice note.

## details

The shared speech pipeline rewrites responses into plain spoken paragraphs with `gemini-3.6-flash`, then synthesizes them with `gemini-3.1-flash-tts-preview` and the Despina voice. TUI playback uses 500-character chunks at concurrency six; Telegram uses 1,000-character chunks at concurrency three. Both preserve paragraph and Unicode boundaries, use a brisk synthesis direction, and apply pitch-preserving 1.1× playback.

Source and rewritten text are each limited to 10,000 Unicode characters, cumulative PCM to 32 MiB, and every TTS request to 8,192 output tokens. Rewriting has a one-minute deadline, conversion has two minutes, and the complete Telegram job has five minutes through upload retries.

Telegram validates each ordered WAV chunk and writes it to a controlled temporary file. One runner-side `ffmpeg` concat operation produces Ogg Opus, and startup removes temporary directories left by crashes. Voice jobs are serialized per session, remain live-only across restarts, and recheck opt-in state before delivery.

Generation, conversion, timeout, size, and exhausted upload failures leave text unaffected. While voice responses remain enabled, the bot sends `voice response failed. please try again.` and keeps detailed diagnostics in runner logs.

Existing version 1 project preferences migrate lazily to the combined version 2 project and TTS preference shape, preserving the selected project and defaulting TTS off. The two added commands reduce the visible project-command capacity from 92 to 90 per bot.
