### PR TITLE
isolate history replication failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,7 +132,7 @@ Recovery discards supervised agents and agent-owned presentation because child p
 
 Effective system instructions are the first committed message. Snapshot user text is raw recoverable Tau session text. Strip Tau metadata before model calls and display, and hide leading exact `<system>...</system>\n` blocks only in user-message display projection. Do not apply user projection to assistant, tool-result, or protocol system messages.
 
-Searchable history is a separate flat transcript of committed user entries, assistant text, and completed tools. Rewind truncates it; compaction does not. Remote replication proceeds asynchronously from the durable local outbox. History is not sufficient to recover session state. See `docs/sessions.md`, `docs/history.md`, and tests under `test/history.test.js` and `test/local_session_host.test.js`.
+Searchable history is a separate flat transcript of committed user entries, assistant text, and completed tools. Rewind truncates it; compaction does not. Remote replication proceeds asynchronously from the durable local outbox, preserves per-session order, and quarantines permanent failures by session so one poisoned lane cannot block unrelated histories. History is not sufficient to recover session state. See `docs/sessions.md`, `docs/history.md`, and tests under `test/history.test.js` and `test/local_session_host.test.js`.
 
 Themes are client-local and never belong in a snapshot. Prompt catalogs contain metadata only; prompt bodies resolve lazily through the execution environment. Path autocomplete is also lazy and must not become persisted session state.
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -222,7 +222,7 @@ A global-only remote history target:
 
 | Nested field | Type | Required | Contract |
 | --- | --- | --- | --- |
-| `endpoint` | Non-empty string | Yes | HTTP(S) URL with no query or fragment |
+| `endpoint` | Non-empty string | Yes | HTTP(S) URL with no credentials, query, or fragment |
 | `apiKey` | Non-empty string | No | Inline service API key |
 | `apiKeyEnv` | Non-empty string | No | Host environment variable containing the key |
 

--- a/docs/history.md
+++ b/docs/history.md
@@ -99,7 +99,7 @@ Remote history is accepted only in the host's eligible global Tau config, normal
 }
 ```
 
-`endpoint` must be an HTTP or HTTPS URL without a query or hash. Tau removes trailing slashes. The API key resolves on the host in this order:
+`endpoint` must be an HTTP or HTTPS URL without credentials, a query, or a hash. Tau removes trailing slashes. The API key resolves on the host in this order:
 
 1. `TAU_HISTORY_API_KEY`
 2. the host environment variable named by `history.apiKeyEnv`

--- a/docs/history.md
+++ b/docs/history.md
@@ -118,7 +118,9 @@ Remote replication is local-first:
 3. The host sends pending operations to the configured endpoint asynchronously.
 4. Successful acknowledgements remove those operations from the outbox.
 
-A service outage does not block session execution or local transcript capture. Pending operations remain durable and are retried when replication is scheduled again, including after host restart or later history activity. The remote service applies operations idempotently and in order.
+A service outage does not block session execution or local transcript capture. Pending operations remain durable and are retried when replication is scheduled again, including after host restart or later history activity. The remote service applies operations idempotently. Tau preserves operation order within each session while processing separate session lanes independently.
+
+A permanent operation-domain rejection, such as conflicting immutable session metadata, quarantines only that session's replication lane. Its pending operations and diagnostic remain in local SQLite, later operations for that session stay blocked, and unrelated sessions continue replicating. Transient transport, authentication, rate-limit, and service failures do not quarantine a lane; they leave endpoint replication pending for a later retry. Both kinds of failure produce a structured `history_replication_failed` host log without exposing the API key.
 
 Local entries retain their complete captured payloads. For remote replication, an entry larger than 1 MiB keeps its identity and metadata but middle-truncates oversized content, arguments, or results with an explicit marker. Remote history is therefore useful for retrieval, but the host's local entry can contain details that the shared copy intentionally omits.
 
@@ -144,7 +146,7 @@ Cloudflare operational failures are visible through normal Worker logs, Cron Eve
 
 **The history tool returns a service error while the session still works.** Remote queries and asynchronous replication can fail independently of session execution. Check endpoint reachability and Worker logs without printing the bearer key. Local capture should continue unless the session also contains a `history unavailable` warning.
 
-**A session does not appear in remote search.** Confirm that the host was restarted with the global remote config, that the session was opened while that target was active, and that later history activity has had a chance to flush the durable outbox. Do not assume remote digests are immediate.
+**A session does not appear in remote search.** Confirm that the host was restarted with the global remote config, that the session was opened while that target was active, and that later history activity has had a chance to flush the durable outbox. Check host logs for `history_replication_failed`; a quarantined failure affects only the named session, while an unquarantined endpoint failure remains retryable. Do not assume remote digests are immediate.
 
 **Local history became unavailable.** Check host-side filesystem access, free space, and ownership for `~/.config/tau`. Restarting is required to reopen a manager disabled by an earlier local failure.
 

--- a/src/core/config/schema.ts
+++ b/src/core/config/schema.ts
@@ -756,13 +756,21 @@ function parseHistoryConfig(
   let endpoint: string;
   try {
     const url = new URL(parsed.data.endpoint);
-    if ((url.protocol !== "https:" && url.protocol !== "http:") || url.search || url.hash) {
+    if (
+      (url.protocol !== "https:" && url.protocol !== "http:") ||
+      url.username ||
+      url.password ||
+      url.search ||
+      url.hash
+    ) {
       throw new Error();
     }
     endpoint = url.toString().replace(/\/+$/, "");
   } catch {
     return {
-      errors: [`${sourceLabel}: history.endpoint must be an HTTP(S) URL without a query or hash.`],
+      errors: [
+        `${sourceLabel}: history.endpoint must be an HTTP(S) URL without credentials, a query, or a hash.`,
+      ],
     };
   }
 

--- a/src/core/history/history_manager.ts
+++ b/src/core/history/history_manager.ts
@@ -1,5 +1,5 @@
 import { LocalHistoryStore } from "./local_history_store.js";
-import { RemoteHistoryClient } from "./remote_history_client.js";
+import { RemoteHistoryClient, RemoteHistoryError } from "./remote_history_client.js";
 import type {
   HistoryEntry,
   HistoryQuery,
@@ -10,8 +10,15 @@ import type {
 } from "./types.js";
 
 const REPLICATION_BATCH_SIZE = 10;
+const REPLICATION_LANE_BATCH_SIZE = 10;
 const REPLICATION_BATCH_BYTES = 6 * 1024 * 1024;
 const REPLICATION_TIMEOUT_MS = 15_000;
+const PERMANENT_REPLICATION_ERROR_CODES = new Set([
+  "immutable_conflict",
+  "invalid_request",
+  "not_found",
+  "request_too_large",
+]);
 
 export class HistoryManager {
   private readonly replicationRuns = new Map<string, Promise<void>>();
@@ -151,7 +158,9 @@ export class HistoryManager {
       }
     });
     this.replicationRuns.set(target.endpoint, run);
-    void run.catch(() => undefined);
+    void run.catch((error) => {
+      reportReplicationFailure({ endpoint: target.endpoint, error });
+    });
   }
 
   private async replicate(endpoint: string): Promise<void> {
@@ -161,14 +170,50 @@ export class HistoryManager {
     while (true) {
       const local = this.local;
       if (!local) return;
-      const pending = local.listPendingOperations(endpoint, REPLICATION_BATCH_SIZE);
-      if (pending.length === 0) return;
-      const batch = boundedReplicationBatch(pending);
-      await client.applyOperations(
-        batch.map((item) => item.operation),
-        AbortSignal.timeout(REPLICATION_TIMEOUT_MS),
+      const lanes = local.listPendingOperationLanes(
+        endpoint,
+        REPLICATION_LANE_BATCH_SIZE,
+        REPLICATION_BATCH_SIZE,
       );
-      local.acknowledgeOperations(batch.map((item) => item.rowId));
+      if (lanes.length === 0) return;
+      for (const pending of lanes) {
+        const batch = boundedReplicationBatch(pending);
+        const first = batch[0]?.operation;
+        if (!first) continue;
+        try {
+          await client.applyOperations(
+            batch.map((item) => item.operation),
+            AbortSignal.timeout(REPLICATION_TIMEOUT_MS),
+          );
+        } catch (error) {
+          if (isPermanentReplicationFailure(error)) {
+            local.quarantineReplicationSession({
+              endpoint,
+              sessionId: first.sessionId,
+              operationId: first.id,
+              code: error.code,
+              message: error.message,
+              failedAt: Date.now(),
+            });
+            reportReplicationFailure({
+              endpoint,
+              sessionId: first.sessionId,
+              operationId: first.id,
+              error,
+              quarantined: true,
+            });
+            continue;
+          }
+          reportReplicationFailure({
+            endpoint,
+            sessionId: first.sessionId,
+            operationId: first.id,
+            error,
+          });
+          return;
+        }
+        local.acknowledgeOperations(batch.map((item) => item.rowId));
+      }
     }
   }
 }
@@ -177,6 +222,43 @@ function formatFailureReason(error: unknown): string {
   if (error instanceof Error && error.message.trim()) return error.message.trim();
   const text = String(error).trim();
   return text || "unknown failure";
+}
+
+function isPermanentReplicationFailure(error: unknown): error is RemoteHistoryError & {
+  code: string;
+} {
+  return (
+    error instanceof RemoteHistoryError &&
+    error.status >= 400 &&
+    error.status < 500 &&
+    error.code !== undefined &&
+    PERMANENT_REPLICATION_ERROR_CODES.has(error.code)
+  );
+}
+
+function reportReplicationFailure(input: {
+  endpoint: string;
+  sessionId?: string;
+  operationId?: string;
+  error: unknown;
+  quarantined?: boolean;
+}): void {
+  const error = input.error;
+  console.error(
+    JSON.stringify({
+      event: "history_replication_failed",
+      endpoint: input.endpoint,
+      ...(input.sessionId ? { sessionId: input.sessionId } : {}),
+      ...(input.operationId ? { operationId: input.operationId } : {}),
+      ...(input.quarantined ? { quarantined: true } : {}),
+      error: {
+        ...(error instanceof RemoteHistoryError
+          ? { status: error.status, ...(error.code ? { code: error.code } : {}) }
+          : {}),
+        message: formatFailureReason(error),
+      },
+    }),
+  );
 }
 
 function boundedReplicationBatch<T extends { operation: unknown }>(pending: T[]): T[] {

--- a/src/core/history/local_history_store.ts
+++ b/src/core/history/local_history_store.ts
@@ -24,9 +24,18 @@ const MAX_SEARCH_SNIPPETS = 3;
 type SqlValue = string | number | null;
 type SqlRow = Record<string, SqlValue>;
 
-type PendingReplicationOperation = {
+export type PendingReplicationOperation = {
   rowId: number;
   operation: HistoryReplicationOperation;
+};
+
+export type HistoryReplicationFailure = {
+  endpoint: string;
+  sessionId: string;
+  operationId: string;
+  code: string;
+  message: string;
+  failedAt: number;
 };
 
 export function getDefaultHistoryDatabasePath(homeDir?: string): string {
@@ -310,6 +319,78 @@ export class LocalHistoryStore {
       .run(...rowIds);
   }
 
+  listPendingOperationLanes(
+    endpoint: string,
+    laneLimit: number,
+    operationLimit: number,
+  ): PendingReplicationOperation[][] {
+    const lanes = this.database
+      .prepare(
+        `SELECT o.session_id
+         FROM history_outbox o
+         WHERE o.endpoint = ?
+           AND NOT EXISTS (
+             SELECT 1 FROM history_replication_failures f
+             WHERE f.endpoint = o.endpoint AND f.session_id = o.session_id
+           )
+         GROUP BY o.session_id
+         ORDER BY MIN(o.id)
+         LIMIT ?`,
+      )
+      .all(endpoint, laneLimit) as SqlRow[];
+    const selectOperations = this.database.prepare(
+      "SELECT id, payload_json FROM history_outbox WHERE endpoint = ? AND session_id = ? ORDER BY id LIMIT ?",
+    );
+    return lanes.map((lane) =>
+      (selectOperations.all(endpoint, String(lane.session_id), operationLimit) as SqlRow[]).map(
+        (row) => ({
+          rowId: Number(row.id),
+          operation: JSON.parse(String(row.payload_json)) as HistoryReplicationOperation,
+        }),
+      ),
+    );
+  }
+
+  quarantineReplicationSession(failure: HistoryReplicationFailure): void {
+    this.database
+      .prepare(
+        `INSERT INTO history_replication_failures
+           (endpoint, session_id, operation_id, code, message, failed_at)
+         VALUES (?, ?, ?, ?, ?, ?)
+         ON CONFLICT(endpoint, session_id) DO UPDATE SET
+           operation_id = excluded.operation_id,
+           code = excluded.code,
+           message = excluded.message,
+           failed_at = excluded.failed_at`,
+      )
+      .run(
+        failure.endpoint,
+        failure.sessionId,
+        failure.operationId,
+        failure.code,
+        failure.message,
+        failure.failedAt,
+      );
+  }
+
+  listReplicationFailures(endpoint: string): HistoryReplicationFailure[] {
+    return (
+      this.database
+        .prepare(
+          `SELECT endpoint, session_id, operation_id, code, message, failed_at
+           FROM history_replication_failures WHERE endpoint = ? ORDER BY failed_at, session_id`,
+        )
+        .all(endpoint) as SqlRow[]
+    ).map((row) => ({
+      endpoint: String(row.endpoint),
+      sessionId: String(row.session_id),
+      operationId: String(row.operation_id),
+      code: String(row.code),
+      message: String(row.message),
+      failedAt: Number(row.failed_at),
+    }));
+  }
+
   private initialize(): void {
     this.database.exec(`
       PRAGMA journal_mode = WAL;
@@ -364,10 +445,42 @@ export class LocalHistoryStore {
       CREATE TABLE IF NOT EXISTS history_outbox (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         endpoint TEXT NOT NULL,
+        session_id TEXT NOT NULL,
         payload_json TEXT NOT NULL
       );
       CREATE INDEX IF NOT EXISTS history_outbox_target ON history_outbox(endpoint, id);
+      CREATE TABLE IF NOT EXISTS history_replication_failures (
+        endpoint TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        operation_id TEXT NOT NULL,
+        code TEXT NOT NULL,
+        message TEXT NOT NULL,
+        failed_at INTEGER NOT NULL,
+        PRIMARY KEY (endpoint, session_id)
+      );
     `);
+    const outboxColumns = new Set(
+      (this.database.prepare("PRAGMA table_info(history_outbox)").all() as SqlRow[]).map((row) =>
+        String(row.name),
+      ),
+    );
+    if (!outboxColumns.has("session_id")) {
+      this.transaction(() => {
+        this.database.exec("ALTER TABLE history_outbox ADD COLUMN session_id TEXT");
+        this.database.exec(
+          "UPDATE history_outbox SET session_id = json_extract(payload_json, '$.sessionId')",
+        );
+      });
+    }
+    const missingSessionId = this.database
+      .prepare("SELECT 1 AS found FROM history_outbox WHERE session_id IS NULL LIMIT 1")
+      .get();
+    if (missingSessionId) {
+      throw new Error("history outbox contains an operation without a session ID");
+    }
+    this.database.exec(
+      "CREATE INDEX IF NOT EXISTS history_outbox_lanes ON history_outbox(endpoint, session_id, id)",
+    );
   }
 
   private requireSession(sessionId: string): void {
@@ -379,8 +492,8 @@ export class LocalHistoryStore {
 
   private enqueue(endpoint: string, operation: HistoryReplicationOperation): void {
     this.database
-      .prepare("INSERT INTO history_outbox (endpoint, payload_json) VALUES (?, ?)")
-      .run(endpoint, JSON.stringify(operation));
+      .prepare("INSERT INTO history_outbox (endpoint, session_id, payload_json) VALUES (?, ?, ?)")
+      .run(endpoint, operation.sessionId, JSON.stringify(operation));
   }
 
   private transaction<T>(handler: () => T): T {

--- a/src/core/history/local_history_store.ts
+++ b/src/core/history/local_history_store.ts
@@ -466,6 +466,12 @@ export class LocalHistoryStore {
     );
     if (!outboxColumns.has("session_id")) {
       this.transaction(() => {
+        const lockedOutboxColumns = new Set(
+          (this.database.prepare("PRAGMA table_info(history_outbox)").all() as SqlRow[]).map(
+            (row) => String(row.name),
+          ),
+        );
+        if (lockedOutboxColumns.has("session_id")) return;
         this.database.exec("ALTER TABLE history_outbox ADD COLUMN session_id TEXT");
         this.database.exec(
           "UPDATE history_outbox SET session_id = json_extract(payload_json, '$.sessionId')",

--- a/src/core/history/remote_history_client.ts
+++ b/src/core/history/remote_history_client.ts
@@ -11,6 +11,8 @@ import type {
 } from "./types.js";
 
 const MAX_RESPONSE_BYTES = 16 * 1024 * 1024;
+const MAX_ERROR_CODE_BYTES = 128;
+const MAX_ERROR_MESSAGE_BYTES = 4096;
 
 export class RemoteHistoryError extends Error {
   constructor(
@@ -150,16 +152,29 @@ export class RemoteHistoryClient implements HistoryQuery {
           : undefined;
       const code =
         remoteError && "code" in remoteError && typeof remoteError.code === "string"
-          ? remoteError.code
+          ? boundUtf8(remoteError.code, MAX_ERROR_CODE_BYTES)
           : undefined;
       const message =
         remoteError && "message" in remoteError && typeof remoteError.message === "string"
-          ? remoteError.message
+          ? boundUtf8(remoteError.message, MAX_ERROR_MESSAGE_BYTES)
           : `History service request failed with HTTP ${response.status}`;
       throw new RemoteHistoryError(response.status, code, message);
     }
     return value;
   }
+}
+
+function boundUtf8(value: string, maxBytes: number): string {
+  if (Buffer.byteLength(value, "utf8") <= maxBytes) return value;
+  let result = "";
+  let bytes = 0;
+  for (const character of value) {
+    const characterBytes = Buffer.byteLength(character, "utf8");
+    if (bytes + characterBytes > maxBytes) break;
+    result += character;
+    bytes += characterBytes;
+  }
+  return result;
 }
 
 async function readBoundedResponse(response: Response): Promise<string> {

--- a/src/core/history/remote_history_client.ts
+++ b/src/core/history/remote_history_client.ts
@@ -12,6 +12,17 @@ import type {
 
 const MAX_RESPONSE_BYTES = 16 * 1024 * 1024;
 
+export class RemoteHistoryError extends Error {
+  constructor(
+    readonly status: number,
+    readonly code: string | undefined,
+    message: string,
+  ) {
+    super(message);
+    this.name = "RemoteHistoryError";
+  }
+}
+
 const digestSchema = z
   .object({
     title: z.string(),
@@ -129,17 +140,23 @@ export class RemoteHistoryClient implements HistoryQuery {
       throw new Error("History service returned a non-JSON response");
     }
     if (!response.ok) {
-      const message =
+      const remoteError =
         typeof value === "object" &&
         value !== null &&
         "error" in value &&
         typeof value.error === "object" &&
-        value.error !== null &&
-        "message" in value.error &&
-        typeof value.error.message === "string"
-          ? value.error.message
+        value.error !== null
+          ? value.error
+          : undefined;
+      const code =
+        remoteError && "code" in remoteError && typeof remoteError.code === "string"
+          ? remoteError.code
+          : undefined;
+      const message =
+        remoteError && "message" in remoteError && typeof remoteError.message === "string"
+          ? remoteError.message
           : `History service request failed with HTTP ${response.status}`;
-      throw new Error(message);
+      throw new RemoteHistoryError(response.status, code, message);
     }
     return value;
   }

--- a/test/config_layers.test.js
+++ b/test/config_layers.test.js
@@ -335,6 +335,39 @@ describe("config paths", () => {
     }
   });
 
+  it("rejects credentials in remote history endpoints", () => {
+    const fx = setupFixture();
+
+    try {
+      const repo = join(fx.home, "repo");
+      const configPath = join(fx.home, ".config", "tau", "config.json");
+      mkdirSync(repo, { recursive: true });
+      mkdirSync(join(fx.home, ".config", "tau"), { recursive: true });
+      writeFileSync(
+        configPath,
+        JSON.stringify({
+          history: {
+            endpoint: "https://user:secret@history.example.com",
+            apiKey: "history-key",
+          },
+        }),
+      );
+
+      const deps = createConfigDeps({ cwd: repo, home: fx.home, env: {} });
+      const levels = resolveConfigLevels(deps, { cwd: repo });
+      const modelResolver = loadModelResolver({ deps, levels });
+      const result = loadConfigWithDiagnostics(deps, { levels, modelResolver });
+
+      expect(result.config.history).toBeUndefined();
+      expect(result.errors).toEqual([
+        `${configPath}: history.endpoint must be an HTTP(S) URL without credentials, a query, or a hash.`,
+      ]);
+      expect(result.errors.join("\n")).not.toContain("secret");
+    } finally {
+      fx.cleanup();
+    }
+  });
+
   it("merges api keys for arbitrary providers", () => {
     const fx = setupFixture();
 

--- a/test/history.test.js
+++ b/test/history.test.js
@@ -4,9 +4,13 @@ import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it, vi } from "vitest";
 import { resolveHistoryRemoteTarget } from "../dist/core/history/config.js";
+import { HistoryManager } from "../dist/core/history/history_manager.js";
 import { LocalHistoryStore } from "../dist/core/history/local_history_store.js";
 import { HISTORY_INITIAL_MIGRATION_SQL } from "../dist/core/history/migrations.js";
-import { RemoteHistoryClient } from "../dist/core/history/remote_history_client.js";
+import {
+  RemoteHistoryClient,
+  RemoteHistoryError,
+} from "../dist/core/history/remote_history_client.js";
 import { setupHistoryService } from "../dist/core/history/setup.js";
 import {
   assistantHistoryEntries,
@@ -585,6 +589,148 @@ describe("session history", () => {
     }
   });
 
+  it("backfills session lanes for existing replication outboxes", () => {
+    const root = mkdtempSync(join(tmpdir(), "tau-history-lanes-"));
+    const path = join(root, "history.sqlite");
+    const sqlite = new DatabaseSync(path);
+    try {
+      sqlite.exec(`
+        CREATE TABLE history_outbox (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          endpoint TEXT NOT NULL,
+          payload_json TEXT NOT NULL
+        );
+      `);
+      sqlite.prepare("INSERT INTO history_outbox (endpoint, payload_json) VALUES (?, ?)").run(
+        "https://history.example.com",
+        JSON.stringify({
+          id: "create-existing",
+          sessionId: "existing",
+          type: "create",
+          session: { sessionId: "existing", attributes: {}, createdAt: 1 },
+        }),
+      );
+    } finally {
+      sqlite.close();
+    }
+
+    const store = new LocalHistoryStore(path);
+    try {
+      expect(store.listPendingOperationLanes("https://history.example.com", 10, 10)).toMatchObject([
+        [{ operation: { id: "create-existing", sessionId: "existing" } }],
+      ]);
+    } finally {
+      store.close();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("isolates permanent replication failures to one session lane", async () => {
+    const store = new LocalHistoryStore(":memory:");
+    const history = new HistoryManager(store);
+    const remote = { endpoint: "https://history.example.com", apiKey: "secret" };
+    const requests = [];
+    const fetchMock = vi.fn(async (_url, init) => {
+      const operations = JSON.parse(init.body).operations;
+      requests.push(operations);
+      expect(new Set(operations.map((operation) => operation.sessionId)).size).toBe(1);
+      if (operations[0].sessionId === "conflicting") {
+        return Response.json(
+          {
+            error: {
+              code: "immutable_conflict",
+              message: "session 'conflicting' has conflicting immutable data",
+            },
+          },
+          { status: 409 },
+        );
+      }
+      return Response.json({ applied: operations.length });
+    });
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      history.registerSession(
+        { sessionId: "conflicting", attributes: { source: "test" }, createdAt: 1 },
+        remote,
+      );
+      history.append(
+        "conflicting",
+        [createTextEntry("conflicting-entry", "user", "conflicting", 2)],
+        remote,
+      );
+      history.registerSession(
+        { sessionId: "healthy", attributes: { source: "test" }, createdAt: 3 },
+        remote,
+      );
+      history.append("healthy", [createTextEntry("healthy-entry", "user", "healthy", 4)], remote);
+
+      await history.flush();
+
+      expect(requests.some((operations) => operations[0].sessionId === "healthy")).toBe(true);
+      expect(
+        store.listPendingOperations(remote.endpoint, 20).map((item) => item.operation.sessionId),
+      ).toEqual(["conflicting", "conflicting"]);
+      expect(store.listReplicationFailures(remote.endpoint)).toMatchObject([
+        {
+          sessionId: "conflicting",
+          operationId: expect.any(String),
+          code: "immutable_conflict",
+          message: "session 'conflicting' has conflicting immutable data",
+        },
+      ]);
+      expect(JSON.parse(errorLog.mock.calls[0][0])).toMatchObject({
+        event: "history_replication_failed",
+        endpoint: remote.endpoint,
+        sessionId: "conflicting",
+        quarantined: true,
+        error: { status: 409, code: "immutable_conflict" },
+      });
+    } finally {
+      await history.flush();
+      history.close();
+      vi.unstubAllGlobals();
+      errorLog.mockRestore();
+    }
+  });
+
+  it("keeps endpoint failures retryable without quarantining a session", async () => {
+    const store = new LocalHistoryStore(":memory:");
+    const history = new HistoryManager(store);
+    const remote = { endpoint: "https://history.example.com", apiKey: "secret" };
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json(
+          { error: { code: "internal_error", message: "Internal server error" } },
+          { status: 503 },
+        ),
+      ),
+    );
+
+    try {
+      history.registerSession(
+        { sessionId: "retryable", attributes: { source: "test" }, createdAt: 1 },
+        remote,
+      );
+      await history.flush();
+
+      expect(store.listPendingOperations(remote.endpoint, 10)).toHaveLength(1);
+      expect(store.listReplicationFailures(remote.endpoint)).toEqual([]);
+      expect(JSON.parse(errorLog.mock.calls[0][0])).toMatchObject({
+        event: "history_replication_failed",
+        sessionId: "retryable",
+        error: { status: 503, code: "internal_error" },
+      });
+    } finally {
+      history.close();
+      vi.unstubAllGlobals();
+      errorLog.mockRestore();
+    }
+  });
+
   it("keeps full local entries while bounding remote replication by entry and operation bytes", async () => {
     const store = new LocalHistoryStore(":memory:");
     const remote = { endpoint: "https://history.example.com", apiKey: "secret" };
@@ -657,6 +803,40 @@ describe("session history", () => {
     } finally {
       store.close();
     }
+  });
+
+  it("preserves structured errors returned by the remote history service", async () => {
+    const client = new RemoteHistoryClient(
+      { endpoint: "https://history.example.com", apiKey: "secret" },
+      async () =>
+        Response.json(
+          {
+            error: {
+              code: "immutable_conflict",
+              message: "session metadata conflicts",
+            },
+          },
+          { status: 409 },
+        ),
+    );
+
+    const error = await client
+      .applyOperations([
+        {
+          id: "create-conflict",
+          sessionId: "conflict",
+          type: "create",
+          session: { sessionId: "conflict", attributes: {}, createdAt: 1 },
+        },
+      ])
+      .catch((caught) => caught);
+
+    expect(error).toBeInstanceOf(RemoteHistoryError);
+    expect(error).toMatchObject({
+      status: 409,
+      code: "immutable_conflict",
+      message: "session metadata conflicts",
+    });
   });
 
   it("paginates remote reads by payload bytes and requested entry count", () => {

--- a/test/history.test.js
+++ b/test/history.test.js
@@ -839,6 +839,39 @@ describe("session history", () => {
     });
   });
 
+  it("bounds structured remote error fields by UTF-8 bytes", async () => {
+    const client = new RemoteHistoryClient(
+      { endpoint: "https://history.example.com", apiKey: "secret" },
+      async () =>
+        Response.json(
+          {
+            error: {
+              code: "é".repeat(100),
+              message: "🙂".repeat(2000),
+            },
+          },
+          { status: 400 },
+        ),
+    );
+
+    const error = await client
+      .applyOperations([
+        {
+          id: "create-invalid",
+          sessionId: "invalid",
+          type: "create",
+          session: { sessionId: "invalid", attributes: {}, createdAt: 1 },
+        },
+      ])
+      .catch((caught) => caught);
+
+    expect(error).toBeInstanceOf(RemoteHistoryError);
+    expect(Buffer.byteLength(error.code, "utf8")).toBe(128);
+    expect(Buffer.byteLength(error.message, "utf8")).toBe(4096);
+    expect(error.code).toBe("é".repeat(64));
+    expect(error.message).toBe("🙂".repeat(1024));
+  });
+
   it("paginates remote reads by payload bytes and requested entry count", () => {
     expect(
       selectHistoryReadPage(


### PR DESCRIPTION
## why

Remote history replication currently uses one endpoint-wide FIFO outbox. A permanent rejection for one session is retried from the head forever, preventing every later session from reaching the shared history service, while the replication error itself is silently discarded.

## what

Replicate ordered batches through independent per-session lanes. Permanent operation-domain rejections quarantine only the affected session and retain its pending operations plus a durable diagnostic, while unrelated lanes continue. Transient transport and endpoint failures remain pending for a later retry.

Preserve remote HTTP status and error codes, emit structured host diagnostics for all replication failures, and migrate existing outboxes by backfilling their session lane from the durable operation payload.
