### PR TITLE
retain failed speech and stream OpenAI transcription

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,8 @@ Treat the client, host, and execution environment as separate logical machines e
 - The execution environment is the agent's machine. It owns every agent-visible path, `cwd`, home, repository, project configuration and content, `AGENTS.md`, skills, model overlays, platform, Node version, `PATH`, filesystem operation, and command.
 - The Telegram runner owns Telegram polling, routing, attachments, prepared workspaces, outbound messages, and runner-specific persisted state. It is a client of local in-process sessions.
 
+Temporary storage follows the same ownership boundary. Client, host, and runner code derives process-local temporary paths from `node:os` `tmpdir()` instead of hard-coding `/tmp`. Target-owned temporary paths come from target capabilities or a documented adapter contract, never from the caller's local temporary directory.
+
 Outside narrow pre-creation metadata obtained by a client from an environment it directly manages, client and host filesystem APIs must not inspect execution-environment paths. Session creation attributes are complete, authoritative client input. The host and stores do not infer or normalize them. All agent-visible access must cross `ExecutionEnvironment` and `ToolExecutionBackend`, even for a local session. Physical co-location must not create a second runtime path.
 
 The boundary contracts are in `src/execution/execution_environment.ts` and `src/core/tools/execution_backend.ts`. Host integration is in `src/host/`, and ownership behavior is covered by `test/local_execution_environment.test.js`, hosted-environment tests, and `test/local_session_host.test.js`.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -171,7 +171,7 @@ The map accepts arbitrary non-empty provider names and string values. Values are
 
 For model requests, credential precedence is an explicit request override, configured `apiKeys.<provider>`, then the provider runtime's ambient authentication. This means `apiKeys.openai` wins over `OPENAI_API_KEY` for model calls. The `openai-codex` provider uses managed OAuth separately and does not use `apiKeys.openai`.
 
-Feature-specific helpers use different precedence: `EXA_API_KEY`, `GEMINI_API_KEY`, and `MISTRAL_API_KEY` take precedence over `apiKeys.exa`, `apiKeys.google`, and `apiKeys.mistral` for the features that consume those helpers. See [credentials](credentials.md) for the exact feature matrix.
+Feature-specific helpers use different precedence: `EXA_API_KEY`, `GEMINI_API_KEY`, `MISTRAL_API_KEY`, and `OPENAI_API_KEY` take precedence over their matching `apiKeys` entries for the features that consume those helpers. See [credentials](credentials.md) for the exact feature matrix.
 
 Credentials are consumed where the model or feature runs. In an attached session that is usually the host, not the TUI client. Avoid committing project API keys. See [credentials](credentials.md).
 
@@ -179,9 +179,9 @@ Credentials are consumed where the model or feature runs. In an attached session
 
 An object with one required field when present:
 
-| Nested field | Type   | Values                |
-| ------------ | ------ | --------------------- |
-| `provider`   | String | `mistral` or `gemini` |
+| Nested field | Type   | Values                           |
+| ------------ | ------ | -------------------------------- |
+| `provider`   | String | `mistral`, `gemini`, or `openai` |
 
 ```json
 {

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -15,7 +15,7 @@ These are defaults built into this Tau version, not a dump of the effective conf
 | Built-in personas | Enabled |
 | Built-in themes | Enabled |
 | Automatic compaction | `{ "enabled": true, "reserveTokens": 16384, "keepRecentTokens": 20000 }` |
-| Speech-to-text provider when unset | `mistral` |
+| Speech-to-text provider when unset | `openai` |
 | Built-in diff tool code theme | `github-dark-dimmed` |
 | Command client tool timeout when unset | `60000` ms |
 
@@ -191,7 +191,7 @@ An object with one required field when present:
 }
 ```
 
-When the object is absent, `/listen` and Telegram transcription use `mistral`. The TUI consumes this setting for client-local recording; the Telegram runner consumes it for Telegram audio. Restart the owning process after changing it.
+When the object is absent, `/listen` and Telegram transcription use `openai`. The TUI consumes this setting for client-local recording; the Telegram runner consumes it for Telegram audio. Restart the owning process after changing it.
 
 ### `nook`
 

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -67,7 +67,7 @@ Several Tau features share provider credentials but intentionally prefer a fixed
 
 The Google, Mistral, and OpenAI rows describe feature-specific helpers. Model calls follow the general model-authentication order instead, where the configured provider key wins over ambient environment authentication.
 
-`web.discover` does not require Exa. `web.search` and `web.fetch` do. `/speak` and Telegram `/tts_on` voice responses use Google. `/listen` and incoming Telegram audio use the configured `speechToText.provider`, which is `mistral` unless configuration selects `gemini` or `openai`. PDF OCR through `tau tool pdf-unpack` uses Mistral.
+`web.discover` does not require Exa. `web.search` and `web.fetch` do. `/speak` and Telegram `/tts_on` voice responses use Google. `/listen` and incoming Telegram audio use the configured `speechToText.provider`, which is `openai` unless configuration selects `gemini` or `mistral`. PDF OCR through `tau tool pdf-unpack` uses Mistral.
 
 Set these variables on the process that owns the feature. For example, a remote TUI's `/speak` reads the attached client's `GEMINI_API_KEY`, while a Google model selected by the session reads credentials at the host.
 

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -63,10 +63,11 @@ Several Tau features share provider credentials but intentionally prefer a fixed
 | Exa web search and fetch | `EXA_API_KEY`, then `apiKeys.exa` |
 | Google speech, Gemini speech-to-text, Telegram Gemini transcription, and Telegram voice responses | `GEMINI_API_KEY`, then `apiKeys.google` |
 | Mistral speech-to-text, Telegram Mistral transcription, and PDF OCR | `MISTRAL_API_KEY`, then `apiKeys.mistral` |
+| OpenAI speech-to-text and Telegram OpenAI transcription | `OPENAI_API_KEY`, then `apiKeys.openai` |
 
-The Google and Mistral rows describe feature-specific helpers. Model calls follow the general model-authentication order instead, where the configured provider key wins over ambient environment authentication.
+The Google, Mistral, and OpenAI rows describe feature-specific helpers. Model calls follow the general model-authentication order instead, where the configured provider key wins over ambient environment authentication.
 
-`web.discover` does not require Exa. `web.search` and `web.fetch` do. `/speak` and Telegram `/tts_on` voice responses use Google. `/listen` and incoming Telegram audio use the configured `speechToText.provider`, which is `mistral` unless configuration selects `gemini`. PDF OCR through `tau tool pdf-unpack` uses Mistral.
+`web.discover` does not require Exa. `web.search` and `web.fetch` do. `/speak` and Telegram `/tts_on` voice responses use Google. `/listen` and incoming Telegram audio use the configured `speechToText.provider`, which is `mistral` unless configuration selects `gemini` or `openai`. PDF OCR through `tau tool pdf-unpack` uses Mistral.
 
 Set these variables on the process that owns the feature. For example, a remote TUI's `/speak` reads the attached client's `GEMINI_API_KEY`, while a Google model selected by the session reads credentials at the host.
 

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -279,7 +279,7 @@ The local execution environment can access these runner temporary paths. Pending
 
 Telegram `voice` and `audio` messages are downloaded and transcribed. Direct DM turns and bot-triggering group turns echo the transcript to the chat before submission so the sender can verify it.
 
-Mistral is the default. Select another provider with `speechToText.provider`. Runner credentials are:
+OpenAI is the default. Select another provider with `speechToText.provider`. Runner credentials are:
 
 - Mistral: `MISTRAL_API_KEY`, then `apiKeys.mistral`
 - Gemini: `GEMINI_API_KEY`, then `apiKeys.google`

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -279,12 +279,13 @@ The local execution environment can access these runner temporary paths. Pending
 
 Telegram `voice` and `audio` messages are downloaded and transcribed. Direct DM turns and bot-triggering group turns echo the transcript to the chat before submission so the sender can verify it.
 
-Mistral is the default provider. Configure credentials in the runner's normal Tau config or environment:
+Mistral is the default. Select another provider with `speechToText.provider`. Runner credentials are:
 
 - Mistral: `MISTRAL_API_KEY`, then `apiKeys.mistral`
-- Gemini: set `speechToText.provider` to `gemini`, then use `GEMINI_API_KEY`, falling back to `apiKeys.google`
+- Gemini: `GEMINI_API_KEY`, then `apiKeys.google`
+- OpenAI: `OPENAI_API_KEY`, then `apiKeys.openai`
 
-The environment variable wins for each speech provider. Audio without a usable key produces a user-facing error instead of entering a turn. See [credentials](credentials.md).
+OpenAI uses `gpt-live-transcribe` and runner-side `ffmpeg`. Missing keys reject the audio. See [credentials](credentials.md).
 
 `/tts_on` uses `gemini-3.7-flash`, `gemini-3.1-flash-tts-preview`, Despina, the Google key, and runner `ffmpeg` with Opus. Source and rewritten text each allow 10,000 Unicode characters; audio allows 32 MiB. Rewrite and job timeouts are one and five minutes. Jobs are ephemeral. Failure sends `voice response failed. please try again.` without affecting text; details stay in logs.
 

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -285,7 +285,7 @@ OpenAI is the default. Select another provider with `speechToText.provider`. Run
 - Gemini: `GEMINI_API_KEY`, then `apiKeys.google`
 - OpenAI: `OPENAI_API_KEY`, then `apiKeys.openai`
 
-OpenAI uses `gpt-live-transcribe` and runner-side `ffmpeg`. Missing keys reject the audio. See [credentials](credentials.md).
+OpenAI normalizes downloaded audio with runner-side `ffmpeg` and uploads it to `gpt-transcribe`. Missing keys reject the audio. See [credentials](credentials.md).
 
 `/tts_on` uses `gemini-3.7-flash`, `gemini-3.1-flash-tts-preview`, Despina, the Google key, and runner `ffmpeg` with Opus. Source and rewritten text each allow 10,000 Unicode characters; audio allows 32 MiB. Rewrite and job timeouts are one and five minutes. Jobs are ephemeral. Failure sends `voice response failed. please try again.` without affecting text; details stay in logs.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -273,7 +273,7 @@ Recovery needs the same `workspaceRoot`, project definitions, host home, and Tau
 
 ## Telegram audio or attachment processing fails
 
-Telegram audio transcription uses the runner's `speechToText.provider`, which defaults to Mistral. Mistral needs `MISTRAL_API_KEY` or `apiKeys.mistral`; Gemini needs `GEMINI_API_KEY` or `apiKeys.google`. Set the credential for the runner process and restart it after changing the environment or provider.
+Telegram audio transcription uses the runner's `speechToText.provider`, which defaults to Mistral. Mistral needs `MISTRAL_API_KEY` or `apiKeys.mistral`; Gemini needs `GEMINI_API_KEY` or `apiKeys.google`; OpenAI needs `OPENAI_API_KEY` or `apiKeys.openai` and runner-side `ffmpeg`. Set the credential for the runner process and restart it after changing the environment or provider.
 
 Distinguish download, materialization, format, and transcription errors. The reply or runner log states which stage failed. Confirm Telegram can deliver the file to the bot, the attachment type is supported, the runner can write its temporary directory, and the selected provider accepts the media type. Do not log media bytes or transcripts merely to prove they exist.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -273,7 +273,7 @@ Recovery needs the same `workspaceRoot`, project definitions, host home, and Tau
 
 ## Telegram audio or attachment processing fails
 
-Telegram audio transcription uses the runner's `speechToText.provider`, which defaults to Mistral. Mistral needs `MISTRAL_API_KEY` or `apiKeys.mistral`; Gemini needs `GEMINI_API_KEY` or `apiKeys.google`; OpenAI needs `OPENAI_API_KEY` or `apiKeys.openai` and runner-side `ffmpeg`. Set the credential for the runner process and restart it after changing the environment or provider.
+Telegram audio transcription uses the runner's `speechToText.provider`, which defaults to OpenAI. OpenAI needs `OPENAI_API_KEY` or `apiKeys.openai` and runner-side `ffmpeg`; Gemini needs `GEMINI_API_KEY` or `apiKeys.google`; Mistral needs `MISTRAL_API_KEY` or `apiKeys.mistral`. Set the credential for the runner process and restart it after changing the environment or provider.
 
 Distinguish download, materialization, format, and transcription errors. The reply or runner log states which stage failed. Confirm Telegram can deliver the file to the bot, the attachment type is supported, the runner can write its temporary directory, and the selected provider accepts the media type. Do not log media bytes or transcripts merely to prove they exist.
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -195,7 +195,7 @@ The TUI also advertises diff review as a client tool unless `--no-client-tools` 
 
 `/listen` and Ctrl+Y are currently macOS-only. Recording uses local `ffmpeg` with the AVFoundation audio input and stops when Ctrl+Y is pressed again, when Escape is pressed, or after five minutes. The transcript is inserted at the cursor for review and is not submitted automatically.
 
-If transcription fails, Tau retains the local WAV and reports its path. Run `/listen retry` to transcribe the same audio again with the current provider and conversation context, or `/listen discard` to delete it. Starting another recording also deletes the retained file. Tau keeps at most one failed recording, and exiting leaves that file at the reported path for manual recovery. Gemini transcription retries a transient failure once on Gemini 3.7 Flash, then uses Gemini 3.6 Flash as a final fallback. OpenAI transcription streams audio to `gpt-live-transcribe` while recording, waits for the final transcript before updating the editor, and replays a retained WAV through a fresh realtime session on retry. Permanent request failures stop immediately.
+If transcription fails, Tau retains the local WAV and reports its path. Run `/listen retry` to transcribe the same audio again with the current provider and conversation context, or `/listen discard` to delete it. A replacement recording deletes the retained file only after the new capture starts producing audio. Tau keeps at most one failed recording, and exiting leaves that file at the reported path for manual recovery. Gemini transcription retries a transient failure once on Gemini 3.7 Flash, then uses Gemini 3.6 Flash as a final fallback. OpenAI transcription streams audio to `gpt-live-transcribe` while recording, waits for the final transcript before updating the editor, and replays a retained WAV through a fresh realtime session on retry. Permanent request failures stop immediately.
 
 Install `ffmpeg` and configure a speech-to-text provider:
 
@@ -203,7 +203,7 @@ Install `ffmpeg` and configure a speech-to-text provider:
 brew install ffmpeg
 ```
 
-Mistral is the default and needs `MISTRAL_API_KEY` or `apiKeys.mistral`. Set `speechToText.provider` to `gemini` to use `GEMINI_API_KEY` or `apiKeys.google`, or to `openai` to use `OPENAI_API_KEY` or `apiKeys.openai`. These settings and credentials are read by the TUI process, including during remote attachment.
+OpenAI is the default and needs `OPENAI_API_KEY` or `apiKeys.openai`. Set `speechToText.provider` to `gemini` to use `GEMINI_API_KEY` or `apiKeys.google`, or to `mistral` to use `MISTRAL_API_KEY` or `apiKeys.mistral`. These settings and credentials are read by the TUI process, including during remote attachment.
 
 `/speak` is also macOS-only. It rewrites the last assistant response for speech, generates audio with Gemini, and plays it through the local `afplay` command. It requires `GEMINI_API_KEY` or `apiKeys.google`, runs only while the session is idle, and can be stopped with Escape. Speech source and rewritten text are limited to 10,000 Unicode characters, and generation stops after 32 MiB of raw audio.
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -193,9 +193,9 @@ The TUI also advertises diff review as a client tool unless `--no-client-tools` 
 
 ## Use speech
 
-`/listen` and Ctrl+Y are currently macOS-only. Recording uses local `ffmpeg` with the AVFoundation audio input and stops when Ctrl+Y is pressed again, when Escape is pressed, or after five minutes. The transcript is inserted at the cursor for review and is not submitted automatically.
+`/listen` and Ctrl+Y are currently macOS-only. Recording uses local `ffmpeg` with the AVFoundation audio input and stops when Ctrl+Y is pressed again, when Escape is pressed, or after five minutes. Startup fails if the microphone produces no audio within 15 seconds. The transcript is inserted at the cursor for review and is not submitted automatically.
 
-If transcription fails, Tau retains the local WAV and reports its path. Run `/listen retry` to transcribe the same audio again with the current provider and conversation context, or `/listen discard` to delete it. A replacement recording deletes the retained file only after the new capture starts producing audio. Tau keeps at most one failed recording, and exiting leaves that file at the reported path for manual recovery. Gemini transcription retries a transient failure once on Gemini 3.7 Flash, then uses Gemini 3.6 Flash as a final fallback. OpenAI transcription streams audio to `gpt-live-transcribe` while recording, waits for the final transcript before updating the editor, and replays a retained WAV through a fresh realtime session on retry. Permanent request failures stop immediately.
+If transcription fails, Tau retains the local WAV and reports its path. Run `/listen retry` to transcribe the same audio again with the current provider and conversation context, or `/listen discard` to delete it. A replacement recording deletes the retained file only after the new capture starts producing audio. Tau keeps at most one failed recording, and exiting leaves that file at the reported path for manual recovery. Gemini transcription makes one request to Gemini 3.7 Flash. OpenAI transcription streams live recording audio to `gpt-live-transcribe`, waits for the final transcript before updating the editor, and uploads a retained recording to `gpt-transcribe` on retry.
 
 Install `ffmpeg` and configure a speech-to-text provider:
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -91,7 +91,7 @@ Then use Shift+Tab to select an allowed reasoning level. Newly added personas do
 | `/compact-all [guidance]` | Replace model context with a generated summary. |
 | `/compact-keep-last [guidance]` | Generate a summary that also includes the previous last assistant response when available. |
 | `/reload` | Reload session-owned configuration and content from the execution environment. |
-| `/listen` | Record speech and insert its transcript into the editor on macOS. |
+| `/listen [retry/discard]` | Record speech, retry a retained failed recording, or discard it on macOS. |
 | `/speak` | Read the last assistant response aloud on macOS. |
 | `/copy-text` | Copy the last assistant response as plain text. |
 | `/copy-code` | Copy code blocks from the last assistant response. |
@@ -194,6 +194,8 @@ The TUI also advertises diff review as a client tool unless `--no-client-tools` 
 ## Use speech
 
 `/listen` and Ctrl+Y are currently macOS-only. Recording uses local `ffmpeg` with the AVFoundation audio input and stops when Ctrl+Y is pressed again, when Escape is pressed, or after five minutes. The transcript is inserted at the cursor for review and is not submitted automatically.
+
+If transcription fails, Tau retains the local WAV and reports its path. Run `/listen retry` to transcribe the same audio again with the current provider and conversation context, or `/listen discard` to delete it. Starting another recording also deletes the retained file. Tau keeps at most one failed recording, and exiting leaves that file at the reported path for manual recovery. Gemini transcription retries a transient failure once on Gemini 3.7 Flash, then uses Gemini 3.6 Flash as a final fallback. Permanent request failures stop immediately.
 
 Install `ffmpeg` and configure a speech-to-text provider:
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -195,7 +195,7 @@ The TUI also advertises diff review as a client tool unless `--no-client-tools` 
 
 `/listen` and Ctrl+Y are currently macOS-only. Recording uses local `ffmpeg` with the AVFoundation audio input and stops when Ctrl+Y is pressed again, when Escape is pressed, or after five minutes. The transcript is inserted at the cursor for review and is not submitted automatically.
 
-If transcription fails, Tau retains the local WAV and reports its path. Run `/listen retry` to transcribe the same audio again with the current provider and conversation context, or `/listen discard` to delete it. Starting another recording also deletes the retained file. Tau keeps at most one failed recording, and exiting leaves that file at the reported path for manual recovery. Gemini transcription retries a transient failure once on Gemini 3.7 Flash, then uses Gemini 3.6 Flash as a final fallback. Permanent request failures stop immediately.
+If transcription fails, Tau retains the local WAV and reports its path. Run `/listen retry` to transcribe the same audio again with the current provider and conversation context, or `/listen discard` to delete it. Starting another recording also deletes the retained file. Tau keeps at most one failed recording, and exiting leaves that file at the reported path for manual recovery. Gemini transcription retries a transient failure once on Gemini 3.7 Flash, then uses Gemini 3.6 Flash as a final fallback. OpenAI transcription streams audio to `gpt-live-transcribe` while recording, waits for the final transcript before updating the editor, and replays a retained WAV through a fresh realtime session on retry. Permanent request failures stop immediately.
 
 Install `ffmpeg` and configure a speech-to-text provider:
 
@@ -203,7 +203,7 @@ Install `ffmpeg` and configure a speech-to-text provider:
 brew install ffmpeg
 ```
 
-Mistral is the default and needs `MISTRAL_API_KEY` or `apiKeys.mistral`. Set `speechToText.provider` to `gemini` to use `GEMINI_API_KEY` or `apiKeys.google` instead. These settings and credentials are read by the TUI process, including during remote attachment.
+Mistral is the default and needs `MISTRAL_API_KEY` or `apiKeys.mistral`. Set `speechToText.provider` to `gemini` to use `GEMINI_API_KEY` or `apiKeys.google`, or to `openai` to use `OPENAI_API_KEY` or `apiKeys.openai`. These settings and credentials are read by the TUI process, including during remote attachment.
 
 `/speak` is also macOS-only. It rewrites the last assistant response for speech, generates audio with Gemini, and plays it through the local `afplay` command. It requires `GEMINI_API_KEY` or `apiKeys.google`, runs only while the session is idle, and can be stopped with Escape. Speech source and rewritten text are limited to 10,000 Unicode characters, and generation stops after 32 MiB of raw audio.
 

--- a/src/core/commands/registry.ts
+++ b/src/core/commands/registry.ts
@@ -15,7 +15,7 @@ export type Command = (
   | { type: "compactSummaryOnly" }
   | { type: "compactSummaryAndLast" }
   | { type: "reload" }
-  | { type: "listen" }
+  | { type: "listen"; action: "record" | "retry" | "discard" }
   | { type: "speak" }
   | { type: "persona"; id: string }
   | { type: "prompt"; id: string }
@@ -55,7 +55,7 @@ export interface CommandDispatchContext {
   compactSummaryOnly: (extra?: string) => Promise<void>;
   compactSummaryAndLast: (extra?: string) => Promise<void>;
   reload: () => Promise<void>;
-  listen: () => Promise<void> | void;
+  listen: (action: "record" | "retry" | "discard") => Promise<void> | void;
   speak: () => Promise<void> | void;
   persona: (id: string) => void;
   prompt: (id: string) => void;
@@ -322,17 +322,21 @@ export function createCommandRegistry(): CommandRegistry<CommandDispatchContext>
 
   registry.register({
     id: "listen",
-    usage: "/listen",
-    description: "start voice recording and transcription",
-    autocompleteDescription: "record and transcribe voice input",
+    usage: "/listen [retry|discard]",
+    description: "record, retry, or discard voice input",
+    autocompleteDescription: "record or recover voice input",
     argument: "none",
     allowDuringStreaming: true,
     parse: (raw) => {
       const { command, extra } = splitCommandInput(raw);
       if (command !== "/listen") return null;
-      return { type: "listen", extra };
+      if (!extra) return { type: "listen", action: "record" };
+      if (extra === "retry" || extra === "discard") {
+        return { type: "listen", action: extra };
+      }
+      return null;
     },
-    run: (ctx) => ctx.listen(),
+    run: (ctx, command) => ctx.listen(command.action),
   });
 
   registry.register({

--- a/src/core/config/index.ts
+++ b/src/core/config/index.ts
@@ -34,6 +34,7 @@ export {
   getHistoryApiKey,
   getMistralApiKey,
   getNookAccessClientSecret,
+  getOpenAIApiKey,
   loadConfig,
   normalizeAutoCompactConfig,
 } from "./schema.js";

--- a/src/core/config/schema.ts
+++ b/src/core/config/schema.ts
@@ -52,7 +52,7 @@ export type BuiltInDiffToolConfig = {
   codeTheme?: string;
 };
 
-export type SpeechToTextProvider = "mistral" | "gemini";
+export type SpeechToTextProvider = "mistral" | "gemini" | "openai";
 
 export type SpeechToTextConfig = {
   provider: SpeechToTextProvider;
@@ -225,7 +225,7 @@ const ApiKeyProviderSchema = z.string();
 const ApiKeysSchema = z.object({}).catchall(z.unknown());
 const SpeechToTextConfigSchema = z
   .object({
-    provider: z.enum(["mistral", "gemini"]),
+    provider: z.enum(["mistral", "gemini", "openai"]),
   })
   .strip();
 const CloudflareSandboxBridgeSchema = z
@@ -636,7 +636,7 @@ function parseSpeechToTextConfig(
   if (!parsed.success) {
     if (parsed.error.issues.some((issue) => issue.path[0] === "provider")) {
       return {
-        errors: [`${sourceLabel}: speechToText.provider must be 'mistral' or 'gemini'.`],
+        errors: [`${sourceLabel}: speechToText.provider must be 'mistral', 'gemini', or 'openai'.`],
       };
     }
     return { errors: [`${sourceLabel}: 'speechToText' must be an object.`] };
@@ -1249,6 +1249,16 @@ export function getGoogleApiKey(config: Config, env?: NodeJS.ProcessEnv): string
   }
 
   const configKey = config.apiKeys?.google?.trim();
+  return configKey || undefined;
+}
+
+export function getOpenAIApiKey(config: Config, env?: NodeJS.ProcessEnv): string | undefined {
+  const envKey = getTrimmedEnvValue("OPENAI_API_KEY", env);
+  if (envKey) {
+    return envKey;
+  }
+
+  const configKey = config.apiKeys?.openai?.trim();
   return configKey || undefined;
 }
 

--- a/src/core/diff_review/bridge.ts
+++ b/src/core/diff_review/bridge.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { randomBytes, randomUUID } from "node:crypto";
 import { existsSync, rmSync } from "node:fs";
 import { createServer, type Server, type Socket } from "node:net";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createInterface, type Interface } from "node:readline";
 import type { DiffToolConfig } from "../config/index.js";
@@ -196,7 +197,7 @@ export class DiffReviewBridge {
     this.submitThreadMessage = options.submitThreadMessage;
     this.deps = options.deps ?? createDefaultCoreDeps();
     this.toolLauncher = options.toolLauncher ?? launchDiffToolProcess;
-    this.socketPath = join("/tmp", `tau-diff-${randomBytes(8).toString("hex")}.sock`);
+    this.socketPath = join(tmpdir(), `tau-diff-${randomBytes(8).toString("hex")}.sock`);
     this.authToken = randomBytes(24).toString("hex");
     this.completionPromise = new Promise<DiffReviewResult>((resolve) => {
       this.completionResolver = resolve;

--- a/src/core/diff_review/tool.ts
+++ b/src/core/diff_review/tool.ts
@@ -20,7 +20,7 @@ const DIFF_REVIEW_ARGS_DESCRIPTION = [
 ].join(" ");
 
 const DIFF_REVIEW_PATCH_FILES_DESCRIPTION =
-  "Patch files to review when source is 'patch_files'. Required for patch_files. Files may be absolute or relative to the current working directory. Each file must contain git unified diff sections with diff --git headers. Use this for selected hunks or custom review scopes. Patch files may be generated in any way as long as they adhere to that format, for example with git commands, by running code that emits a patch, or by manually editing a temporary patch file. One common approach is starting from `git diff main...HEAD -- src/foo.ts > /tmp/foo.patch` and editing it down to the hunks that should be reviewed. Multiple patch files are allowed, for example [`/tmp/parser.patch`, `/tmp/tests.patch`].";
+  "Patch files to review when source is 'patch_files'. Required for patch_files. Files may be absolute or relative to the current working directory. Each file must contain git unified diff sections with diff --git headers. Use this for selected hunks or custom review scopes. Patch files may be generated in any way as long as they adhere to that format, for example with git commands, by running code that emits a patch, or by manually editing a temporary patch file. One common approach is using `mktemp` to create a patch file in the platform temporary directory, writing selected `git diff` output to it, and passing the reported path. Multiple patch files are allowed.";
 
 const DIFF_REVIEW_LABEL_DESCRIPTION =
   "Optional human-readable label for patch-file reviews, for example 'selected hunks from src/foo.ts'.";

--- a/src/core/telegram/adapter.ts
+++ b/src/core/telegram/adapter.ts
@@ -10,7 +10,7 @@ import type {
 import { TauSessionProtocolResponseError } from "../../transport/errors.js";
 import type { SpeechToTextProvider, TelegramProjectConfig } from "../config/schema.js";
 import { formatAdaptiveNumber, formatTokenWindow } from "../utils/format.js";
-import { transcribeAudio } from "../utils/speech_to_text.js";
+import { type SpeechToTextDependencies, transcribeAudio } from "../utils/speech_to_text.js";
 import {
   collectSpeechToTextContext,
   type SpeechToTextContext,
@@ -144,6 +144,8 @@ export type TelegramAdapterOptions = {
   speechToTextProvider?: SpeechToTextProvider;
   geminiApiKey?: string;
   mistralApiKey?: string;
+  openaiApiKey?: string;
+  speechToTextDeps?: SpeechToTextDependencies;
   sessionManager: TelegramSessionManager;
   projectPreferences: TelegramProjectPreferenceStore;
   api?: TelegramApi;
@@ -1270,6 +1272,8 @@ class TelegramAdapterImpl {
   private readonly speechToTextProvider: SpeechToTextProvider;
   private readonly geminiApiKey?: string;
   private readonly mistralApiKey?: string;
+  private readonly openaiApiKey?: string;
+  private readonly speechToTextDeps?: SpeechToTextDependencies;
   private readonly sessionManager: TelegramSessionManager;
   private readonly projectPreferences: TelegramProjectPreferenceStore;
   private readonly enforceChatOwnership: boolean;
@@ -1329,6 +1333,8 @@ class TelegramAdapterImpl {
     this.speechToTextProvider = options.speechToTextProvider ?? "mistral";
     this.geminiApiKey = options.geminiApiKey?.trim() || undefined;
     this.mistralApiKey = options.mistralApiKey?.trim() || undefined;
+    this.openaiApiKey = options.openaiApiKey?.trim() || undefined;
+    this.speechToTextDeps = options.speechToTextDeps;
     this.sessionManager = options.sessionManager;
     this.projectPreferences = options.projectPreferences;
     this.enforceChatOwnership = true;
@@ -2670,13 +2676,25 @@ class TelegramAdapterImpl {
   }
 
   private getSpeechToTextApiKey(): string | undefined {
-    return this.speechToTextProvider === "gemini" ? this.geminiApiKey : this.mistralApiKey;
+    switch (this.speechToTextProvider) {
+      case "gemini":
+        return this.geminiApiKey;
+      case "mistral":
+        return this.mistralApiKey;
+      case "openai":
+        return this.openaiApiKey;
+    }
   }
 
   private getSpeechToTextApiKeyErrorMessage(action: string): string {
-    return this.speechToTextProvider === "gemini"
-      ? `set GEMINI_API_KEY or apiKeys.google to ${action}`
-      : `set MISTRAL_API_KEY or apiKeys.mistral to ${action}`;
+    switch (this.speechToTextProvider) {
+      case "gemini":
+        return `set GEMINI_API_KEY or apiKeys.google to ${action}`;
+      case "mistral":
+        return `set MISTRAL_API_KEY or apiKeys.mistral to ${action}`;
+      case "openai":
+        return `set OPENAI_API_KEY or apiKeys.openai to ${action}`;
+    }
   }
 
   private async transcribeTelegramAudio(
@@ -2704,6 +2722,7 @@ class TelegramAdapterImpl {
         mimeType: message.mimeType,
         context: await this.resolveSpeechToTextContext(chatId),
         fetchImpl: this.fetchImpl,
+        ...this.speechToTextDeps,
       });
       transcript = result.text;
     } catch (error) {

--- a/src/core/telegram/adapter.ts
+++ b/src/core/telegram/adapter.ts
@@ -10,7 +10,10 @@ import type {
 import { TauSessionProtocolResponseError } from "../../transport/errors.js";
 import type { SpeechToTextProvider, TelegramProjectConfig } from "../config/schema.js";
 import { formatAdaptiveNumber, formatTokenWindow } from "../utils/format.js";
-import { type SpeechToTextDependencies, transcribeAudio } from "../utils/speech_to_text.js";
+import {
+  createSpeechToTextTranscription,
+  type SpeechToTextDependencies,
+} from "../utils/speech_to_text.js";
 import {
   collectSpeechToTextContext,
   type SpeechToTextContext,
@@ -2714,17 +2717,25 @@ class TelegramAdapterImpl {
     let transcript: string;
     try {
       const audio = await this.api.downloadFile(message.fileId);
-      const result = await transcribeAudio({
+      const transcription = createSpeechToTextTranscription({
         provider: this.speechToTextProvider,
         apiKey,
-        audio,
-        fileName: message.fileName,
-        mimeType: message.mimeType,
         context: await this.resolveSpeechToTextContext(chatId),
-        fetchImpl: this.fetchImpl,
-        ...this.speechToTextDeps,
+        deps: {
+          ...this.speechToTextDeps,
+          fetchImpl: this.fetchImpl,
+        },
       });
-      transcript = result.text;
+      try {
+        const result = await transcription.finish({
+          audio,
+          fileName: message.fileName,
+          mimeType: message.mimeType,
+        });
+        transcript = result.text;
+      } finally {
+        transcription.abort();
+      }
     } catch (error) {
       const errorMessage = `audio transcription failed: ${this.formatManagerError(error)}`;
       if (!options.silent) {

--- a/src/core/telegram/adapter.ts
+++ b/src/core/telegram/adapter.ts
@@ -1333,7 +1333,7 @@ class TelegramAdapterImpl {
     this.botUsername = options.botUsername;
     this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
     this.requestTimeoutSeconds = options.requestTimeoutSeconds ?? DEFAULT_REQUEST_TIMEOUT_SECONDS;
-    this.speechToTextProvider = options.speechToTextProvider ?? "mistral";
+    this.speechToTextProvider = options.speechToTextProvider ?? "openai";
     this.geminiApiKey = options.geminiApiKey?.trim() || undefined;
     this.mistralApiKey = options.mistralApiKey?.trim() || undefined;
     this.openaiApiKey = options.openaiApiKey?.trim() || undefined;
@@ -2727,11 +2727,14 @@ class TelegramAdapterImpl {
         },
       });
       try {
-        const result = await transcription.finish({
-          audio,
-          fileName: message.fileName,
-          mimeType: message.mimeType,
-        });
+        const result = await transcription.finish(
+          {
+            audio,
+            fileName: message.fileName,
+            mimeType: message.mimeType,
+          },
+          { signal: this.abortController.signal },
+        );
         transcript = result.text;
       } finally {
         transcription.abort();

--- a/src/core/telegram/adapter.ts
+++ b/src/core/telegram/adapter.ts
@@ -2719,6 +2719,7 @@ class TelegramAdapterImpl {
       const audio = await this.api.downloadFile(message.fileId);
       const transcription = createSpeechToTextTranscription({
         provider: this.speechToTextProvider,
+        mode: "file",
         apiKey,
         context: await this.resolveSpeechToTextContext(chatId),
         deps: {
@@ -2727,7 +2728,7 @@ class TelegramAdapterImpl {
         },
       });
       try {
-        const result = await transcription.finish(
+        transcript = await transcription.finish(
           {
             audio,
             fileName: message.fileName,
@@ -2735,7 +2736,6 @@ class TelegramAdapterImpl {
           },
           { signal: this.abortController.signal },
         );
-        transcript = result.text;
       } finally {
         transcription.abort();
       }

--- a/src/core/telegram/adapter.ts
+++ b/src/core/telegram/adapter.ts
@@ -2693,34 +2693,25 @@ class TelegramAdapterImpl {
       return { error };
     }
 
-    let transcript = "";
+    let transcript: string;
     try {
       const audio = await this.api.downloadFile(message.fileId);
-      transcript = (
-        await transcribeAudio({
-          provider: this.speechToTextProvider,
-          apiKey,
-          audio,
-          fileName: message.fileName,
-          mimeType: message.mimeType,
-          context: await this.resolveSpeechToTextContext(chatId),
-          fetchImpl: this.fetchImpl,
-        })
-      ).trim();
+      const result = await transcribeAudio({
+        provider: this.speechToTextProvider,
+        apiKey,
+        audio,
+        fileName: message.fileName,
+        mimeType: message.mimeType,
+        context: await this.resolveSpeechToTextContext(chatId),
+        fetchImpl: this.fetchImpl,
+      });
+      transcript = result.text;
     } catch (error) {
       const errorMessage = `audio transcription failed: ${this.formatManagerError(error)}`;
       if (!options.silent) {
         await this.reply(chatId, errorMessage);
       }
       return { error: errorMessage };
-    }
-
-    if (!transcript) {
-      const error = "audio transcription failed: transcription result was empty";
-      if (!options.silent) {
-        await this.reply(chatId, error);
-      }
-      return { error };
     }
 
     return { transcript };

--- a/src/core/telegram/cli.ts
+++ b/src/core/telegram/cli.ts
@@ -1,6 +1,11 @@
 import { createDefaultConfigDeps } from "../config/deps.js";
 import type { Config } from "../config/schema.js";
-import { getGoogleApiKey, getMistralApiKey, loadConfig } from "../config/schema.js";
+import {
+  getGoogleApiKey,
+  getMistralApiKey,
+  getOpenAIApiKey,
+  loadConfig,
+} from "../config/schema.js";
 import { loadTelegramConfig, TelegramConfigError } from "./config.js";
 import { startTelegramRuntime, TelegramRuntimeError } from "./runtime.js";
 import type { TelegramSessionClient, TelegramSessionClientOptions } from "./session_manager.js";
@@ -108,6 +113,7 @@ export async function runTelegramCommand(
   const speechToTextProvider = config.speechToText?.provider ?? "mistral";
   const geminiApiKey = getGoogleApiKey(config, env);
   const mistralApiKey = getMistralApiKey(config, env);
+  const openaiApiKey = getOpenAIApiKey(config, env);
 
   const createSessionClient = options.createSessionClient;
   if (!createSessionClient) {
@@ -132,6 +138,7 @@ export async function runTelegramCommand(
         speechToTextProvider,
         geminiApiKey,
         mistralApiKey,
+        openaiApiKey,
         createSessionClient,
         onLog: stdout,
       });

--- a/src/core/telegram/cli.ts
+++ b/src/core/telegram/cli.ts
@@ -110,7 +110,7 @@ export async function runTelegramCommand(
   const cwd = options.cwd ?? process.cwd();
   const env = options.env ?? process.env;
   const config = options.config ?? loadConfig(cwd, createDefaultConfigDeps());
-  const speechToTextProvider = config.speechToText?.provider ?? "mistral";
+  const speechToTextProvider = config.speechToText?.provider ?? "openai";
   const geminiApiKey = getGoogleApiKey(config, env);
   const mistralApiKey = getMistralApiKey(config, env);
   const openaiApiKey = getOpenAIApiKey(config, env);

--- a/src/core/telegram/runtime.ts
+++ b/src/core/telegram/runtime.ts
@@ -23,6 +23,7 @@ export type StartTelegramRuntimeOptions = {
   speechToTextProvider?: SpeechToTextProvider;
   geminiApiKey?: string;
   mistralApiKey?: string;
+  openaiApiKey?: string;
   createSessionClient: (options: TelegramSessionClientOptions) => Promise<TelegramSessionClient>;
   onLog?: (line: string) => void;
   deps?: Partial<TelegramRuntimeDependencies>;
@@ -187,6 +188,7 @@ export async function startTelegramRuntime(
         speechToTextProvider: options.speechToTextProvider,
         geminiApiKey: options.geminiApiKey,
         mistralApiKey: options.mistralApiKey,
+        openaiApiKey: options.openaiApiKey,
         sessionManager,
         projectPreferences,
         onLog: (entry) => {

--- a/src/core/utils/gemini_transcription.ts
+++ b/src/core/utils/gemini_transcription.ts
@@ -2,9 +2,44 @@ import { z } from "zod";
 import { formatSpeechToTextContext, type SpeechToTextContext } from "./speech_to_text_context.js";
 
 const GEMINI_GENERATE_CONTENT_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/models";
-const DEFAULT_GEMINI_TRANSCRIPTION_MODEL = "gemini-3.7-flash";
-const DEFAULT_GEMINI_TRANSCRIPTION_THINKING_LEVEL = "low";
+const PRIMARY_GEMINI_TRANSCRIPTION_MODEL = "gemini-3.7-flash";
+const PRIMARY_GEMINI_TRANSCRIPTION_THINKING_LEVEL = "low";
+const FALLBACK_GEMINI_TRANSCRIPTION_MODEL = "gemini-3.6-flash";
+const FALLBACK_GEMINI_TRANSCRIPTION_THINKING_LEVEL = "minimal";
 const DEFAULT_GEMINI_AUDIO_MIME_TYPE = "audio/wav";
+const MAX_RETRY_DELAY_MS = 5_000;
+
+const RETRYABLE_GEMINI_ERROR_STATUSES = new Set([
+  "DEADLINE_EXCEEDED",
+  "INTERNAL",
+  "NOT_FOUND",
+  "RESOURCE_EXHAUSTED",
+  "UNAVAILABLE",
+]);
+
+const GEMINI_TRANSCRIPTION_ATTEMPTS = [
+  {
+    model: PRIMARY_GEMINI_TRANSCRIPTION_MODEL,
+    thinkingLevel: PRIMARY_GEMINI_TRANSCRIPTION_THINKING_LEVEL,
+    progress: undefined,
+    delayMs: 0,
+    usedFallback: false,
+  },
+  {
+    model: PRIMARY_GEMINI_TRANSCRIPTION_MODEL,
+    thinkingLevel: PRIMARY_GEMINI_TRANSCRIPTION_THINKING_LEVEL,
+    progress: "retrying" as const,
+    delayMs: 250,
+    usedFallback: false,
+  },
+  {
+    model: FALLBACK_GEMINI_TRANSCRIPTION_MODEL,
+    thinkingLevel: FALLBACK_GEMINI_TRANSCRIPTION_THINKING_LEVEL,
+    progress: "trying-fallback" as const,
+    delayMs: 500,
+    usedFallback: true,
+  },
+];
 
 const errorPayloadSchema = z.object({
   error: z
@@ -37,69 +72,141 @@ const apiResponseSchema = z.object({
     .optional(),
 });
 const transcriptionResultSchema = z.object({
-  transcription: z.string(),
+  transcription: z.string().trim().min(1),
 });
+
+export type GeminiTranscriptionProgress = "retrying" | "trying-fallback";
+
+export type GeminiTranscriptionResult = {
+  text: string;
+  usedFallback: boolean;
+};
 
 export type GeminiTranscriptionOptions = {
   apiKey: string;
   audio: Buffer;
-  model?: string;
   mimeType?: string;
   context?: SpeechToTextContext;
   fetchImpl?: typeof fetch;
+  onProgress?: (progress: GeminiTranscriptionProgress) => void;
 };
 
-export async function transcribeGeminiAudio(options: GeminiTranscriptionOptions): Promise<string> {
+class GeminiTranscriptionAttemptError extends Error {
+  constructor(
+    message: string,
+    readonly retryable: boolean,
+    readonly retryAfterMs = 0,
+  ) {
+    super(message);
+  }
+}
+
+export async function transcribeGeminiAudio(
+  options: GeminiTranscriptionOptions,
+): Promise<GeminiTranscriptionResult> {
   const apiKey = options.apiKey.trim();
   if (!apiKey) {
     throw new Error("missing Gemini API key");
   }
 
   const fetchFn = options.fetchImpl ?? fetch;
-  const model = options.model ?? DEFAULT_GEMINI_TRANSCRIPTION_MODEL;
-  const response = await fetchFn(
-    `${GEMINI_GENERATE_CONTENT_BASE_URL}/${encodeURIComponent(model)}:generateContent`,
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-goog-api-key": apiKey,
-      },
-      body: JSON.stringify({
-        systemInstruction: {
-          parts: [
-            {
-              text: buildTranscriptionSystemInstruction(),
-            },
-          ],
+  let retryAfterMs = 0;
+
+  for (const [index, attempt] of GEMINI_TRANSCRIPTION_ATTEMPTS.entries()) {
+    if (attempt.progress) {
+      options.onProgress?.(attempt.progress);
+      await waitForRetry(Math.max(attempt.delayMs, retryAfterMs));
+    }
+
+    try {
+      const text = await requestGeminiTranscription({
+        apiKey,
+        audio: options.audio,
+        mimeType: options.mimeType ?? DEFAULT_GEMINI_AUDIO_MIME_TYPE,
+        context: options.context,
+        fetchFn,
+        model: attempt.model,
+        thinkingLevel: attempt.thinkingLevel,
+      });
+      return { text, usedFallback: attempt.usedFallback };
+    } catch (error) {
+      if (
+        !(error instanceof GeminiTranscriptionAttemptError) ||
+        !error.retryable ||
+        index === GEMINI_TRANSCRIPTION_ATTEMPTS.length - 1
+      ) {
+        throw error;
+      }
+      retryAfterMs = error.retryAfterMs;
+    }
+  }
+
+  throw new Error("Gemini transcription attempts exhausted");
+}
+
+async function requestGeminiTranscription(args: {
+  apiKey: string;
+  audio: Buffer;
+  mimeType: string;
+  context?: SpeechToTextContext;
+  fetchFn: typeof fetch;
+  model: string;
+  thinkingLevel: string;
+}): Promise<string> {
+  let response: Response;
+  try {
+    response = await args.fetchFn(
+      `${GEMINI_GENERATE_CONTENT_BASE_URL}/${encodeURIComponent(args.model)}:generateContent`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-goog-api-key": args.apiKey,
         },
-        contents: [
-          {
+        body: JSON.stringify({
+          systemInstruction: {
             parts: [
               {
-                text: buildTranscriptionPrompt(options.context),
-              },
-              {
-                inlineData: {
-                  mimeType: options.mimeType ?? DEFAULT_GEMINI_AUDIO_MIME_TYPE,
-                  data: options.audio.toString("base64"),
-                },
+                text: buildTranscriptionSystemInstruction(),
               },
             ],
           },
-        ],
-        generationConfig: {
-          responseMimeType: "application/json",
-          responseSchema: GEMINI_TRANSCRIPTION_RESPONSE_SCHEMA,
-          thinkingConfig: {
-            thinkingLevel: DEFAULT_GEMINI_TRANSCRIPTION_THINKING_LEVEL,
+          contents: [
+            {
+              parts: [
+                {
+                  text: buildTranscriptionPrompt(args.context),
+                },
+                {
+                  inlineData: {
+                    mimeType: args.mimeType,
+                    data: args.audio.toString("base64"),
+                  },
+                },
+              ],
+            },
+          ],
+          generationConfig: {
+            responseMimeType: "application/json",
+            responseSchema: GEMINI_TRANSCRIPTION_RESPONSE_SCHEMA,
+            thinkingConfig: {
+              thinkingLevel: args.thinkingLevel,
+            },
           },
-        },
-      }),
-    },
-  );
+        }),
+      },
+    );
+  } catch (error) {
+    throw new GeminiTranscriptionAttemptError((error as Error).message, true);
+  }
 
-  const responseText = await response.text();
+  let responseText: string;
+  try {
+    responseText = await response.text();
+  } catch (error) {
+    throw new GeminiTranscriptionAttemptError((error as Error).message, true);
+  }
+
   let payload: unknown;
   try {
     payload = responseText ? (JSON.parse(responseText) as unknown) : undefined;
@@ -110,12 +217,46 @@ export async function transcribeGeminiAudio(options: GeminiTranscriptionOptions)
   if (!response.ok) {
     const parsed = errorPayloadSchema.safeParse(payload);
     const fallbackMessage = responseText.trim() || `HTTP ${response.status}`;
-    throw new Error(
+    const errorStatus = parsed.success ? parsed.data.error?.status : undefined;
+    throw new GeminiTranscriptionAttemptError(
       parsed.success ? (parsed.data.error?.message ?? fallbackMessage) : fallbackMessage,
+      isRetryableGeminiError(response.status, errorStatus),
+      parseRetryAfterMs(response.headers.get("retry-after")),
     );
   }
 
-  return extractGeminiText(payload).trim();
+  const text = extractGeminiText(payload);
+  if (!text) {
+    throw new GeminiTranscriptionAttemptError("transcription result was empty or malformed", true);
+  }
+  return text;
+}
+
+function isRetryableGeminiError(status: number, errorStatus: string | undefined): boolean {
+  return (
+    status === 408 ||
+    status === 429 ||
+    status >= 500 ||
+    (errorStatus !== undefined && RETRYABLE_GEMINI_ERROR_STATUSES.has(errorStatus))
+  );
+}
+
+function parseRetryAfterMs(value: string | null): number {
+  if (!value) return 0;
+
+  const seconds = Number(value);
+  if (Number.isFinite(seconds)) {
+    return Math.min(Math.max(0, seconds * 1_000), MAX_RETRY_DELAY_MS);
+  }
+
+  const dateMs = Date.parse(value);
+  if (!Number.isFinite(dateMs)) return 0;
+  return Math.min(Math.max(0, dateMs - Date.now()), MAX_RETRY_DELAY_MS);
+}
+
+async function waitForRetry(delayMs: number): Promise<void> {
+  if (delayMs <= 0) return;
+  await new Promise((resolve) => setTimeout(resolve, delayMs));
 }
 
 function buildTranscriptionSystemInstruction(): string {
@@ -150,10 +291,10 @@ function buildTranscriptionPrompt(context: SpeechToTextContext | undefined): str
     .join("\n");
 }
 
-function extractGeminiText(payload: unknown): string {
+function extractGeminiText(payload: unknown): string | undefined {
   const parsed = apiResponseSchema.safeParse(payload);
   if (!parsed.success) {
-    return "";
+    return undefined;
   }
 
   const responseText = (parsed.data.candidates?.[0]?.content.parts ?? [])
@@ -167,13 +308,9 @@ function extractGeminiText(payload: unknown): string {
   try {
     transcriptionPayload = responseText ? (JSON.parse(responseText) as unknown) : undefined;
   } catch {
-    return "";
+    return undefined;
   }
 
   const transcription = transcriptionResultSchema.safeParse(transcriptionPayload);
-  if (!transcription.success) {
-    return "";
-  }
-
-  return transcription.data.transcription;
+  return transcription.success ? transcription.data.transcription : undefined;
 }

--- a/src/core/utils/gemini_transcription.ts
+++ b/src/core/utils/gemini_transcription.ts
@@ -2,51 +2,14 @@ import { z } from "zod";
 import { formatSpeechToTextContext, type SpeechToTextContext } from "./speech_to_text_context.js";
 
 const GEMINI_GENERATE_CONTENT_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/models";
-const PRIMARY_GEMINI_TRANSCRIPTION_MODEL = "gemini-3.7-flash";
-const PRIMARY_GEMINI_TRANSCRIPTION_THINKING_LEVEL = "low";
-const FALLBACK_GEMINI_TRANSCRIPTION_MODEL = "gemini-3.6-flash";
-const FALLBACK_GEMINI_TRANSCRIPTION_THINKING_LEVEL = "minimal";
+const GEMINI_TRANSCRIPTION_MODEL = "gemini-3.7-flash";
+const GEMINI_TRANSCRIPTION_THINKING_LEVEL = "low";
 const DEFAULT_GEMINI_AUDIO_MIME_TYPE = "audio/wav";
-const MAX_RETRY_DELAY_MS = 5_000;
-
-const RETRYABLE_GEMINI_ERROR_STATUSES = new Set([
-  "DEADLINE_EXCEEDED",
-  "INTERNAL",
-  "NOT_FOUND",
-  "RESOURCE_EXHAUSTED",
-  "UNAVAILABLE",
-]);
-
-const GEMINI_TRANSCRIPTION_ATTEMPTS = [
-  {
-    model: PRIMARY_GEMINI_TRANSCRIPTION_MODEL,
-    thinkingLevel: PRIMARY_GEMINI_TRANSCRIPTION_THINKING_LEVEL,
-    progress: undefined,
-    delayMs: 0,
-    usedFallback: false,
-  },
-  {
-    model: PRIMARY_GEMINI_TRANSCRIPTION_MODEL,
-    thinkingLevel: PRIMARY_GEMINI_TRANSCRIPTION_THINKING_LEVEL,
-    progress: "retrying" as const,
-    delayMs: 250,
-    usedFallback: false,
-  },
-  {
-    model: FALLBACK_GEMINI_TRANSCRIPTION_MODEL,
-    thinkingLevel: FALLBACK_GEMINI_TRANSCRIPTION_THINKING_LEVEL,
-    progress: "trying-fallback" as const,
-    delayMs: 500,
-    usedFallback: true,
-  },
-];
 
 const errorPayloadSchema = z.object({
   error: z
     .object({
       message: z.string().trim().min(1).optional(),
-      status: z.string().trim().min(1).optional(),
-      code: z.number().int().optional(),
     })
     .optional(),
 });
@@ -75,138 +38,66 @@ const transcriptionResultSchema = z.object({
   transcription: z.string().trim().min(1),
 });
 
-export type GeminiTranscriptionProgress = "retrying" | "trying-fallback";
-
-export type GeminiTranscriptionResult = {
-  text: string;
-  usedFallback: boolean;
-};
-
 export type GeminiTranscriptionOptions = {
   apiKey: string;
   audio: Buffer;
   mimeType?: string;
   context?: SpeechToTextContext;
+  signal?: AbortSignal;
   fetchImpl?: typeof fetch;
-  onProgress?: (progress: GeminiTranscriptionProgress) => void;
 };
 
-class GeminiTranscriptionAttemptError extends Error {
-  constructor(
-    message: string,
-    readonly retryable: boolean,
-    readonly retryAfterMs = 0,
-  ) {
-    super(message);
-  }
-}
-
-export async function transcribeGeminiAudio(
-  options: GeminiTranscriptionOptions,
-): Promise<GeminiTranscriptionResult> {
+export async function transcribeGeminiAudio(options: GeminiTranscriptionOptions): Promise<string> {
   const apiKey = options.apiKey.trim();
   if (!apiKey) {
     throw new Error("missing Gemini API key");
   }
 
   const fetchFn = options.fetchImpl ?? fetch;
-  let retryAfterMs = 0;
-
-  for (const [index, attempt] of GEMINI_TRANSCRIPTION_ATTEMPTS.entries()) {
-    if (attempt.progress) {
-      options.onProgress?.(attempt.progress);
-      await waitForRetry(Math.max(attempt.delayMs, retryAfterMs));
-    }
-
-    try {
-      const text = await requestGeminiTranscription({
-        apiKey,
-        audio: options.audio,
-        mimeType: options.mimeType ?? DEFAULT_GEMINI_AUDIO_MIME_TYPE,
-        context: options.context,
-        fetchFn,
-        model: attempt.model,
-        thinkingLevel: attempt.thinkingLevel,
-      });
-      return { text, usedFallback: attempt.usedFallback };
-    } catch (error) {
-      if (
-        !(error instanceof GeminiTranscriptionAttemptError) ||
-        !error.retryable ||
-        index === GEMINI_TRANSCRIPTION_ATTEMPTS.length - 1
-      ) {
-        throw error;
-      }
-      retryAfterMs = error.retryAfterMs;
-    }
-  }
-
-  throw new Error("Gemini transcription attempts exhausted");
-}
-
-async function requestGeminiTranscription(args: {
-  apiKey: string;
-  audio: Buffer;
-  mimeType: string;
-  context?: SpeechToTextContext;
-  fetchFn: typeof fetch;
-  model: string;
-  thinkingLevel: string;
-}): Promise<string> {
-  let response: Response;
-  try {
-    response = await args.fetchFn(
-      `${GEMINI_GENERATE_CONTENT_BASE_URL}/${encodeURIComponent(args.model)}:generateContent`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "x-goog-api-key": args.apiKey,
+  const response = await fetchFn(
+    `${GEMINI_GENERATE_CONTENT_BASE_URL}/${GEMINI_TRANSCRIPTION_MODEL}:generateContent`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-goog-api-key": apiKey,
+      },
+      signal: options.signal,
+      body: JSON.stringify({
+        systemInstruction: {
+          parts: [
+            {
+              text: buildTranscriptionSystemInstruction(),
+            },
+          ],
         },
-        body: JSON.stringify({
-          systemInstruction: {
+        contents: [
+          {
             parts: [
               {
-                text: buildTranscriptionSystemInstruction(),
+                text: buildTranscriptionPrompt(options.context),
+              },
+              {
+                inlineData: {
+                  mimeType: options.mimeType ?? DEFAULT_GEMINI_AUDIO_MIME_TYPE,
+                  data: options.audio.toString("base64"),
+                },
               },
             ],
           },
-          contents: [
-            {
-              parts: [
-                {
-                  text: buildTranscriptionPrompt(args.context),
-                },
-                {
-                  inlineData: {
-                    mimeType: args.mimeType,
-                    data: args.audio.toString("base64"),
-                  },
-                },
-              ],
-            },
-          ],
-          generationConfig: {
-            responseMimeType: "application/json",
-            responseSchema: GEMINI_TRANSCRIPTION_RESPONSE_SCHEMA,
-            thinkingConfig: {
-              thinkingLevel: args.thinkingLevel,
-            },
+        ],
+        generationConfig: {
+          responseMimeType: "application/json",
+          responseSchema: GEMINI_TRANSCRIPTION_RESPONSE_SCHEMA,
+          thinkingConfig: {
+            thinkingLevel: GEMINI_TRANSCRIPTION_THINKING_LEVEL,
           },
-        }),
-      },
-    );
-  } catch (error) {
-    throw new GeminiTranscriptionAttemptError((error as Error).message, true);
-  }
+        },
+      }),
+    },
+  );
 
-  let responseText: string;
-  try {
-    responseText = await response.text();
-  } catch (error) {
-    throw new GeminiTranscriptionAttemptError((error as Error).message, true);
-  }
-
+  const responseText = await response.text();
   let payload: unknown;
   try {
     payload = responseText ? (JSON.parse(responseText) as unknown) : undefined;
@@ -217,46 +108,16 @@ async function requestGeminiTranscription(args: {
   if (!response.ok) {
     const parsed = errorPayloadSchema.safeParse(payload);
     const fallbackMessage = responseText.trim() || `HTTP ${response.status}`;
-    const errorStatus = parsed.success ? parsed.data.error?.status : undefined;
-    throw new GeminiTranscriptionAttemptError(
+    throw new Error(
       parsed.success ? (parsed.data.error?.message ?? fallbackMessage) : fallbackMessage,
-      isRetryableGeminiError(response.status, errorStatus),
-      parseRetryAfterMs(response.headers.get("retry-after")),
     );
   }
 
   const text = extractGeminiText(payload);
   if (!text) {
-    throw new GeminiTranscriptionAttemptError("transcription result was empty or malformed", true);
+    throw new Error("transcription result was empty or malformed");
   }
   return text;
-}
-
-function isRetryableGeminiError(status: number, errorStatus: string | undefined): boolean {
-  return (
-    status === 408 ||
-    status === 429 ||
-    status >= 500 ||
-    (errorStatus !== undefined && RETRYABLE_GEMINI_ERROR_STATUSES.has(errorStatus))
-  );
-}
-
-function parseRetryAfterMs(value: string | null): number {
-  if (!value) return 0;
-
-  const seconds = Number(value);
-  if (Number.isFinite(seconds)) {
-    return Math.min(Math.max(0, seconds * 1_000), MAX_RETRY_DELAY_MS);
-  }
-
-  const dateMs = Date.parse(value);
-  if (!Number.isFinite(dateMs)) return 0;
-  return Math.min(Math.max(0, dateMs - Date.now()), MAX_RETRY_DELAY_MS);
-}
-
-async function waitForRetry(delayMs: number): Promise<void> {
-  if (delayMs <= 0) return;
-  await new Promise((resolve) => setTimeout(resolve, delayMs));
 }
 
 function buildTranscriptionSystemInstruction(): string {

--- a/src/core/utils/mistral_transcription.ts
+++ b/src/core/utils/mistral_transcription.ts
@@ -16,6 +16,7 @@ export type MistralTranscriptionOptions = {
   language?: string;
   mimeType?: string;
   fileName?: string;
+  signal?: AbortSignal;
   fetchImpl?: typeof fetch;
 };
 
@@ -42,6 +43,7 @@ export async function transcribeMistralAudio(
       Authorization: `Bearer ${options.apiKey}`,
     },
     body: formData,
+    signal: options.signal,
   });
 
   const responseText = await response.text();

--- a/src/core/utils/mistral_transcription.ts
+++ b/src/core/utils/mistral_transcription.ts
@@ -7,7 +7,7 @@ const DEFAULT_MISTRAL_AUDIO_MIME_TYPE = "audio/wav";
 const DEFAULT_MISTRAL_AUDIO_FILE_NAME = "speech.wav";
 
 const errorSchema = z.object({ message: z.string() });
-const successSchema = z.object({ text: z.string() });
+const successSchema = z.object({ text: z.string().trim().min(1) });
 
 export type MistralTranscriptionOptions = {
   apiKey: string;
@@ -60,5 +60,8 @@ export async function transcribeMistralAudio(
   }
 
   const parsed = successSchema.safeParse(payload);
-  return parsed.success ? parsed.data.text : "";
+  if (!parsed.success) {
+    throw new Error("transcription result was empty or malformed");
+  }
+  return parsed.data.text;
 }

--- a/src/core/utils/openai_transcription.ts
+++ b/src/core/utils/openai_transcription.ts
@@ -14,6 +14,10 @@ const OPENAI_TRANSCRIPTION_COMPLETION_TIMEOUT_MS = 30_000;
 const OPENAI_TRANSCRIPTION_CONTEXT_TOKENS = 900;
 const OPENAI_TRANSCRIPTION_FFMPEG_TIMEOUT_MS = 5 * 60 * 1_000;
 const OPENAI_TRANSCRIPTION_FFMPEG_OUTPUT_LIMIT_BYTES = 20_000;
+const OPENAI_TRANSCRIPTION_MAX_PCM_BYTES =
+  OPENAI_TRANSCRIPTION_SAMPLE_RATE * 2 * (OPENAI_TRANSCRIPTION_FFMPEG_TIMEOUT_MS / 1_000);
+const OPENAI_TRANSCRIPTION_BACKPRESSURE_HIGH_BYTES = 1024 * 1024;
+const OPENAI_TRANSCRIPTION_BACKPRESSURE_LOW_BYTES = 256 * 1024;
 
 const eventSchema = z.object({ type: z.string() }).passthrough();
 const errorEventSchema = z.object({
@@ -30,6 +34,7 @@ const transcriptionCompletedEventSchema = z.object({
 });
 
 export type OpenAITranscriptionWebSocket = {
+  readonly bufferedAmount?: number;
   on(event: "open", listener: () => void): unknown;
   on(event: "message", listener: (data: unknown) => void): unknown;
   on(event: "error", listener: (error: Error) => void): unknown;
@@ -46,7 +51,11 @@ export type OpenAITranscriptionWebSocketFactory = (
 
 export type OpenAIStreamingTranscription = {
   appendAudio(audio: Buffer): void;
-  finish(options?: { audio?: Buffer; spawnImpl?: typeof spawnWithCapture }): Promise<string>;
+  finish(options?: {
+    audio?: Buffer;
+    signal?: AbortSignal;
+    spawnImpl?: typeof spawnWithCapture;
+  }): Promise<string>;
   abort(): void;
 };
 
@@ -58,17 +67,21 @@ export type StartOpenAITranscriptionOptions = {
 
 export type TranscribeOpenAIAudioOptions = StartOpenAITranscriptionOptions & {
   audio: Buffer;
+  signal?: AbortSignal;
   spawnImpl?: typeof spawnWithCapture;
 };
 
 class OpenAIStreamingTranscriptionImpl implements OpenAIStreamingTranscription {
   private readonly socket: OpenAITranscriptionWebSocket;
+  private readonly abortController = new AbortController();
+  private readonly audioDrainWaiters = new Set<() => void>();
   private ready = false;
   private aborted = false;
   private failure?: Error;
   private completedTranscript?: string;
   private hasAudio = false;
   private pendingAudio: Buffer[] = [];
+  private pendingAudioBytes = 0;
   private readyTimeout?: ReturnType<typeof setTimeout>;
   private completionTimeout?: ReturnType<typeof setTimeout>;
   private resolveReady?: () => void;
@@ -142,6 +155,7 @@ class OpenAIStreamingTranscriptionImpl implements OpenAIStreamingTranscription {
     this.hasAudio = true;
     if (!this.ready) {
       this.pendingAudio.push(audio);
+      this.pendingAudioBytes += audio.length;
       return;
     }
 
@@ -149,41 +163,66 @@ class OpenAIStreamingTranscriptionImpl implements OpenAIStreamingTranscription {
   }
 
   async finish(
-    options: { audio?: Buffer; spawnImpl?: typeof spawnWithCapture } = {},
+    options: { audio?: Buffer; signal?: AbortSignal; spawnImpl?: typeof spawnWithCapture } = {},
   ): Promise<string> {
-    if (!this.hasAudio && options.audio) {
-      await decodeAndStreamOpenAIAudio({
-        audio: options.audio,
-        transcription: this,
-        spawnImpl: options.spawnImpl,
-      });
+    const abortListener = () => this.abort();
+    if (options.signal?.aborted) {
+      abortListener();
+    } else {
+      options.signal?.addEventListener("abort", abortListener, { once: true });
     }
 
-    await this.readyPromise;
-    if (this.failure) throw this.failure;
-    if (this.aborted) throw new Error("OpenAI transcription was aborted");
-    if (this.completedTranscript) return this.completedTranscript;
+    try {
+      await this.readyPromise;
+      if (this.failure) throw this.failure;
+      if (this.aborted) throw new Error("OpenAI transcription was aborted");
+      if (this.completedTranscript) return this.completedTranscript;
 
-    const completion = new Promise<string>((resolve, reject) => {
-      this.resolveCompletion = resolve;
-      this.rejectCompletion = reject;
-    });
-    this.completionTimeout = setTimeout(() => {
-      this.fail(new Error("timed out waiting for OpenAI transcription"));
-      this.socket.terminate();
-    }, OPENAI_TRANSCRIPTION_COMPLETION_TIMEOUT_MS);
-    this.completionTimeout.unref?.();
-    this.send({ type: "input_audio_buffer.commit" });
-    return await completion;
+      if (!this.hasAudio && options.audio) {
+        try {
+          await decodeAndStreamOpenAIAudio({
+            audio: options.audio,
+            signal: this.abortController.signal,
+            transcription: this,
+            spawnImpl: options.spawnImpl,
+          });
+        } catch (error) {
+          const failure = error instanceof Error ? error : new Error(String(error));
+          this.fail(failure);
+          throw failure;
+        }
+      }
+
+      if (this.failure) throw this.failure;
+      if (this.aborted) throw new Error("OpenAI transcription was aborted");
+
+      const completion = new Promise<string>((resolve, reject) => {
+        this.resolveCompletion = resolve;
+        this.rejectCompletion = reject;
+      });
+      this.completionTimeout = setTimeout(() => {
+        this.fail(new Error("timed out waiting for OpenAI transcription"));
+        this.socket.terminate();
+      }, OPENAI_TRANSCRIPTION_COMPLETION_TIMEOUT_MS);
+      this.completionTimeout.unref?.();
+      this.send({ type: "input_audio_buffer.commit" });
+      return await completion;
+    } finally {
+      options.signal?.removeEventListener("abort", abortListener);
+    }
   }
 
   abort(): void {
     if (this.aborted || this.completedTranscript) return;
+    const error = new Error("OpenAI transcription was aborted");
     this.aborted = true;
+    this.abortController.abort(error);
     this.pendingAudio = [];
+    this.pendingAudioBytes = 0;
     this.clearTimers();
-    this.rejectReady?.(new Error("OpenAI transcription was aborted"));
-    this.rejectCompletion?.(new Error("OpenAI transcription was aborted"));
+    this.rejectReady?.(error);
+    this.rejectCompletion?.(error);
+    this.resolveAudioDrainWaiters();
     this.clearWaiters();
     this.socket.close();
   }
@@ -209,9 +248,11 @@ class OpenAIStreamingTranscriptionImpl implements OpenAIStreamingTranscription {
       this.readyTimeout = undefined;
       const pendingAudio = this.pendingAudio;
       this.pendingAudio = [];
+      this.pendingAudioBytes = 0;
       for (const audio of pendingAudio) {
         this.sendAudio(audio);
       }
+      this.resolveAudioDrainWaitersIfReady();
       if (this.failure) return;
       this.resolveReady?.();
       this.resolveReady = undefined;
@@ -269,7 +310,9 @@ class OpenAIStreamingTranscriptionImpl implements OpenAIStreamingTranscription {
       this.socket.send(JSON.stringify(event), (error) => {
         if (error) {
           this.fail(new Error(`failed to send OpenAI transcription audio: ${error.message}`));
+          return;
         }
+        this.resolveAudioDrainWaitersIfReady();
       });
     } catch (error) {
       this.fail(
@@ -278,15 +321,50 @@ class OpenAIStreamingTranscriptionImpl implements OpenAIStreamingTranscription {
     }
   }
 
+  isAudioBackpressured(): boolean {
+    return (
+      this.pendingAudioBytes > OPENAI_TRANSCRIPTION_BACKPRESSURE_HIGH_BYTES ||
+      (this.socket.bufferedAmount ?? 0) > OPENAI_TRANSCRIPTION_BACKPRESSURE_HIGH_BYTES
+    );
+  }
+
+  waitForAudioDrain(): Promise<void> {
+    if (!this.isAudioBackpressured() || this.failure || this.aborted) {
+      return Promise.resolve();
+    }
+
+    return new Promise((resolve) => this.audioDrainWaiters.add(resolve));
+  }
+
   private fail(error: Error): void {
     if (this.failure || this.aborted || this.completedTranscript) return;
     this.failure = error;
+    this.abortController.abort(error);
     this.pendingAudio = [];
+    this.pendingAudioBytes = 0;
     this.clearTimers();
     this.rejectReady?.(error);
     this.rejectCompletion?.(error);
+    this.resolveAudioDrainWaiters();
     this.clearWaiters();
     this.socket.terminate();
+  }
+
+  private resolveAudioDrainWaitersIfReady(): void {
+    if (
+      this.pendingAudioBytes > OPENAI_TRANSCRIPTION_BACKPRESSURE_LOW_BYTES ||
+      (this.socket.bufferedAmount ?? 0) > OPENAI_TRANSCRIPTION_BACKPRESSURE_LOW_BYTES
+    ) {
+      return;
+    }
+    this.resolveAudioDrainWaiters();
+  }
+
+  private resolveAudioDrainWaiters(): void {
+    for (const resolve of this.audioDrainWaiters) {
+      resolve();
+    }
+    this.audioDrainWaiters.clear();
   }
 
   private clearTimers(): void {
@@ -315,7 +393,11 @@ export async function transcribeOpenAIAudio(
 ): Promise<string> {
   const transcription = startOpenAITranscription(options);
   try {
-    return await transcription.finish({ audio: options.audio, spawnImpl: options.spawnImpl });
+    return await transcription.finish({
+      audio: options.audio,
+      signal: options.signal,
+      spawnImpl: options.spawnImpl,
+    });
   } catch (error) {
     transcription.abort();
     throw error;
@@ -324,10 +406,15 @@ export async function transcribeOpenAIAudio(
 
 async function decodeAndStreamOpenAIAudio(args: {
   audio: Buffer;
-  transcription: OpenAIStreamingTranscription;
+  signal: AbortSignal;
+  transcription: OpenAIStreamingTranscriptionImpl;
   spawnImpl?: typeof spawnWithCapture;
 }): Promise<void> {
   const spawnImpl = args.spawnImpl ?? spawnWithCapture;
+  const decoderAbortController = new AbortController();
+  const signal = AbortSignal.any([args.signal, decoderAbortController.signal]);
+  let decodedBytes = 0;
+  let decodeFailure: Error | undefined;
   let result: SpawnCaptureResult;
   try {
     result = await spawnImpl(
@@ -352,12 +439,32 @@ async function decodeAndStreamOpenAIAudio(args: {
       ],
       {
         input: args.audio,
+        signal,
         timeoutMs: OPENAI_TRANSCRIPTION_FFMPEG_TIMEOUT_MS,
         maxCaptureBytes: OPENAI_TRANSCRIPTION_FFMPEG_OUTPUT_LIMIT_BYTES,
         captureOutput: "stderr",
         stdio: ["pipe", "pipe", "pipe"],
         onSpawn: (child: ChildProcess) => {
-          child.stdout?.on("data", (chunk: Buffer) => args.transcription.appendAudio(chunk));
+          const output = child.stdout;
+          output?.on("data", (chunk: Buffer) => {
+            if (decodeFailure || signal.aborted) return;
+            decodedBytes += chunk.length;
+            if (decodedBytes > OPENAI_TRANSCRIPTION_MAX_PCM_BYTES) {
+              decodeFailure = new Error("audio exceeds the five-minute OpenAI transcription limit");
+              decoderAbortController.abort(decodeFailure);
+              return;
+            }
+
+            args.transcription.appendAudio(chunk);
+            if (!args.transcription.isAudioBackpressured()) return;
+
+            output.pause();
+            void args.transcription.waitForAudioDrain().then(() => {
+              if (!signal.aborted) {
+                output.resume();
+              }
+            });
+          });
         },
       },
     );
@@ -368,6 +475,14 @@ async function decodeAndStreamOpenAIAudio(args: {
     throw error;
   }
 
+  if (decodeFailure) {
+    throw decodeFailure;
+  }
+  if (result.aborted) {
+    throw signal.reason instanceof Error
+      ? signal.reason
+      : new Error("OpenAI transcription was aborted");
+  }
   if (result.timedOut) {
     throw new Error("ffmpeg timed out while decoding audio for OpenAI transcription");
   }

--- a/src/core/utils/openai_transcription.ts
+++ b/src/core/utils/openai_transcription.ts
@@ -7,17 +7,18 @@ import { formatSpeechToTextContext, type SpeechToTextContext } from "./speech_to
 import { truncateForTokens } from "./truncate.js";
 
 const OPENAI_REALTIME_TRANSCRIPTION_URL = "wss://api.openai.com/v1/realtime?intent=transcription";
-const OPENAI_TRANSCRIPTION_MODEL = "gpt-live-transcribe";
-const OPENAI_TRANSCRIPTION_SAMPLE_RATE = 24_000;
+const OPENAI_FILE_TRANSCRIPTION_URL = "https://api.openai.com/v1/audio/transcriptions";
+const OPENAI_STREAMING_TRANSCRIPTION_MODEL = "gpt-live-transcribe";
+const OPENAI_FILE_TRANSCRIPTION_MODEL = "gpt-transcribe";
+const OPENAI_STREAMING_SAMPLE_RATE = 24_000;
+const OPENAI_FILE_SAMPLE_RATE = 16_000;
 const OPENAI_TRANSCRIPTION_CONNECT_TIMEOUT_MS = 15_000;
 const OPENAI_TRANSCRIPTION_COMPLETION_TIMEOUT_MS = 30_000;
-const OPENAI_TRANSCRIPTION_CONTEXT_TOKENS = 900;
+const OPENAI_TRANSCRIPTION_CONTEXT_TOKENS = 1_024;
 const OPENAI_TRANSCRIPTION_FFMPEG_TIMEOUT_MS = 5 * 60 * 1_000;
 const OPENAI_TRANSCRIPTION_FFMPEG_OUTPUT_LIMIT_BYTES = 20_000;
 const OPENAI_TRANSCRIPTION_MAX_PCM_BYTES =
-  OPENAI_TRANSCRIPTION_SAMPLE_RATE * 2 * (OPENAI_TRANSCRIPTION_FFMPEG_TIMEOUT_MS / 1_000);
-const OPENAI_TRANSCRIPTION_BACKPRESSURE_HIGH_BYTES = 1024 * 1024;
-const OPENAI_TRANSCRIPTION_BACKPRESSURE_LOW_BYTES = 256 * 1024;
+  OPENAI_FILE_SAMPLE_RATE * 2 * (OPENAI_TRANSCRIPTION_FFMPEG_TIMEOUT_MS / 1_000);
 
 const eventSchema = z.object({ type: z.string() }).passthrough();
 const errorEventSchema = z.object({
@@ -32,9 +33,12 @@ const transcriptionCompletedEventSchema = z.object({
   type: z.literal("conversation.item.input_audio_transcription.completed"),
   transcript: z.string().trim().min(1),
 });
+const fileErrorSchema = z.object({
+  error: z.object({ message: z.string().trim().min(1) }),
+});
+const fileSuccessSchema = z.object({ text: z.string().trim().min(1) });
 
 export type OpenAITranscriptionWebSocket = {
-  readonly bufferedAmount?: number;
   on(event: "open", listener: () => void): unknown;
   on(event: "message", listener: (data: unknown) => void): unknown;
   on(event: "error", listener: (error: Error) => void): unknown;
@@ -51,11 +55,7 @@ export type OpenAITranscriptionWebSocketFactory = (
 
 export type OpenAIStreamingTranscription = {
   appendAudio(audio: Buffer): void;
-  finish(options?: {
-    audio?: Buffer;
-    signal?: AbortSignal;
-    spawnImpl?: typeof spawnWithCapture;
-  }): Promise<string>;
+  finish(options?: { signal?: AbortSignal }): Promise<string>;
   abort(): void;
 };
 
@@ -65,23 +65,23 @@ export type StartOpenAITranscriptionOptions = {
   webSocketFactory?: OpenAITranscriptionWebSocketFactory;
 };
 
-export type TranscribeOpenAIAudioOptions = StartOpenAITranscriptionOptions & {
+export type TranscribeOpenAIAudioOptions = {
+  apiKey: string;
   audio: Buffer;
+  context?: SpeechToTextContext;
   signal?: AbortSignal;
+  fetchImpl?: typeof fetch;
   spawnImpl?: typeof spawnWithCapture;
 };
 
 class OpenAIStreamingTranscriptionImpl implements OpenAIStreamingTranscription {
   private readonly socket: OpenAITranscriptionWebSocket;
-  private readonly abortController = new AbortController();
-  private readonly audioDrainWaiters = new Set<() => void>();
   private ready = false;
   private aborted = false;
   private failure?: Error;
   private completedTranscript?: string;
   private hasAudio = false;
   private pendingAudio: Buffer[] = [];
-  private pendingAudioBytes = 0;
   private readyTimeout?: ReturnType<typeof setTimeout>;
   private completionTimeout?: ReturnType<typeof setTimeout>;
   private resolveReady?: () => void;
@@ -120,10 +120,10 @@ class OpenAIStreamingTranscriptionImpl implements OpenAIStreamingTranscription {
             input: {
               format: {
                 type: "audio/pcm",
-                rate: OPENAI_TRANSCRIPTION_SAMPLE_RATE,
+                rate: OPENAI_STREAMING_SAMPLE_RATE,
               },
               transcription: {
-                model: OPENAI_TRANSCRIPTION_MODEL,
+                model: OPENAI_STREAMING_TRANSCRIPTION_MODEL,
                 prompt: buildOpenAITranscriptionPrompt(options.context),
                 delay: "medium",
               },
@@ -155,16 +155,13 @@ class OpenAIStreamingTranscriptionImpl implements OpenAIStreamingTranscription {
     this.hasAudio = true;
     if (!this.ready) {
       this.pendingAudio.push(audio);
-      this.pendingAudioBytes += audio.length;
       return;
     }
 
     this.sendAudio(audio);
   }
 
-  async finish(
-    options: { audio?: Buffer; signal?: AbortSignal; spawnImpl?: typeof spawnWithCapture } = {},
-  ): Promise<string> {
+  async finish(options: { signal?: AbortSignal } = {}): Promise<string> {
     const abortListener = () => this.abort();
     if (options.signal?.aborted) {
       abortListener();
@@ -177,24 +174,7 @@ class OpenAIStreamingTranscriptionImpl implements OpenAIStreamingTranscription {
       if (this.failure) throw this.failure;
       if (this.aborted) throw new Error("OpenAI transcription was aborted");
       if (this.completedTranscript) return this.completedTranscript;
-
-      if (!this.hasAudio && options.audio) {
-        try {
-          await decodeAndStreamOpenAIAudio({
-            audio: options.audio,
-            signal: this.abortController.signal,
-            transcription: this,
-            spawnImpl: options.spawnImpl,
-          });
-        } catch (error) {
-          const failure = error instanceof Error ? error : new Error(String(error));
-          this.fail(failure);
-          throw failure;
-        }
-      }
-
-      if (this.failure) throw this.failure;
-      if (this.aborted) throw new Error("OpenAI transcription was aborted");
+      if (!this.hasAudio) throw new Error("OpenAI transcription received no audio");
 
       const completion = new Promise<string>((resolve, reject) => {
         this.resolveCompletion = resolve;
@@ -216,13 +196,10 @@ class OpenAIStreamingTranscriptionImpl implements OpenAIStreamingTranscription {
     if (this.aborted || this.completedTranscript) return;
     const error = new Error("OpenAI transcription was aborted");
     this.aborted = true;
-    this.abortController.abort(error);
     this.pendingAudio = [];
-    this.pendingAudioBytes = 0;
     this.clearTimers();
     this.rejectReady?.(error);
     this.rejectCompletion?.(error);
-    this.resolveAudioDrainWaiters();
     this.clearWaiters();
     this.socket.close();
   }
@@ -248,11 +225,9 @@ class OpenAIStreamingTranscriptionImpl implements OpenAIStreamingTranscription {
       this.readyTimeout = undefined;
       const pendingAudio = this.pendingAudio;
       this.pendingAudio = [];
-      this.pendingAudioBytes = 0;
       for (const audio of pendingAudio) {
         this.sendAudio(audio);
       }
-      this.resolveAudioDrainWaitersIfReady();
       if (this.failure) return;
       this.resolveReady?.();
       this.resolveReady = undefined;
@@ -310,9 +285,7 @@ class OpenAIStreamingTranscriptionImpl implements OpenAIStreamingTranscription {
       this.socket.send(JSON.stringify(event), (error) => {
         if (error) {
           this.fail(new Error(`failed to send OpenAI transcription audio: ${error.message}`));
-          return;
         }
-        this.resolveAudioDrainWaitersIfReady();
       });
     } catch (error) {
       this.fail(
@@ -321,50 +294,15 @@ class OpenAIStreamingTranscriptionImpl implements OpenAIStreamingTranscription {
     }
   }
 
-  isAudioBackpressured(): boolean {
-    return (
-      this.pendingAudioBytes > OPENAI_TRANSCRIPTION_BACKPRESSURE_HIGH_BYTES ||
-      (this.socket.bufferedAmount ?? 0) > OPENAI_TRANSCRIPTION_BACKPRESSURE_HIGH_BYTES
-    );
-  }
-
-  waitForAudioDrain(): Promise<void> {
-    if (!this.isAudioBackpressured() || this.failure || this.aborted) {
-      return Promise.resolve();
-    }
-
-    return new Promise((resolve) => this.audioDrainWaiters.add(resolve));
-  }
-
   private fail(error: Error): void {
     if (this.failure || this.aborted || this.completedTranscript) return;
     this.failure = error;
-    this.abortController.abort(error);
     this.pendingAudio = [];
-    this.pendingAudioBytes = 0;
     this.clearTimers();
     this.rejectReady?.(error);
     this.rejectCompletion?.(error);
-    this.resolveAudioDrainWaiters();
     this.clearWaiters();
     this.socket.terminate();
-  }
-
-  private resolveAudioDrainWaitersIfReady(): void {
-    if (
-      this.pendingAudioBytes > OPENAI_TRANSCRIPTION_BACKPRESSURE_LOW_BYTES ||
-      (this.socket.bufferedAmount ?? 0) > OPENAI_TRANSCRIPTION_BACKPRESSURE_LOW_BYTES
-    ) {
-      return;
-    }
-    this.resolveAudioDrainWaiters();
-  }
-
-  private resolveAudioDrainWaiters(): void {
-    for (const resolve of this.audioDrainWaiters) {
-      resolve();
-    }
-    this.audioDrainWaiters.clear();
   }
 
   private clearTimers(): void {
@@ -391,28 +329,61 @@ export function startOpenAITranscription(
 export async function transcribeOpenAIAudio(
   options: TranscribeOpenAIAudioOptions,
 ): Promise<string> {
-  const transcription = startOpenAITranscription(options);
-  try {
-    return await transcription.finish({
-      audio: options.audio,
-      signal: options.signal,
-      spawnImpl: options.spawnImpl,
-    });
-  } catch (error) {
-    transcription.abort();
-    throw error;
+  const apiKey = options.apiKey.trim();
+  if (!apiKey) {
+    throw new Error("missing OpenAI API key");
   }
+
+  const wav = await decodeOpenAIAudio({
+    audio: options.audio,
+    signal: options.signal,
+    spawnImpl: options.spawnImpl,
+  });
+  const formData = new FormData();
+  formData.append("model", OPENAI_FILE_TRANSCRIPTION_MODEL);
+  formData.append("file", new Blob([Uint8Array.from(wav)], { type: "audio/wav" }), "speech.wav");
+  formData.append("prompt", buildOpenAITranscriptionPrompt(options.context));
+
+  const fetchFn = options.fetchImpl ?? fetch;
+  const response = await fetchFn(OPENAI_FILE_TRANSCRIPTION_URL, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${apiKey}` },
+    body: formData,
+    signal: options.signal,
+  });
+  const responseText = await response.text();
+  let payload: unknown;
+  try {
+    payload = responseText ? (JSON.parse(responseText) as unknown) : undefined;
+  } catch {
+    payload = undefined;
+  }
+
+  if (!response.ok) {
+    const parsed = fileErrorSchema.safeParse(payload);
+    throw new Error(
+      parsed.success ? parsed.data.error.message : responseText.trim() || `HTTP ${response.status}`,
+    );
+  }
+
+  const parsed = fileSuccessSchema.safeParse(payload);
+  if (!parsed.success) {
+    throw new Error("transcription result was empty or malformed");
+  }
+  return parsed.data.text;
 }
 
-async function decodeAndStreamOpenAIAudio(args: {
+async function decodeOpenAIAudio(args: {
   audio: Buffer;
-  signal: AbortSignal;
-  transcription: OpenAIStreamingTranscriptionImpl;
+  signal?: AbortSignal;
   spawnImpl?: typeof spawnWithCapture;
-}): Promise<void> {
+}): Promise<Buffer> {
   const spawnImpl = args.spawnImpl ?? spawnWithCapture;
   const decoderAbortController = new AbortController();
-  const signal = AbortSignal.any([args.signal, decoderAbortController.signal]);
+  const signal = args.signal
+    ? AbortSignal.any([args.signal, decoderAbortController.signal])
+    : decoderAbortController.signal;
+  const chunks: Buffer[] = [];
   let decodedBytes = 0;
   let decodeFailure: Error | undefined;
   let result: SpawnCaptureResult;
@@ -430,7 +401,7 @@ async function decodeAndStreamOpenAIAudio(args: {
         "-ac",
         "1",
         "-ar",
-        String(OPENAI_TRANSCRIPTION_SAMPLE_RATE),
+        String(OPENAI_FILE_SAMPLE_RATE),
         "-c:a",
         "pcm_s16le",
         "-f",
@@ -445,8 +416,7 @@ async function decodeAndStreamOpenAIAudio(args: {
         captureOutput: "stderr",
         stdio: ["pipe", "pipe", "pipe"],
         onSpawn: (child: ChildProcess) => {
-          const output = child.stdout;
-          output?.on("data", (chunk: Buffer) => {
+          child.stdout?.on("data", (chunk: Buffer) => {
             if (decodeFailure || signal.aborted) return;
             decodedBytes += chunk.length;
             if (decodedBytes > OPENAI_TRANSCRIPTION_MAX_PCM_BYTES) {
@@ -454,16 +424,7 @@ async function decodeAndStreamOpenAIAudio(args: {
               decoderAbortController.abort(decodeFailure);
               return;
             }
-
-            args.transcription.appendAudio(chunk);
-            if (!args.transcription.isAudioBackpressured()) return;
-
-            output.pause();
-            void args.transcription.waitForAudioDrain().then(() => {
-              if (!signal.aborted) {
-                output.resume();
-              }
-            });
+            chunks.push(Buffer.from(chunk));
           });
         },
       },
@@ -494,6 +455,29 @@ async function decodeAndStreamOpenAIAudio(args: {
         : `ffmpeg exited with code ${result.exitCode ?? "unknown"}`,
     );
   }
+  if (decodedBytes === 0) {
+    throw new Error("audio contained no decodable speech data");
+  }
+
+  return createPcmWav(Buffer.concat(chunks, decodedBytes));
+}
+
+function createPcmWav(pcm: Buffer): Buffer {
+  const header = Buffer.alloc(44);
+  header.write("RIFF", 0, "ascii");
+  header.writeUInt32LE(36 + pcm.length, 4);
+  header.write("WAVE", 8, "ascii");
+  header.write("fmt ", 12, "ascii");
+  header.writeUInt32LE(16, 16);
+  header.writeUInt16LE(1, 20);
+  header.writeUInt16LE(1, 22);
+  header.writeUInt32LE(OPENAI_FILE_SAMPLE_RATE, 24);
+  header.writeUInt32LE(OPENAI_FILE_SAMPLE_RATE * 2, 28);
+  header.writeUInt16LE(2, 32);
+  header.writeUInt16LE(16, 34);
+  header.write("data", 36, "ascii");
+  header.writeUInt32LE(pcm.length, 40);
+  return Buffer.concat([header, pcm]);
 }
 
 function buildOpenAITranscriptionPrompt(context: SpeechToTextContext | undefined): string {

--- a/src/core/utils/openai_transcription.ts
+++ b/src/core/utils/openai_transcription.ts
@@ -46,7 +46,7 @@ export type OpenAITranscriptionWebSocketFactory = (
 
 export type OpenAIStreamingTranscription = {
   appendAudio(audio: Buffer): void;
-  finish(): Promise<string>;
+  finish(options?: { audio?: Buffer; spawnImpl?: typeof spawnWithCapture }): Promise<string>;
   abort(): void;
 };
 
@@ -67,6 +67,8 @@ class OpenAIStreamingTranscriptionImpl implements OpenAIStreamingTranscription {
   private aborted = false;
   private failure?: Error;
   private completedTranscript?: string;
+  private hasAudio = false;
+  private pendingAudio: Buffer[] = [];
   private readyTimeout?: ReturnType<typeof setTimeout>;
   private completionTimeout?: ReturnType<typeof setTimeout>;
   private resolveReady?: () => void;
@@ -89,6 +91,7 @@ class OpenAIStreamingTranscriptionImpl implements OpenAIStreamingTranscription {
       this.resolveReady = resolve;
       this.rejectReady = reject;
     });
+    void this.readyPromise.catch(() => {});
     this.readyTimeout = setTimeout(() => {
       this.fail(new Error("timed out opening OpenAI transcription session"));
       this.socket.terminate();
@@ -109,7 +112,7 @@ class OpenAIStreamingTranscriptionImpl implements OpenAIStreamingTranscription {
               transcription: {
                 model: OPENAI_TRANSCRIPTION_MODEL,
                 prompt: buildOpenAITranscriptionPrompt(options.context),
-                delay: "low",
+                delay: "medium",
               },
               turn_detection: null,
             },
@@ -136,18 +139,26 @@ class OpenAIStreamingTranscriptionImpl implements OpenAIStreamingTranscription {
 
   appendAudio(audio: Buffer): void {
     if (audio.length === 0 || this.aborted || this.failure || this.completedTranscript) return;
+    this.hasAudio = true;
     if (!this.ready) {
-      this.fail(new Error("OpenAI transcription session was not ready for audio"));
+      this.pendingAudio.push(audio);
       return;
     }
 
-    this.send({
-      type: "input_audio_buffer.append",
-      audio: audio.toString("base64"),
-    });
+    this.sendAudio(audio);
   }
 
-  async finish(): Promise<string> {
+  async finish(
+    options: { audio?: Buffer; spawnImpl?: typeof spawnWithCapture } = {},
+  ): Promise<string> {
+    if (!this.hasAudio && options.audio) {
+      await decodeAndStreamOpenAIAudio({
+        audio: options.audio,
+        transcription: this,
+        spawnImpl: options.spawnImpl,
+      });
+    }
+
     await this.readyPromise;
     if (this.failure) throw this.failure;
     if (this.aborted) throw new Error("OpenAI transcription was aborted");
@@ -169,6 +180,7 @@ class OpenAIStreamingTranscriptionImpl implements OpenAIStreamingTranscription {
   abort(): void {
     if (this.aborted || this.completedTranscript) return;
     this.aborted = true;
+    this.pendingAudio = [];
     this.clearTimers();
     this.rejectReady?.(new Error("OpenAI transcription was aborted"));
     this.rejectCompletion?.(new Error("OpenAI transcription was aborted"));
@@ -195,6 +207,12 @@ class OpenAIStreamingTranscriptionImpl implements OpenAIStreamingTranscription {
       this.ready = true;
       if (this.readyTimeout) clearTimeout(this.readyTimeout);
       this.readyTimeout = undefined;
+      const pendingAudio = this.pendingAudio;
+      this.pendingAudio = [];
+      for (const audio of pendingAudio) {
+        this.sendAudio(audio);
+      }
+      if (this.failure) return;
       this.resolveReady?.();
       this.resolveReady = undefined;
       this.rejectReady = undefined;
@@ -238,6 +256,13 @@ class OpenAIStreamingTranscriptionImpl implements OpenAIStreamingTranscription {
     }
   }
 
+  private sendAudio(audio: Buffer): void {
+    this.send({
+      type: "input_audio_buffer.append",
+      audio: audio.toString("base64"),
+    });
+  }
+
   private send(event: Record<string, unknown>): void {
     if (this.failure || this.aborted) return;
     try {
@@ -256,6 +281,7 @@ class OpenAIStreamingTranscriptionImpl implements OpenAIStreamingTranscription {
   private fail(error: Error): void {
     if (this.failure || this.aborted || this.completedTranscript) return;
     this.failure = error;
+    this.pendingAudio = [];
     this.clearTimers();
     this.rejectReady?.(error);
     this.rejectCompletion?.(error);
@@ -278,25 +304,18 @@ class OpenAIStreamingTranscriptionImpl implements OpenAIStreamingTranscription {
   }
 }
 
-export async function startOpenAITranscription(
+export function startOpenAITranscription(
   options: StartOpenAITranscriptionOptions,
-): Promise<OpenAIStreamingTranscription> {
-  const transcription = new OpenAIStreamingTranscriptionImpl(options);
-  await transcription.readyPromise;
-  return transcription;
+): OpenAIStreamingTranscription {
+  return new OpenAIStreamingTranscriptionImpl(options);
 }
 
 export async function transcribeOpenAIAudio(
   options: TranscribeOpenAIAudioOptions,
 ): Promise<string> {
-  const transcription = await startOpenAITranscription(options);
+  const transcription = startOpenAITranscription(options);
   try {
-    await decodeAndStreamOpenAIAudio({
-      audio: options.audio,
-      transcription,
-      spawnImpl: options.spawnImpl,
-    });
-    return await transcription.finish();
+    return await transcription.finish({ audio: options.audio, spawnImpl: options.spawnImpl });
   } catch (error) {
     transcription.abort();
     throw error;

--- a/src/core/utils/openai_transcription.ts
+++ b/src/core/utils/openai_transcription.ts
@@ -1,0 +1,398 @@
+import type { ChildProcess } from "node:child_process";
+import WebSocket from "ws";
+import { z } from "zod";
+import type { SpawnCaptureResult } from "./spawn_capture.js";
+import { spawnWithCapture } from "./spawn_capture.js";
+import { formatSpeechToTextContext, type SpeechToTextContext } from "./speech_to_text_context.js";
+import { truncateForTokens } from "./truncate.js";
+
+const OPENAI_REALTIME_TRANSCRIPTION_URL = "wss://api.openai.com/v1/realtime?intent=transcription";
+const OPENAI_TRANSCRIPTION_MODEL = "gpt-live-transcribe";
+const OPENAI_TRANSCRIPTION_SAMPLE_RATE = 24_000;
+const OPENAI_TRANSCRIPTION_CONNECT_TIMEOUT_MS = 15_000;
+const OPENAI_TRANSCRIPTION_COMPLETION_TIMEOUT_MS = 30_000;
+const OPENAI_TRANSCRIPTION_CONTEXT_TOKENS = 900;
+const OPENAI_TRANSCRIPTION_FFMPEG_TIMEOUT_MS = 5 * 60 * 1_000;
+const OPENAI_TRANSCRIPTION_FFMPEG_OUTPUT_LIMIT_BYTES = 20_000;
+
+const eventSchema = z.object({ type: z.string() }).passthrough();
+const errorEventSchema = z.object({
+  type: z.literal("error"),
+  error: z.object({ message: z.string().trim().min(1) }),
+});
+const transcriptionFailedEventSchema = z.object({
+  type: z.literal("conversation.item.input_audio_transcription.failed"),
+  error: z.object({ message: z.string().trim().min(1) }),
+});
+const transcriptionCompletedEventSchema = z.object({
+  type: z.literal("conversation.item.input_audio_transcription.completed"),
+  transcript: z.string().trim().min(1),
+});
+
+export type OpenAITranscriptionWebSocket = {
+  on(event: "open", listener: () => void): unknown;
+  on(event: "message", listener: (data: unknown) => void): unknown;
+  on(event: "error", listener: (error: Error) => void): unknown;
+  on(event: "close", listener: (code: number, reason: Buffer) => void): unknown;
+  send(data: string, callback?: (error?: Error) => void): void;
+  close(): void;
+  terminate(): void;
+};
+
+export type OpenAITranscriptionWebSocketFactory = (
+  url: string,
+  options: { headers: Record<string, string> },
+) => OpenAITranscriptionWebSocket;
+
+export type OpenAIStreamingTranscription = {
+  appendAudio(audio: Buffer): void;
+  finish(): Promise<string>;
+  abort(): void;
+};
+
+export type StartOpenAITranscriptionOptions = {
+  apiKey: string;
+  context?: SpeechToTextContext;
+  webSocketFactory?: OpenAITranscriptionWebSocketFactory;
+};
+
+export type TranscribeOpenAIAudioOptions = StartOpenAITranscriptionOptions & {
+  audio: Buffer;
+  spawnImpl?: typeof spawnWithCapture;
+};
+
+class OpenAIStreamingTranscriptionImpl implements OpenAIStreamingTranscription {
+  private readonly socket: OpenAITranscriptionWebSocket;
+  private ready = false;
+  private aborted = false;
+  private failure?: Error;
+  private completedTranscript?: string;
+  private readyTimeout?: ReturnType<typeof setTimeout>;
+  private completionTimeout?: ReturnType<typeof setTimeout>;
+  private resolveReady?: () => void;
+  private rejectReady?: (error: Error) => void;
+  private resolveCompletion?: (transcript: string) => void;
+  private rejectCompletion?: (error: Error) => void;
+  readonly readyPromise: Promise<void>;
+
+  constructor(options: StartOpenAITranscriptionOptions) {
+    const apiKey = options.apiKey.trim();
+    if (!apiKey) {
+      throw new Error("missing OpenAI API key");
+    }
+
+    const webSocketFactory = options.webSocketFactory ?? defaultWebSocketFactory;
+    this.socket = webSocketFactory(OPENAI_REALTIME_TRANSCRIPTION_URL, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    this.readyPromise = new Promise<void>((resolve, reject) => {
+      this.resolveReady = resolve;
+      this.rejectReady = reject;
+    });
+    this.readyTimeout = setTimeout(() => {
+      this.fail(new Error("timed out opening OpenAI transcription session"));
+      this.socket.terminate();
+    }, OPENAI_TRANSCRIPTION_CONNECT_TIMEOUT_MS);
+    this.readyTimeout.unref?.();
+
+    this.socket.on("open", () => {
+      this.send({
+        type: "session.update",
+        session: {
+          type: "transcription",
+          audio: {
+            input: {
+              format: {
+                type: "audio/pcm",
+                rate: OPENAI_TRANSCRIPTION_SAMPLE_RATE,
+              },
+              transcription: {
+                model: OPENAI_TRANSCRIPTION_MODEL,
+                prompt: buildOpenAITranscriptionPrompt(options.context),
+                delay: "low",
+              },
+              turn_detection: null,
+            },
+          },
+        },
+      });
+    });
+    this.socket.on("message", (data) => this.handleMessage(data));
+    this.socket.on("error", (error) => {
+      this.fail(new Error(`OpenAI transcription connection failed: ${error.message}`));
+    });
+    this.socket.on("close", (code, reason) => {
+      if (this.aborted || this.completedTranscript) return;
+      const detail = reason.toString("utf8").trim();
+      this.fail(
+        new Error(
+          detail
+            ? `OpenAI transcription connection closed (${code}): ${detail}`
+            : `OpenAI transcription connection closed (${code})`,
+        ),
+      );
+    });
+  }
+
+  appendAudio(audio: Buffer): void {
+    if (audio.length === 0 || this.aborted || this.failure || this.completedTranscript) return;
+    if (!this.ready) {
+      this.fail(new Error("OpenAI transcription session was not ready for audio"));
+      return;
+    }
+
+    this.send({
+      type: "input_audio_buffer.append",
+      audio: audio.toString("base64"),
+    });
+  }
+
+  async finish(): Promise<string> {
+    await this.readyPromise;
+    if (this.failure) throw this.failure;
+    if (this.aborted) throw new Error("OpenAI transcription was aborted");
+    if (this.completedTranscript) return this.completedTranscript;
+
+    const completion = new Promise<string>((resolve, reject) => {
+      this.resolveCompletion = resolve;
+      this.rejectCompletion = reject;
+    });
+    this.completionTimeout = setTimeout(() => {
+      this.fail(new Error("timed out waiting for OpenAI transcription"));
+      this.socket.terminate();
+    }, OPENAI_TRANSCRIPTION_COMPLETION_TIMEOUT_MS);
+    this.completionTimeout.unref?.();
+    this.send({ type: "input_audio_buffer.commit" });
+    return await completion;
+  }
+
+  abort(): void {
+    if (this.aborted || this.completedTranscript) return;
+    this.aborted = true;
+    this.clearTimers();
+    this.rejectReady?.(new Error("OpenAI transcription was aborted"));
+    this.rejectCompletion?.(new Error("OpenAI transcription was aborted"));
+    this.clearWaiters();
+    this.socket.close();
+  }
+
+  private handleMessage(data: unknown): void {
+    let payload: unknown;
+    try {
+      payload = JSON.parse(formatWebSocketMessage(data)) as unknown;
+    } catch {
+      this.fail(new Error("OpenAI transcription returned malformed JSON"));
+      return;
+    }
+
+    const event = eventSchema.safeParse(payload);
+    if (!event.success) {
+      this.fail(new Error("OpenAI transcription returned a malformed event"));
+      return;
+    }
+
+    if (event.data.type === "session.updated") {
+      this.ready = true;
+      if (this.readyTimeout) clearTimeout(this.readyTimeout);
+      this.readyTimeout = undefined;
+      this.resolveReady?.();
+      this.resolveReady = undefined;
+      this.rejectReady = undefined;
+      return;
+    }
+
+    if (event.data.type === "error") {
+      const parsed = errorEventSchema.safeParse(payload);
+      this.fail(
+        new Error(
+          parsed.success ? parsed.data.error.message : "OpenAI transcription returned an error",
+        ),
+      );
+      return;
+    }
+
+    if (event.data.type === "conversation.item.input_audio_transcription.failed") {
+      const parsed = transcriptionFailedEventSchema.safeParse(payload);
+      this.fail(
+        new Error(
+          parsed.success
+            ? parsed.data.error.message
+            : "OpenAI transcription failed with a malformed error",
+        ),
+      );
+      return;
+    }
+
+    if (event.data.type === "conversation.item.input_audio_transcription.completed") {
+      const parsed = transcriptionCompletedEventSchema.safeParse(payload);
+      if (!parsed.success) {
+        this.fail(new Error("transcription result was empty or malformed"));
+        return;
+      }
+
+      this.completedTranscript = parsed.data.transcript;
+      this.clearTimers();
+      this.resolveCompletion?.(this.completedTranscript);
+      this.clearWaiters();
+      this.socket.close();
+    }
+  }
+
+  private send(event: Record<string, unknown>): void {
+    if (this.failure || this.aborted) return;
+    try {
+      this.socket.send(JSON.stringify(event), (error) => {
+        if (error) {
+          this.fail(new Error(`failed to send OpenAI transcription audio: ${error.message}`));
+        }
+      });
+    } catch (error) {
+      this.fail(
+        new Error(`failed to send OpenAI transcription audio: ${(error as Error).message}`),
+      );
+    }
+  }
+
+  private fail(error: Error): void {
+    if (this.failure || this.aborted || this.completedTranscript) return;
+    this.failure = error;
+    this.clearTimers();
+    this.rejectReady?.(error);
+    this.rejectCompletion?.(error);
+    this.clearWaiters();
+    this.socket.terminate();
+  }
+
+  private clearTimers(): void {
+    if (this.readyTimeout) clearTimeout(this.readyTimeout);
+    if (this.completionTimeout) clearTimeout(this.completionTimeout);
+    this.readyTimeout = undefined;
+    this.completionTimeout = undefined;
+  }
+
+  private clearWaiters(): void {
+    this.resolveReady = undefined;
+    this.rejectReady = undefined;
+    this.resolveCompletion = undefined;
+    this.rejectCompletion = undefined;
+  }
+}
+
+export async function startOpenAITranscription(
+  options: StartOpenAITranscriptionOptions,
+): Promise<OpenAIStreamingTranscription> {
+  const transcription = new OpenAIStreamingTranscriptionImpl(options);
+  await transcription.readyPromise;
+  return transcription;
+}
+
+export async function transcribeOpenAIAudio(
+  options: TranscribeOpenAIAudioOptions,
+): Promise<string> {
+  const transcription = await startOpenAITranscription(options);
+  try {
+    await decodeAndStreamOpenAIAudio({
+      audio: options.audio,
+      transcription,
+      spawnImpl: options.spawnImpl,
+    });
+    return await transcription.finish();
+  } catch (error) {
+    transcription.abort();
+    throw error;
+  }
+}
+
+async function decodeAndStreamOpenAIAudio(args: {
+  audio: Buffer;
+  transcription: OpenAIStreamingTranscription;
+  spawnImpl?: typeof spawnWithCapture;
+}): Promise<void> {
+  const spawnImpl = args.spawnImpl ?? spawnWithCapture;
+  let result: SpawnCaptureResult;
+  try {
+    result = await spawnImpl(
+      "ffmpeg",
+      [
+        "-nostdin",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-i",
+        "pipe:0",
+        "-vn",
+        "-ac",
+        "1",
+        "-ar",
+        String(OPENAI_TRANSCRIPTION_SAMPLE_RATE),
+        "-c:a",
+        "pcm_s16le",
+        "-f",
+        "s16le",
+        "pipe:1",
+      ],
+      {
+        input: args.audio,
+        timeoutMs: OPENAI_TRANSCRIPTION_FFMPEG_TIMEOUT_MS,
+        maxCaptureBytes: OPENAI_TRANSCRIPTION_FFMPEG_OUTPUT_LIMIT_BYTES,
+        captureOutput: "stderr",
+        stdio: ["pipe", "pipe", "pipe"],
+        onSpawn: (child: ChildProcess) => {
+          child.stdout?.on("data", (chunk: Buffer) => args.transcription.appendAudio(chunk));
+        },
+      },
+    );
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error("ffmpeg is required for OpenAI speech transcription");
+    }
+    throw error;
+  }
+
+  if (result.timedOut) {
+    throw new Error("ffmpeg timed out while decoding audio for OpenAI transcription");
+  }
+  if (result.exitCode !== 0) {
+    const detail = result.stderr.trim();
+    throw new Error(
+      detail
+        ? `ffmpeg failed to decode audio for OpenAI transcription: ${detail}`
+        : `ffmpeg exited with code ${result.exitCode ?? "unknown"}`,
+    );
+  }
+}
+
+function buildOpenAITranscriptionPrompt(context: SpeechToTextContext | undefined): string {
+  const formattedContext = formatSpeechToTextContext(context);
+  const boundedContext = formattedContext
+    ? truncateForTokens(formattedContext, {
+        maxTokens: OPENAI_TRANSCRIPTION_CONTEXT_TOKENS,
+        strategy: "tail",
+      }).content.trim()
+    : "";
+  return [
+    "The speaker is dictating a message for insertion into an AI coding assistant chat input.",
+    boundedContext
+      ? `Use this recent conversation only to resolve likely names, acronyms, terminology, and references:\n${boundedContext}`
+      : undefined,
+  ]
+    .filter((line): line is string => line !== undefined)
+    .join("\n\n");
+}
+
+function formatWebSocketMessage(data: unknown): string {
+  if (typeof data === "string") return data;
+  if (Buffer.isBuffer(data)) return data.toString("utf8");
+  if (data instanceof ArrayBuffer) return Buffer.from(data).toString("utf8");
+  if (ArrayBuffer.isView(data)) {
+    return Buffer.from(data.buffer, data.byteOffset, data.byteLength).toString("utf8");
+  }
+  throw new Error("unsupported WebSocket message");
+}
+
+function defaultWebSocketFactory(
+  url: string,
+  options: { headers: Record<string, string> },
+): OpenAITranscriptionWebSocket {
+  return new WebSocket(url, options) as OpenAITranscriptionWebSocket;
+}

--- a/src/core/utils/speech_to_text.ts
+++ b/src/core/utils/speech_to_text.ts
@@ -1,7 +1,9 @@
 import type { SpeechToTextProvider } from "../config/schema.js";
-import { transcribeGeminiAudio } from "./gemini_transcription.js";
+import { type GeminiTranscriptionProgress, transcribeGeminiAudio } from "./gemini_transcription.js";
 import { transcribeMistralAudio } from "./mistral_transcription.js";
 import type { SpeechToTextContext } from "./speech_to_text_context.js";
+
+export type SpeechToTextProgress = GeminiTranscriptionProgress;
 
 export type SpeechToTextOptions = {
   provider: SpeechToTextProvider;
@@ -12,9 +14,15 @@ export type SpeechToTextOptions = {
   language?: string;
   context?: SpeechToTextContext;
   fetchImpl?: typeof fetch;
+  onProgress?: (progress: SpeechToTextProgress) => void;
 };
 
-export async function transcribeAudio(options: SpeechToTextOptions): Promise<string> {
+export type SpeechToTextResult = {
+  text: string;
+  usedFallback: boolean;
+};
+
+export async function transcribeAudio(options: SpeechToTextOptions): Promise<SpeechToTextResult> {
   switch (options.provider) {
     case "gemini":
       return await transcribeGeminiAudio({
@@ -23,15 +31,19 @@ export async function transcribeAudio(options: SpeechToTextOptions): Promise<str
         mimeType: options.mimeType,
         context: options.context,
         fetchImpl: options.fetchImpl,
+        onProgress: options.onProgress,
       });
     case "mistral":
-      return await transcribeMistralAudio({
-        apiKey: options.apiKey,
-        audio: options.audio,
-        mimeType: options.mimeType,
-        fileName: options.fileName,
-        language: options.language,
-        fetchImpl: options.fetchImpl,
-      });
+      return {
+        text: await transcribeMistralAudio({
+          apiKey: options.apiKey,
+          audio: options.audio,
+          mimeType: options.mimeType,
+          fileName: options.fileName,
+          language: options.language,
+          fetchImpl: options.fetchImpl,
+        }),
+        usedFallback: false,
+      };
   }
 }

--- a/src/core/utils/speech_to_text.ts
+++ b/src/core/utils/speech_to_text.ts
@@ -38,7 +38,10 @@ export type SpeechToTextResult = {
 
 export type SpeechToTextTranscription = {
   appendAudio(audio: Buffer): void;
-  finish(recording: SpeechToTextRecording): Promise<SpeechToTextResult>;
+  finish(
+    recording: SpeechToTextRecording,
+    options?: { signal?: AbortSignal },
+  ): Promise<SpeechToTextResult>;
   abort(): void;
 };
 
@@ -79,9 +82,10 @@ export function createSpeechToTextTranscription(
       });
       return {
         appendAudio: (audio) => transcription.appendAudio(audio),
-        finish: async (recording) => ({
+        finish: async (recording, finishOptions) => ({
           text: await transcription.finish({
             audio: recording.audio,
+            signal: finishOptions?.signal,
             spawnImpl: options.deps?.spawnImpl,
           }),
           usedFallback: false,

--- a/src/core/utils/speech_to_text.ts
+++ b/src/core/utils/speech_to_text.ts
@@ -1,90 +1,115 @@
 import type { SpeechToTextProvider } from "../config/schema.js";
-import { type GeminiTranscriptionProgress, transcribeGeminiAudio } from "./gemini_transcription.js";
+import { transcribeGeminiAudio } from "./gemini_transcription.js";
 import { transcribeMistralAudio } from "./mistral_transcription.js";
 import {
-  type OpenAIStreamingTranscription,
   type OpenAITranscriptionWebSocketFactory,
   startOpenAITranscription,
-  transcribeOpenAIAudio,
 } from "./openai_transcription.js";
 import type { spawnWithCapture } from "./spawn_capture.js";
 import type { SpeechToTextContext } from "./speech_to_text_context.js";
 
-export type SpeechToTextProgress = GeminiTranscriptionProgress;
+export type SpeechToTextProgress = "retrying" | "trying-fallback";
 
 export type SpeechToTextDependencies = {
+  fetchImpl?: typeof fetch;
   webSocketFactory?: OpenAITranscriptionWebSocketFactory;
   spawnImpl?: typeof spawnWithCapture;
 };
 
-export type SpeechToTextOptions = SpeechToTextDependencies & {
+export type SpeechToTextTranscriptionOptions = {
   provider: SpeechToTextProvider;
   apiKey: string;
+  context?: SpeechToTextContext;
+  onProgress?: (progress: SpeechToTextProgress) => void;
+  deps?: SpeechToTextDependencies;
+};
+
+export type SpeechToTextRecording = {
   audio: Buffer;
   mimeType?: string;
   fileName?: string;
   language?: string;
-  context?: SpeechToTextContext;
-  fetchImpl?: typeof fetch;
-  onProgress?: (progress: SpeechToTextProgress) => void;
 };
-
-export type StreamingSpeechToTextOptions = Pick<
-  SpeechToTextOptions,
-  "provider" | "apiKey" | "context" | "webSocketFactory"
->;
-
-export type StreamingSpeechToText = OpenAIStreamingTranscription;
 
 export type SpeechToTextResult = {
   text: string;
   usedFallback: boolean;
 };
 
-export async function startStreamingSpeechToText(
-  options: StreamingSpeechToTextOptions,
-): Promise<StreamingSpeechToText | undefined> {
-  if (options.provider !== "openai") return undefined;
-  return await startOpenAITranscription({
-    apiKey: options.apiKey,
-    context: options.context,
-    webSocketFactory: options.webSocketFactory,
-  });
-}
+export type SpeechToTextTranscription = {
+  appendAudio(audio: Buffer): void;
+  finish(recording: SpeechToTextRecording): Promise<SpeechToTextResult>;
+  abort(): void;
+};
 
-export async function transcribeAudio(options: SpeechToTextOptions): Promise<SpeechToTextResult> {
+export function createSpeechToTextTranscription(
+  options: SpeechToTextTranscriptionOptions,
+): SpeechToTextTranscription {
   switch (options.provider) {
     case "gemini":
-      return await transcribeGeminiAudio({
-        apiKey: options.apiKey,
-        audio: options.audio,
-        mimeType: options.mimeType,
-        context: options.context,
-        fetchImpl: options.fetchImpl,
-        onProgress: options.onProgress,
+      return createBatchTranscription(async (recording) => {
+        return await transcribeGeminiAudio({
+          apiKey: options.apiKey,
+          audio: recording.audio,
+          mimeType: recording.mimeType,
+          context: options.context,
+          fetchImpl: options.deps?.fetchImpl,
+          onProgress: options.onProgress,
+        });
       });
     case "mistral":
+      return createBatchTranscription(async (recording) => {
+        return {
+          text: await transcribeMistralAudio({
+            apiKey: options.apiKey,
+            audio: recording.audio,
+            mimeType: recording.mimeType,
+            fileName: recording.fileName,
+            language: recording.language,
+            fetchImpl: options.deps?.fetchImpl,
+          }),
+          usedFallback: false,
+        };
+      });
+    case "openai": {
+      const transcription = startOpenAITranscription({
+        apiKey: options.apiKey,
+        context: options.context,
+        webSocketFactory: options.deps?.webSocketFactory,
+      });
       return {
-        text: await transcribeMistralAudio({
-          apiKey: options.apiKey,
-          audio: options.audio,
-          mimeType: options.mimeType,
-          fileName: options.fileName,
-          language: options.language,
-          fetchImpl: options.fetchImpl,
+        appendAudio: (audio) => transcription.appendAudio(audio),
+        finish: async (recording) => ({
+          text: await transcription.finish({
+            audio: recording.audio,
+            spawnImpl: options.deps?.spawnImpl,
+          }),
+          usedFallback: false,
         }),
-        usedFallback: false,
+        abort: () => transcription.abort(),
       };
-    case "openai":
-      return {
-        text: await transcribeOpenAIAudio({
-          apiKey: options.apiKey,
-          audio: options.audio,
-          context: options.context,
-          webSocketFactory: options.webSocketFactory,
-          spawnImpl: options.spawnImpl,
-        }),
-        usedFallback: false,
-      };
+    }
   }
+}
+
+function createBatchTranscription(
+  transcribe: (recording: SpeechToTextRecording) => Promise<SpeechToTextResult>,
+): SpeechToTextTranscription {
+  let aborted = false;
+  return {
+    appendAudio: () => {},
+    finish: async (recording) => {
+      if (aborted) {
+        throw new Error("speech transcription was aborted");
+      }
+      const result = await transcribe(recording);
+      if (aborted) {
+        throw new Error("speech transcription was aborted");
+      }
+      return result;
+    },
+    abort: () => {
+      aborted = true;
+    },
+  };
 }

--- a/src/core/utils/speech_to_text.ts
+++ b/src/core/utils/speech_to_text.ts
@@ -1,11 +1,23 @@
 import type { SpeechToTextProvider } from "../config/schema.js";
 import { type GeminiTranscriptionProgress, transcribeGeminiAudio } from "./gemini_transcription.js";
 import { transcribeMistralAudio } from "./mistral_transcription.js";
+import {
+  type OpenAIStreamingTranscription,
+  type OpenAITranscriptionWebSocketFactory,
+  startOpenAITranscription,
+  transcribeOpenAIAudio,
+} from "./openai_transcription.js";
+import type { spawnWithCapture } from "./spawn_capture.js";
 import type { SpeechToTextContext } from "./speech_to_text_context.js";
 
 export type SpeechToTextProgress = GeminiTranscriptionProgress;
 
-export type SpeechToTextOptions = {
+export type SpeechToTextDependencies = {
+  webSocketFactory?: OpenAITranscriptionWebSocketFactory;
+  spawnImpl?: typeof spawnWithCapture;
+};
+
+export type SpeechToTextOptions = SpeechToTextDependencies & {
   provider: SpeechToTextProvider;
   apiKey: string;
   audio: Buffer;
@@ -17,10 +29,28 @@ export type SpeechToTextOptions = {
   onProgress?: (progress: SpeechToTextProgress) => void;
 };
 
+export type StreamingSpeechToTextOptions = Pick<
+  SpeechToTextOptions,
+  "provider" | "apiKey" | "context" | "webSocketFactory"
+>;
+
+export type StreamingSpeechToText = OpenAIStreamingTranscription;
+
 export type SpeechToTextResult = {
   text: string;
   usedFallback: boolean;
 };
+
+export async function startStreamingSpeechToText(
+  options: StreamingSpeechToTextOptions,
+): Promise<StreamingSpeechToText | undefined> {
+  if (options.provider !== "openai") return undefined;
+  return await startOpenAITranscription({
+    apiKey: options.apiKey,
+    context: options.context,
+    webSocketFactory: options.webSocketFactory,
+  });
+}
 
 export async function transcribeAudio(options: SpeechToTextOptions): Promise<SpeechToTextResult> {
   switch (options.provider) {
@@ -42,6 +72,17 @@ export async function transcribeAudio(options: SpeechToTextOptions): Promise<Spe
           fileName: options.fileName,
           language: options.language,
           fetchImpl: options.fetchImpl,
+        }),
+        usedFallback: false,
+      };
+    case "openai":
+      return {
+        text: await transcribeOpenAIAudio({
+          apiKey: options.apiKey,
+          audio: options.audio,
+          context: options.context,
+          webSocketFactory: options.webSocketFactory,
+          spawnImpl: options.spawnImpl,
         }),
         usedFallback: false,
       };

--- a/src/core/utils/speech_to_text.ts
+++ b/src/core/utils/speech_to_text.ts
@@ -4,11 +4,10 @@ import { transcribeMistralAudio } from "./mistral_transcription.js";
 import {
   type OpenAITranscriptionWebSocketFactory,
   startOpenAITranscription,
+  transcribeOpenAIAudio,
 } from "./openai_transcription.js";
 import type { spawnWithCapture } from "./spawn_capture.js";
 import type { SpeechToTextContext } from "./speech_to_text_context.js";
-
-export type SpeechToTextProgress = "retrying" | "trying-fallback";
 
 export type SpeechToTextDependencies = {
   fetchImpl?: typeof fetch;
@@ -18,9 +17,9 @@ export type SpeechToTextDependencies = {
 
 export type SpeechToTextTranscriptionOptions = {
   provider: SpeechToTextProvider;
+  mode: "streaming" | "file";
   apiKey: string;
   context?: SpeechToTextContext;
-  onProgress?: (progress: SpeechToTextProgress) => void;
   deps?: SpeechToTextDependencies;
 };
 
@@ -31,17 +30,9 @@ export type SpeechToTextRecording = {
   language?: string;
 };
 
-export type SpeechToTextResult = {
-  text: string;
-  usedFallback: boolean;
-};
-
 export type SpeechToTextTranscription = {
   appendAudio(audio: Buffer): void;
-  finish(
-    recording: SpeechToTextRecording,
-    options?: { signal?: AbortSignal },
-  ): Promise<SpeechToTextResult>;
+  finish(recording: SpeechToTextRecording, options?: { signal?: AbortSignal }): Promise<string>;
   abort(): void;
 };
 
@@ -50,70 +41,78 @@ export function createSpeechToTextTranscription(
 ): SpeechToTextTranscription {
   switch (options.provider) {
     case "gemini":
-      return createBatchTranscription(async (recording) => {
+      return createBatchTranscription(async (recording, signal) => {
         return await transcribeGeminiAudio({
           apiKey: options.apiKey,
           audio: recording.audio,
           mimeType: recording.mimeType,
           context: options.context,
+          signal,
           fetchImpl: options.deps?.fetchImpl,
-          onProgress: options.onProgress,
         });
       });
     case "mistral":
-      return createBatchTranscription(async (recording) => {
-        return {
-          text: await transcribeMistralAudio({
-            apiKey: options.apiKey,
-            audio: recording.audio,
-            mimeType: recording.mimeType,
-            fileName: recording.fileName,
-            language: recording.language,
-            fetchImpl: options.deps?.fetchImpl,
-          }),
-          usedFallback: false,
-        };
+      return createBatchTranscription(async (recording, signal) => {
+        return await transcribeMistralAudio({
+          apiKey: options.apiKey,
+          audio: recording.audio,
+          mimeType: recording.mimeType,
+          fileName: recording.fileName,
+          language: recording.language,
+          signal,
+          fetchImpl: options.deps?.fetchImpl,
+        });
       });
     case "openai": {
-      const transcription = startOpenAITranscription({
-        apiKey: options.apiKey,
-        context: options.context,
-        webSocketFactory: options.deps?.webSocketFactory,
-      });
+      if (options.mode === "streaming") {
+        const transcription = startOpenAITranscription({
+          apiKey: options.apiKey,
+          context: options.context,
+          webSocketFactory: options.deps?.webSocketFactory,
+        });
+        return {
+          appendAudio: (audio) => transcription.appendAudio(audio),
+          finish: async (_recording, finishOptions) =>
+            await transcription.finish({ signal: finishOptions?.signal }),
+          abort: () => transcription.abort(),
+        };
+      }
+
+      const abortController = new AbortController();
       return {
-        appendAudio: (audio) => transcription.appendAudio(audio),
-        finish: async (recording, finishOptions) => ({
-          text: await transcription.finish({
+        appendAudio: () => {},
+        finish: async (recording, finishOptions) =>
+          await transcribeOpenAIAudio({
+            apiKey: options.apiKey,
             audio: recording.audio,
-            signal: finishOptions?.signal,
+            context: options.context,
+            signal: finishOptions?.signal
+              ? AbortSignal.any([abortController.signal, finishOptions.signal])
+              : abortController.signal,
+            fetchImpl: options.deps?.fetchImpl,
             spawnImpl: options.deps?.spawnImpl,
           }),
-          usedFallback: false,
-        }),
-        abort: () => transcription.abort(),
+        abort: () => abortController.abort(new Error("OpenAI transcription was aborted")),
       };
     }
   }
 }
 
 function createBatchTranscription(
-  transcribe: (recording: SpeechToTextRecording) => Promise<SpeechToTextResult>,
+  transcribe: (recording: SpeechToTextRecording, signal: AbortSignal) => Promise<string>,
 ): SpeechToTextTranscription {
-  let aborted = false;
+  const abortController = new AbortController();
   return {
     appendAudio: () => {},
-    finish: async (recording) => {
-      if (aborted) {
-        throw new Error("speech transcription was aborted");
-      }
-      const result = await transcribe(recording);
-      if (aborted) {
-        throw new Error("speech transcription was aborted");
-      }
+    finish: async (recording, finishOptions) => {
+      const signal = finishOptions?.signal
+        ? AbortSignal.any([abortController.signal, finishOptions.signal])
+        : abortController.signal;
+      signal.throwIfAborted();
+      const result = await transcribe(recording, signal);
+      signal.throwIfAborted();
       return result;
     },
-    abort: () => {
-      aborted = true;
-    },
+    abort: () => abortController.abort(new Error("speech transcription was aborted")),
   };
 }

--- a/src/tui/listen_capture.ts
+++ b/src/tui/listen_capture.ts
@@ -1,15 +1,20 @@
+import type { ChildProcess } from "node:child_process";
 import { readFile, unlink } from "node:fs/promises";
 import {
   type Config,
   getGoogleApiKey,
   getMistralApiKey,
+  getOpenAIApiKey,
   type SpeechToTextProvider,
 } from "../core/config/index.js";
 import type { CoreDeps } from "../core/runtime/deps.js";
 import type { SpawnCaptureResult } from "../core/utils/spawn_capture.js";
 import {
+  type SpeechToTextDependencies,
   type SpeechToTextProgress,
   type SpeechToTextResult,
+  type StreamingSpeechToText,
+  startStreamingSpeechToText,
   transcribeAudio,
 } from "../core/utils/speech_to_text.js";
 import type { SpeechToTextContext } from "../core/utils/speech_to_text_context.js";
@@ -23,6 +28,7 @@ export type ListenRecording = {
   stopRequested: boolean;
   abortController: AbortController;
   completion: Promise<SpawnCaptureResult>;
+  streamingTranscription?: StreamingSpeechToText;
   maxDurationTimeout?: ReturnType<typeof setTimeout>;
 };
 
@@ -44,36 +50,51 @@ export function startListenAudioCapture(args: {
   deps: CoreDeps;
   audioPath: string;
   signal: AbortSignal;
+  onAudioChunk?: (audio: Buffer) => void;
 }): Promise<SpawnCaptureResult> {
-  return args.deps.spawn(
-    "ffmpeg",
-    [
-      "-hide_banner",
-      "-loglevel",
-      "error",
-      "-nostdin",
-      "-f",
-      "avfoundation",
-      "-i",
-      ":0",
-      "-ac",
-      "1",
-      "-ar",
-      "16000",
-      "-c:a",
-      "pcm_s16le",
-      "-f",
-      "wav",
-      "-y",
-      args.audioPath,
-    ],
-    {
-      detached: true,
-      killProcessGroup: true,
-      signal: args.signal,
-      stdio: ["ignore", "ignore", "ignore"],
-    },
-  );
+  const inputArgs = [
+    "-hide_banner",
+    "-loglevel",
+    "error",
+    "-nostdin",
+    "-f",
+    "avfoundation",
+    "-i",
+    ":0",
+  ];
+  const waveOutputArgs = [
+    "-map",
+    "0:a",
+    "-ac",
+    "1",
+    "-ar",
+    args.onAudioChunk ? "24000" : "16000",
+    "-c:a",
+    "pcm_s16le",
+    "-f",
+    "wav",
+    "-y",
+    args.audioPath,
+  ];
+  const streamOutputArgs = args.onAudioChunk
+    ? ["-map", "0:a", "-ac", "1", "-ar", "24000", "-c:a", "pcm_s16le", "-f", "s16le", "pipe:1"]
+    : [];
+
+  return args.deps.spawn("ffmpeg", [...inputArgs, ...waveOutputArgs, ...streamOutputArgs], {
+    detached: true,
+    killProcessGroup: true,
+    signal: args.signal,
+    ...(args.onAudioChunk
+      ? {
+          captureOutput: "stderr" as const,
+          maxCaptureBytes: 20_000,
+          stdio: ["ignore", "pipe", "pipe"] as ["ignore", "pipe", "pipe"],
+          onSpawn: (child: ChildProcess) => {
+            child.stdout?.on("data", (chunk: Buffer) => args.onAudioChunk?.(chunk));
+          },
+        }
+      : { stdio: ["ignore", "ignore", "ignore"] as ["ignore", "ignore", "ignore"] }),
+  });
 }
 
 export async function readListenAudio(path: string): Promise<Buffer> {
@@ -104,16 +125,46 @@ export function getSpeechToTextProvider(config: Config): SpeechToTextProvider {
 
 export function getSpeechToTextApiKey(config: Config, deps: CoreDeps): string | undefined {
   const provider = getSpeechToTextProvider(config);
-  return provider === "gemini"
-    ? getGoogleApiKey(config, deps.env.env())
-    : getMistralApiKey(config, deps.env.env());
+  switch (provider) {
+    case "gemini":
+      return getGoogleApiKey(config, deps.env.env());
+    case "mistral":
+      return getMistralApiKey(config, deps.env.env());
+    case "openai":
+      return getOpenAIApiKey(config, deps.env.env());
+  }
 }
 
 export function getSpeechToTextApiKeyErrorMessage(config: Config, action: string): string {
   const provider = getSpeechToTextProvider(config);
-  return provider === "gemini"
-    ? `set GEMINI_API_KEY or apiKeys.google to ${action}`
-    : `set MISTRAL_API_KEY or apiKeys.mistral to ${action}`;
+  switch (provider) {
+    case "gemini":
+      return `set GEMINI_API_KEY or apiKeys.google to ${action}`;
+    case "mistral":
+      return `set MISTRAL_API_KEY or apiKeys.mistral to ${action}`;
+    case "openai":
+      return `set OPENAI_API_KEY or apiKeys.openai to ${action}`;
+  }
+}
+
+export async function startListenStreamingTranscription(args: {
+  config: Config;
+  deps: CoreDeps;
+  context?: SpeechToTextContext;
+  speechToTextDeps?: SpeechToTextDependencies;
+}): Promise<StreamingSpeechToText | undefined> {
+  const provider = getSpeechToTextProvider(args.config);
+  const apiKey = getSpeechToTextApiKey(args.config, args.deps);
+  if (!apiKey) {
+    throw new Error(getSpeechToTextApiKeyErrorMessage(args.config, "transcribe speech"));
+  }
+
+  return await startStreamingSpeechToText({
+    provider,
+    apiKey,
+    context: args.context,
+    webSocketFactory: args.speechToTextDeps?.webSocketFactory,
+  });
 }
 
 export async function transcribeListenAudio(args: {
@@ -122,6 +173,7 @@ export async function transcribeListenAudio(args: {
   audio: Buffer;
   context?: SpeechToTextContext;
   onProgress?: (progress: SpeechToTextProgress) => void;
+  speechToTextDeps?: SpeechToTextDependencies;
 }): Promise<SpeechToTextResult> {
   const provider = getSpeechToTextProvider(args.config);
   const apiKey = getSpeechToTextApiKey(args.config, args.deps);
@@ -138,5 +190,7 @@ export async function transcribeListenAudio(args: {
     language: "en",
     context: args.context,
     onProgress: args.onProgress,
+    webSocketFactory: args.speechToTextDeps?.webSocketFactory,
+    spawnImpl: args.speechToTextDeps?.spawnImpl ?? args.deps.spawn,
   });
 }

--- a/src/tui/listen_capture.ts
+++ b/src/tui/listen_capture.ts
@@ -1,5 +1,7 @@
 import type { ChildProcess } from "node:child_process";
 import { readFile, unlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   type Config,
   getGoogleApiKey,
@@ -12,12 +14,12 @@ import type { SpawnCaptureResult } from "../core/utils/spawn_capture.js";
 import {
   createSpeechToTextTranscription,
   type SpeechToTextDependencies,
-  type SpeechToTextProgress,
   type SpeechToTextTranscription,
 } from "../core/utils/speech_to_text.js";
 import type { SpeechToTextContext } from "../core/utils/speech_to_text_context.js";
 
-export const LISTEN_TEMP_FILE_TEMPLATE = "/tmp/tau-listen.XXXXXX";
+export const LISTEN_TEMP_FILE_TEMPLATE = join(tmpdir(), "tau-listen.XXXXXX");
+export const LISTEN_CAPTURE_START_TIMEOUT_MS = 15_000;
 export const LISTEN_RECORDING_MIN_BYTES = 1024;
 export const LISTEN_RECORDING_MAX_DURATION_MS = 5 * 60 * 1000;
 
@@ -185,8 +187,8 @@ export function getSpeechToTextApiKeyErrorMessage(config: Config, action: string
 export function createListenTranscription(args: {
   config: Config;
   deps: CoreDeps;
+  mode: "streaming" | "file";
   context?: SpeechToTextContext;
-  onProgress?: (progress: SpeechToTextProgress) => void;
   speechToTextDeps?: SpeechToTextDependencies;
 }): SpeechToTextTranscription {
   const provider = getSpeechToTextProvider(args.config);
@@ -197,9 +199,9 @@ export function createListenTranscription(args: {
 
   return createSpeechToTextTranscription({
     provider,
+    mode: args.mode,
     apiKey,
     context: args.context,
-    onProgress: args.onProgress,
     deps: {
       ...args.speechToTextDeps,
       spawnImpl: args.speechToTextDeps?.spawnImpl ?? args.deps.spawn,

--- a/src/tui/listen_capture.ts
+++ b/src/tui/listen_capture.ts
@@ -7,7 +7,11 @@ import {
 } from "../core/config/index.js";
 import type { CoreDeps } from "../core/runtime/deps.js";
 import type { SpawnCaptureResult } from "../core/utils/spawn_capture.js";
-import { transcribeAudio } from "../core/utils/speech_to_text.js";
+import {
+  type SpeechToTextProgress,
+  type SpeechToTextResult,
+  transcribeAudio,
+} from "../core/utils/speech_to_text.js";
 import type { SpeechToTextContext } from "../core/utils/speech_to_text_context.js";
 
 export const LISTEN_TEMP_FILE_TEMPLATE = "/tmp/tau-listen.XXXXXX";
@@ -76,9 +80,19 @@ export async function readListenAudio(path: string): Promise<Buffer> {
   return await readFile(path);
 }
 
-export async function cleanupListenTempFile(path: string): Promise<void> {
+export async function deleteListenTempFile(path: string): Promise<void> {
   try {
     await unlink(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+}
+
+export async function cleanupListenTempFile(path: string): Promise<void> {
+  try {
+    await deleteListenTempFile(path);
   } catch {
     // best-effort cleanup
   }
@@ -107,7 +121,8 @@ export async function transcribeListenAudio(args: {
   deps: CoreDeps;
   audio: Buffer;
   context?: SpeechToTextContext;
-}): Promise<string> {
+  onProgress?: (progress: SpeechToTextProgress) => void;
+}): Promise<SpeechToTextResult> {
   const provider = getSpeechToTextProvider(args.config);
   const apiKey = getSpeechToTextApiKey(args.config, args.deps);
   if (!apiKey) {
@@ -122,5 +137,6 @@ export async function transcribeListenAudio(args: {
     fileName: "speech.wav",
     language: "en",
     context: args.context,
+    onProgress: args.onProgress,
   });
 }

--- a/src/tui/listen_capture.ts
+++ b/src/tui/listen_capture.ts
@@ -49,7 +49,7 @@ export function startListenAudioCapture(args: {
   audioPath: string;
   signal: AbortSignal;
   onAudioChunk: (audio: Buffer) => void;
-}): Promise<SpawnCaptureResult> {
+}): { completion: Promise<SpawnCaptureResult>; started: Promise<void> } {
   const inputArgs = [
     "-hide_banner",
     "-loglevel",
@@ -88,17 +88,48 @@ export function startListenAudioCapture(args: {
     "pipe:1",
   ];
 
-  return args.deps.spawn("ffmpeg", [...inputArgs, ...waveOutputArgs, ...streamOutputArgs], {
-    detached: true,
-    killProcessGroup: true,
-    signal: args.signal,
-    captureOutput: "stderr",
-    maxCaptureBytes: 20_000,
-    stdio: ["ignore", "pipe", "pipe"],
-    onSpawn: (child: ChildProcess) => {
-      child.stdout?.on("data", (chunk: Buffer) => args.onAudioChunk(chunk));
+  const {
+    promise: started,
+    resolve: resolveStarted,
+    reject: rejectStarted,
+  } = Promise.withResolvers<void>();
+  let receivedAudio = false;
+  const completion = args.deps.spawn(
+    "ffmpeg",
+    [...inputArgs, ...waveOutputArgs, ...streamOutputArgs],
+    {
+      detached: true,
+      killProcessGroup: true,
+      signal: args.signal,
+      captureOutput: "stderr",
+      maxCaptureBytes: 20_000,
+      stdio: ["ignore", "pipe", "pipe"],
+      onSpawn: (child: ChildProcess) => {
+        child.stdout?.on("data", (chunk: Buffer) => {
+          if (!receivedAudio) {
+            receivedAudio = true;
+            resolveStarted();
+          }
+          args.onAudioChunk(chunk);
+        });
+      },
     },
-  });
+  );
+  void completion.then(
+    (result) => {
+      if (receivedAudio) return;
+      const detail = result.stderr.trim();
+      rejectStarted(
+        new Error(
+          detail
+            ? `ffmpeg failed to start recording: ${detail}`
+            : "ffmpeg exited before recording audio",
+        ),
+      );
+    },
+    (error) => rejectStarted(error),
+  );
+  return { completion, started };
 }
 
 export async function readListenAudio(path: string): Promise<Buffer> {
@@ -124,7 +155,7 @@ export async function cleanupListenTempFile(path: string): Promise<void> {
 }
 
 export function getSpeechToTextProvider(config: Config): SpeechToTextProvider {
-  return config.speechToText?.provider ?? "mistral";
+  return config.speechToText?.provider ?? "openai";
 }
 
 export function getSpeechToTextApiKey(config: Config, deps: CoreDeps): string | undefined {

--- a/src/tui/listen_capture.ts
+++ b/src/tui/listen_capture.ts
@@ -10,12 +10,10 @@ import {
 import type { CoreDeps } from "../core/runtime/deps.js";
 import type { SpawnCaptureResult } from "../core/utils/spawn_capture.js";
 import {
+  createSpeechToTextTranscription,
   type SpeechToTextDependencies,
   type SpeechToTextProgress,
-  type SpeechToTextResult,
-  type StreamingSpeechToText,
-  startStreamingSpeechToText,
-  transcribeAudio,
+  type SpeechToTextTranscription,
 } from "../core/utils/speech_to_text.js";
 import type { SpeechToTextContext } from "../core/utils/speech_to_text_context.js";
 
@@ -28,7 +26,7 @@ export type ListenRecording = {
   stopRequested: boolean;
   abortController: AbortController;
   completion: Promise<SpawnCaptureResult>;
-  streamingTranscription?: StreamingSpeechToText;
+  transcription: SpeechToTextTranscription;
   maxDurationTimeout?: ReturnType<typeof setTimeout>;
 };
 
@@ -50,7 +48,7 @@ export function startListenAudioCapture(args: {
   deps: CoreDeps;
   audioPath: string;
   signal: AbortSignal;
-  onAudioChunk?: (audio: Buffer) => void;
+  onAudioChunk: (audio: Buffer) => void;
 }): Promise<SpawnCaptureResult> {
   const inputArgs = [
     "-hide_banner",
@@ -68,7 +66,7 @@ export function startListenAudioCapture(args: {
     "-ac",
     "1",
     "-ar",
-    args.onAudioChunk ? "24000" : "16000",
+    "16000",
     "-c:a",
     "pcm_s16le",
     "-f",
@@ -76,24 +74,30 @@ export function startListenAudioCapture(args: {
     "-y",
     args.audioPath,
   ];
-  const streamOutputArgs = args.onAudioChunk
-    ? ["-map", "0:a", "-ac", "1", "-ar", "24000", "-c:a", "pcm_s16le", "-f", "s16le", "pipe:1"]
-    : [];
+  const streamOutputArgs = [
+    "-map",
+    "0:a",
+    "-ac",
+    "1",
+    "-ar",
+    "24000",
+    "-c:a",
+    "pcm_s16le",
+    "-f",
+    "s16le",
+    "pipe:1",
+  ];
 
   return args.deps.spawn("ffmpeg", [...inputArgs, ...waveOutputArgs, ...streamOutputArgs], {
     detached: true,
     killProcessGroup: true,
     signal: args.signal,
-    ...(args.onAudioChunk
-      ? {
-          captureOutput: "stderr" as const,
-          maxCaptureBytes: 20_000,
-          stdio: ["ignore", "pipe", "pipe"] as ["ignore", "pipe", "pipe"],
-          onSpawn: (child: ChildProcess) => {
-            child.stdout?.on("data", (chunk: Buffer) => args.onAudioChunk?.(chunk));
-          },
-        }
-      : { stdio: ["ignore", "ignore", "ignore"] as ["ignore", "ignore", "ignore"] }),
+    captureOutput: "stderr",
+    maxCaptureBytes: 20_000,
+    stdio: ["ignore", "pipe", "pipe"],
+    onSpawn: (child: ChildProcess) => {
+      child.stdout?.on("data", (chunk: Buffer) => args.onAudioChunk(chunk));
+    },
   });
 }
 
@@ -147,50 +151,27 @@ export function getSpeechToTextApiKeyErrorMessage(config: Config, action: string
   }
 }
 
-export async function startListenStreamingTranscription(args: {
+export function createListenTranscription(args: {
   config: Config;
   deps: CoreDeps;
-  context?: SpeechToTextContext;
-  speechToTextDeps?: SpeechToTextDependencies;
-}): Promise<StreamingSpeechToText | undefined> {
-  const provider = getSpeechToTextProvider(args.config);
-  const apiKey = getSpeechToTextApiKey(args.config, args.deps);
-  if (!apiKey) {
-    throw new Error(getSpeechToTextApiKeyErrorMessage(args.config, "transcribe speech"));
-  }
-
-  return await startStreamingSpeechToText({
-    provider,
-    apiKey,
-    context: args.context,
-    webSocketFactory: args.speechToTextDeps?.webSocketFactory,
-  });
-}
-
-export async function transcribeListenAudio(args: {
-  config: Config;
-  deps: CoreDeps;
-  audio: Buffer;
   context?: SpeechToTextContext;
   onProgress?: (progress: SpeechToTextProgress) => void;
   speechToTextDeps?: SpeechToTextDependencies;
-}): Promise<SpeechToTextResult> {
+}): SpeechToTextTranscription {
   const provider = getSpeechToTextProvider(args.config);
   const apiKey = getSpeechToTextApiKey(args.config, args.deps);
   if (!apiKey) {
     throw new Error(getSpeechToTextApiKeyErrorMessage(args.config, "transcribe speech"));
   }
 
-  return await transcribeAudio({
+  return createSpeechToTextTranscription({
     provider,
     apiKey,
-    audio: args.audio,
-    mimeType: "audio/wav",
-    fileName: "speech.wav",
-    language: "en",
     context: args.context,
     onProgress: args.onProgress,
-    webSocketFactory: args.speechToTextDeps?.webSocketFactory,
-    spawnImpl: args.speechToTextDeps?.spawnImpl ?? args.deps.spawn,
+    deps: {
+      ...args.speechToTextDeps,
+      spawnImpl: args.speechToTextDeps?.spawnImpl ?? args.deps.spawn,
+    },
   });
 }

--- a/src/tui/session_chat_controller.ts
+++ b/src/tui/session_chat_controller.ts
@@ -85,6 +85,7 @@ import { DOUBLE_PRESS_WINDOW_MS } from "./constants.js";
 import {
   cleanupListenTempFile,
   createListenTempFilePath,
+  createListenTranscription,
   deleteListenTempFile,
   getSpeechToTextApiKey,
   getSpeechToTextApiKeyErrorMessage,
@@ -93,8 +94,6 @@ import {
   type ListenRecording,
   readListenAudio,
   startListenAudioCapture,
-  startListenStreamingTranscription,
-  transcribeListenAudio,
 } from "./listen_capture.js";
 import {
   createSdkDiffSnapshotDeps,
@@ -827,23 +826,16 @@ export class SessionChatController {
     }
 
     let audioPath: string | undefined;
-    let streamingTranscription: ListenRecording["streamingTranscription"];
+    let transcription: ListenRecording["transcription"] | undefined;
     try {
       audioPath = await createListenTempFilePath(this.deps);
-      streamingTranscription = await startListenStreamingTranscription({
-        config: this.config,
-        deps: this.deps,
-        context: collectSpeechToTextContext(this.snapshot),
-        speechToTextDeps: this.speechToTextDeps,
-      });
+      transcription = this.createSpeechTranscription();
       const abortController = new AbortController();
       const completion = startListenAudioCapture({
         deps: this.deps,
         audioPath,
         signal: abortController.signal,
-        onAudioChunk: streamingTranscription
-          ? (audio) => streamingTranscription?.appendAudio(audio)
-          : undefined,
+        onAudioChunk: (audio) => transcription?.appendAudio(audio),
       });
 
       const recording: ListenRecording = {
@@ -851,7 +843,7 @@ export class SessionChatController {
         stopRequested: false,
         abortController,
         completion,
-        ...(streamingTranscription ? { streamingTranscription } : {}),
+        transcription,
       };
       recording.maxDurationTimeout = setTimeout(() => {
         if (this.listenRecording !== recording || this.listenTransition) return;
@@ -862,7 +854,7 @@ export class SessionChatController {
       this.refreshStatus();
       void this.watchListenRecording(recording);
     } catch (err) {
-      streamingTranscription?.abort();
+      transcription?.abort();
       if (audioPath) {
         await cleanupListenTempFile(audioPath);
       }
@@ -885,13 +877,13 @@ export class SessionChatController {
     try {
       await recording.completion;
     } catch (err) {
-      recording.streamingTranscription?.abort();
+      recording.transcription.abort();
       this.view.addTranscriptNotice("failed to record audio", "error", [(err as Error).message]);
       await cleanupListenTempFile(recording.audioPath);
       return;
     }
 
-    await this.transcribeListenAudioFile(recording.audioPath, recording.streamingTranscription);
+    await this.transcribeListenAudioFile(recording.audioPath, recording.transcription);
   }
 
   private async retryRetainedListenAudio(): Promise<void> {
@@ -933,15 +925,31 @@ export class SessionChatController {
     }
   }
 
+  private createSpeechTranscription(): ListenRecording["transcription"] {
+    return createListenTranscription({
+      config: this.config,
+      deps: this.deps,
+      context: collectSpeechToTextContext(this.snapshot),
+      onProgress: (progress) => {
+        this.listenActivityLabel =
+          progress === "retrying"
+            ? "retrying voice transcription"
+            : "trying fallback transcription model";
+        this.refreshStatus();
+      },
+      speechToTextDeps: this.speechToTextDeps,
+    });
+  }
+
   private async transcribeListenAudioFile(
     audioPath: string,
-    streamingTranscription?: ListenRecording["streamingTranscription"],
+    transcription?: ListenRecording["transcription"],
   ): Promise<void> {
     let audio: Buffer;
     try {
       audio = await readListenAudio(audioPath);
     } catch (error) {
-      streamingTranscription?.abort();
+      transcription?.abort();
       this.view.addTranscriptNotice("failed to read speech recording", "error", [
         (error as Error).message,
       ]);
@@ -953,7 +961,7 @@ export class SessionChatController {
     }
 
     if (audio.byteLength < LISTEN_RECORDING_MIN_BYTES) {
-      streamingTranscription?.abort();
+      transcription?.abort();
       this.view.showFooterNotice("recording too short, try again", "default");
       if (this.retainedListenAudioPath === audioPath) {
         this.retainedListenAudioPath = undefined;
@@ -962,25 +970,17 @@ export class SessionChatController {
       return;
     }
 
+    let activeTranscription = transcription;
     this.listenActivityLabel = "transcribing voice input";
     this.refreshStatus();
     try {
-      const result = streamingTranscription
-        ? { text: await streamingTranscription.finish(), usedFallback: false }
-        : await transcribeListenAudio({
-            config: this.config,
-            deps: this.deps,
-            audio,
-            context: collectSpeechToTextContext(this.snapshot),
-            onProgress: (progress) => {
-              this.listenActivityLabel =
-                progress === "retrying"
-                  ? "retrying voice transcription"
-                  : "trying fallback transcription model";
-              this.refreshStatus();
-            },
-            speechToTextDeps: this.speechToTextDeps,
-          });
+      activeTranscription ??= this.createSpeechTranscription();
+      const result = await activeTranscription.finish({
+        audio,
+        mimeType: "audio/wav",
+        fileName: "speech.wav",
+        language: "en",
+      });
       this.view.insertEditorTextAtCursor(result.text);
       if (result.usedFallback) {
         this.view.showFooterNotice("transcribed with fallback model", "default");
@@ -1002,6 +1002,7 @@ export class SessionChatController {
         "run /listen retry to try again, or /listen discard to delete it",
       ]);
     } finally {
+      activeTranscription?.abort();
       this.listenActivityLabel = undefined;
       this.refreshStatus();
     }
@@ -1018,7 +1019,7 @@ export class SessionChatController {
     this.refreshStatus();
 
     recording.abortController.abort();
-    recording.streamingTranscription?.abort();
+    recording.transcription.abort();
     try {
       await recording.completion;
     } catch {
@@ -1034,7 +1035,7 @@ export class SessionChatController {
       if (this.listenRecording !== recording || recording.stopRequested) return;
 
       this.listenRecording = undefined;
-      recording.streamingTranscription?.abort();
+      recording.transcription.abort();
       this.view.setEditorInputEnabled(true);
       this.refreshStatus();
       const detail =
@@ -1050,7 +1051,7 @@ export class SessionChatController {
       if (this.listenRecording !== recording || recording.stopRequested) return;
 
       this.listenRecording = undefined;
-      recording.streamingTranscription?.abort();
+      recording.transcription.abort();
       this.view.setEditorInputEnabled(true);
       this.refreshStatus();
       const error = err as NodeJS.ErrnoException;

--- a/src/tui/session_chat_controller.ts
+++ b/src/tui/session_chat_controller.ts
@@ -28,6 +28,7 @@ import { TOOL_NAME_BASH } from "../core/tools/tool_names.js";
 import { REASONING_LEVELS, type ReasoningEffort } from "../core/types.js";
 import { formatAdaptiveNumber, formatCwd, formatTokenWindow } from "../core/utils/format.js";
 import { extractAssistantText } from "../core/utils/messages.js";
+import type { SpeechToTextDependencies } from "../core/utils/speech_to_text.js";
 import { collectSpeechToTextContext } from "../core/utils/speech_to_text_context.js";
 import { hasAutoCompactionContinuationMetadata } from "../core/utils/user_metadata.js";
 import { APP_VERSION } from "../core/version.js";
@@ -92,6 +93,7 @@ import {
   type ListenRecording,
   readListenAudio,
   startListenAudioCapture,
+  startListenStreamingTranscription,
   transcribeListenAudio,
 } from "./listen_capture.js";
 import {
@@ -113,6 +115,7 @@ export type SessionChatControllerOptions = {
   defaultDiffTool?: DiffToolConfig;
   diffToolLauncher?: DiffReviewToolLauncher;
   deps?: CoreDeps;
+  speechToTextDeps?: SpeechToTextDependencies;
   themeIds?: string[];
   onExit?: () => void;
 };
@@ -127,6 +130,7 @@ export class SessionChatController {
   private readonly defaultDiffTool?: DiffToolConfig;
   private readonly diffToolLauncher?: DiffReviewToolLauncher;
   private readonly deps: CoreDeps;
+  private readonly speechToTextDeps?: SpeechToTextDependencies;
   private readonly themeIds: string[];
   private readonly commandRegistry: CommandRegistry<CommandDispatchContext>;
   private readonly commandHandlers: CommandDispatchContext;
@@ -184,6 +188,7 @@ export class SessionChatController {
     this.defaultDiffTool = options.defaultDiffTool;
     this.diffToolLauncher = options.diffToolLauncher;
     this.deps = options.deps ?? createDefaultCoreDeps();
+    this.speechToTextDeps = options.speechToTextDeps;
     this.themeIds = options.themeIds ?? [];
     this.observedSessionRevision = options.snapshot.revision;
     this.commandRegistry = createCommandRegistry();
@@ -822,13 +827,23 @@ export class SessionChatController {
     }
 
     let audioPath: string | undefined;
+    let streamingTranscription: ListenRecording["streamingTranscription"];
     try {
       audioPath = await createListenTempFilePath(this.deps);
+      streamingTranscription = await startListenStreamingTranscription({
+        config: this.config,
+        deps: this.deps,
+        context: collectSpeechToTextContext(this.snapshot),
+        speechToTextDeps: this.speechToTextDeps,
+      });
       const abortController = new AbortController();
       const completion = startListenAudioCapture({
         deps: this.deps,
         audioPath,
         signal: abortController.signal,
+        onAudioChunk: streamingTranscription
+          ? (audio) => streamingTranscription?.appendAudio(audio)
+          : undefined,
       });
 
       const recording: ListenRecording = {
@@ -836,6 +851,7 @@ export class SessionChatController {
         stopRequested: false,
         abortController,
         completion,
+        ...(streamingTranscription ? { streamingTranscription } : {}),
       };
       recording.maxDurationTimeout = setTimeout(() => {
         if (this.listenRecording !== recording || this.listenTransition) return;
@@ -846,6 +862,7 @@ export class SessionChatController {
       this.refreshStatus();
       void this.watchListenRecording(recording);
     } catch (err) {
+      streamingTranscription?.abort();
       if (audioPath) {
         await cleanupListenTempFile(audioPath);
       }
@@ -868,12 +885,13 @@ export class SessionChatController {
     try {
       await recording.completion;
     } catch (err) {
+      recording.streamingTranscription?.abort();
       this.view.addTranscriptNotice("failed to record audio", "error", [(err as Error).message]);
       await cleanupListenTempFile(recording.audioPath);
       return;
     }
 
-    await this.transcribeListenAudioFile(recording.audioPath);
+    await this.transcribeListenAudioFile(recording.audioPath, recording.streamingTranscription);
   }
 
   private async retryRetainedListenAudio(): Promise<void> {
@@ -915,11 +933,15 @@ export class SessionChatController {
     }
   }
 
-  private async transcribeListenAudioFile(audioPath: string): Promise<void> {
+  private async transcribeListenAudioFile(
+    audioPath: string,
+    streamingTranscription?: ListenRecording["streamingTranscription"],
+  ): Promise<void> {
     let audio: Buffer;
     try {
       audio = await readListenAudio(audioPath);
     } catch (error) {
+      streamingTranscription?.abort();
       this.view.addTranscriptNotice("failed to read speech recording", "error", [
         (error as Error).message,
       ]);
@@ -931,6 +953,7 @@ export class SessionChatController {
     }
 
     if (audio.byteLength < LISTEN_RECORDING_MIN_BYTES) {
+      streamingTranscription?.abort();
       this.view.showFooterNotice("recording too short, try again", "default");
       if (this.retainedListenAudioPath === audioPath) {
         this.retainedListenAudioPath = undefined;
@@ -942,19 +965,22 @@ export class SessionChatController {
     this.listenActivityLabel = "transcribing voice input";
     this.refreshStatus();
     try {
-      const result = await transcribeListenAudio({
-        config: this.config,
-        deps: this.deps,
-        audio,
-        context: collectSpeechToTextContext(this.snapshot),
-        onProgress: (progress) => {
-          this.listenActivityLabel =
-            progress === "retrying"
-              ? "retrying voice transcription"
-              : "trying fallback transcription model";
-          this.refreshStatus();
-        },
-      });
+      const result = streamingTranscription
+        ? { text: await streamingTranscription.finish(), usedFallback: false }
+        : await transcribeListenAudio({
+            config: this.config,
+            deps: this.deps,
+            audio,
+            context: collectSpeechToTextContext(this.snapshot),
+            onProgress: (progress) => {
+              this.listenActivityLabel =
+                progress === "retrying"
+                  ? "retrying voice transcription"
+                  : "trying fallback transcription model";
+              this.refreshStatus();
+            },
+            speechToTextDeps: this.speechToTextDeps,
+          });
       this.view.insertEditorTextAtCursor(result.text);
       if (result.usedFallback) {
         this.view.showFooterNotice("transcribed with fallback model", "default");
@@ -992,6 +1018,7 @@ export class SessionChatController {
     this.refreshStatus();
 
     recording.abortController.abort();
+    recording.streamingTranscription?.abort();
     try {
       await recording.completion;
     } catch {
@@ -1007,6 +1034,7 @@ export class SessionChatController {
       if (this.listenRecording !== recording || recording.stopRequested) return;
 
       this.listenRecording = undefined;
+      recording.streamingTranscription?.abort();
       this.view.setEditorInputEnabled(true);
       this.refreshStatus();
       const detail =
@@ -1022,6 +1050,7 @@ export class SessionChatController {
       if (this.listenRecording !== recording || recording.stopRequested) return;
 
       this.listenRecording = undefined;
+      recording.streamingTranscription?.abort();
       this.view.setEditorInputEnabled(true);
       this.refreshStatus();
       const error = err as NodeJS.ErrnoException;

--- a/src/tui/session_chat_controller.ts
+++ b/src/tui/session_chat_controller.ts
@@ -168,6 +168,7 @@ export class SessionChatController {
   private listenRecording?: ListenRecording;
   private retainedListenAudioPath?: string;
   private listenTransition?: Promise<void>;
+  private activeListenTranscription?: ListenRecording["transcription"];
   private listenActivityLabel?: string;
   private speechActivityLabel?: string;
   private speakTask?: {
@@ -248,6 +249,7 @@ export class SessionChatController {
     this.ephemeralUnsubscribe?.();
     this.pendingUserMessagesUnsubscribe?.();
     this.subagentActivitiesUnsubscribe?.();
+    this.activeListenTranscription?.abort();
     if (this.listenTransition) {
       await this.listenTransition;
     }
@@ -812,31 +814,41 @@ export class SessionChatController {
     }
 
     const retainedAudioPath = this.retainedListenAudioPath;
-    if (retainedAudioPath) {
-      try {
-        await deleteListenTempFile(retainedAudioPath);
-        this.retainedListenAudioPath = undefined;
-      } catch (error) {
-        this.view.addTranscriptNotice("failed to replace retained recording", "error", [
-          (error as Error).message,
-          `recording retained at ${retainedAudioPath}`,
-        ]);
-        return;
-      }
-    }
-
     let audioPath: string | undefined;
     let transcription: ListenRecording["transcription"] | undefined;
+    let abortController: AbortController | undefined;
+    let completion: ListenRecording["completion"] | undefined;
     try {
       audioPath = await createListenTempFilePath(this.deps);
       transcription = this.createSpeechTranscription();
-      const abortController = new AbortController();
-      const completion = startListenAudioCapture({
+      abortController = new AbortController();
+      const capture = startListenAudioCapture({
         deps: this.deps,
         audioPath,
         signal: abortController.signal,
         onAudioChunk: (audio) => transcription?.appendAudio(audio),
       });
+      completion = capture.completion;
+      await capture.started;
+
+      if (retainedAudioPath) {
+        try {
+          await deleteListenTempFile(retainedAudioPath);
+          if (this.retainedListenAudioPath === retainedAudioPath) {
+            this.retainedListenAudioPath = undefined;
+          }
+        } catch (error) {
+          abortController.abort();
+          transcription.abort();
+          await completion.catch(() => undefined);
+          await cleanupListenTempFile(audioPath);
+          this.view.addTranscriptNotice("failed to replace retained recording", "error", [
+            (error as Error).message,
+            `recording retained at ${retainedAudioPath}`,
+          ]);
+          return;
+        }
+      }
 
       const recording: ListenRecording = {
         audioPath,
@@ -854,7 +866,9 @@ export class SessionChatController {
       this.refreshStatus();
       void this.watchListenRecording(recording);
     } catch (err) {
+      abortController?.abort();
       transcription?.abort();
+      await completion?.catch(() => undefined);
       if (audioPath) {
         await cleanupListenTempFile(audioPath);
       }
@@ -975,6 +989,7 @@ export class SessionChatController {
     this.refreshStatus();
     try {
       activeTranscription ??= this.createSpeechTranscription();
+      this.activeListenTranscription = activeTranscription;
       const result = await activeTranscription.finish({
         audio,
         mimeType: "audio/wav",
@@ -1003,6 +1018,9 @@ export class SessionChatController {
       ]);
     } finally {
       activeTranscription?.abort();
+      if (this.activeListenTranscription === activeTranscription) {
+        this.activeListenTranscription = undefined;
+      }
       this.listenActivityLabel = undefined;
       this.refreshStatus();
     }

--- a/src/tui/session_chat_controller.ts
+++ b/src/tui/session_chat_controller.ts
@@ -84,6 +84,7 @@ import { DOUBLE_PRESS_WINDOW_MS } from "./constants.js";
 import {
   cleanupListenTempFile,
   createListenTempFilePath,
+  deleteListenTempFile,
   getSpeechToTextApiKey,
   getSpeechToTextApiKeyErrorMessage,
   LISTEN_RECORDING_MAX_DURATION_MS,
@@ -162,8 +163,9 @@ export class SessionChatController {
   private turnTimer?: ReturnType<typeof setInterval>;
   private lastEmptySubmitAt?: number;
   private listenRecording?: ListenRecording;
+  private retainedListenAudioPath?: string;
   private listenTransition?: Promise<void>;
-  private isTranscribingListen = false;
+  private listenActivityLabel?: string;
   private speechActivityLabel?: string;
   private speakTask?: {
     abortController: AbortController;
@@ -197,7 +199,7 @@ export class SessionChatController {
       compactSummaryOnly: (extra) => this.compactSession("summary-only", extra),
       compactSummaryAndLast: (extra) => this.compactSession("summary-and-last", extra),
       reload: () => this.reloadContent(),
-      listen: () => this.startListenCaptureFromCommand(),
+      listen: (action) => this.handleListenCommand(action),
       speak: () => this.speakLastAssistantMessage(),
       persona: (id) => this.setPersona(id),
       prompt: (id) => this.insertPrompt(id),
@@ -727,6 +729,20 @@ export class SessionChatController {
     }
   }
 
+  private async handleListenCommand(action: "record" | "retry" | "discard"): Promise<void> {
+    switch (action) {
+      case "record":
+        await this.startListenCaptureFromCommand();
+        return;
+      case "retry":
+        await this.retryRetainedListenAudio();
+        return;
+      case "discard":
+        await this.discardRetainedListenAudio();
+        return;
+    }
+  }
+
   private async toggleListenCapture(): Promise<void> {
     if (this.listenTransition) {
       this.view.showFooterNotice("speech recording state change already in progress", "default");
@@ -752,7 +768,7 @@ export class SessionChatController {
       return;
     }
 
-    if (this.isTranscribingListen) {
+    if (this.listenActivityLabel) {
       this.view.showFooterNotice("speech transcription already in progress", "default");
       return;
     }
@@ -789,6 +805,20 @@ export class SessionChatController {
         getSpeechToTextApiKeyErrorMessage(this.config, "use /listen"),
       ]);
       return;
+    }
+
+    const retainedAudioPath = this.retainedListenAudioPath;
+    if (retainedAudioPath) {
+      try {
+        await deleteListenTempFile(retainedAudioPath);
+        this.retainedListenAudioPath = undefined;
+      } catch (error) {
+        this.view.addTranscriptNotice("failed to replace retained recording", "error", [
+          (error as Error).message,
+          `recording retained at ${retainedAudioPath}`,
+        ]);
+        return;
+      }
     }
 
     let audioPath: string | undefined;
@@ -843,35 +873,111 @@ export class SessionChatController {
       return;
     }
 
-    this.isTranscribingListen = true;
+    await this.transcribeListenAudioFile(recording.audioPath);
+  }
+
+  private async retryRetainedListenAudio(): Promise<void> {
+    if (this.listenRecording || this.listenTransition || this.listenActivityLabel) {
+      this.view.showFooterNotice("speech recording state change already in progress", "default");
+      return;
+    }
+
+    const audioPath = this.retainedListenAudioPath;
+    if (!audioPath) {
+      this.view.showFooterNotice("no failed speech recording to retry", "default");
+      return;
+    }
+
+    await this.runListenTransition(() => this.transcribeListenAudioFile(audioPath));
+  }
+
+  private async discardRetainedListenAudio(): Promise<void> {
+    if (this.listenRecording || this.listenTransition || this.listenActivityLabel) {
+      this.view.showFooterNotice("speech recording state change already in progress", "default");
+      return;
+    }
+
+    const audioPath = this.retainedListenAudioPath;
+    if (!audioPath) {
+      this.view.showFooterNotice("no failed speech recording to discard", "default");
+      return;
+    }
+
+    try {
+      await deleteListenTempFile(audioPath);
+      this.retainedListenAudioPath = undefined;
+      this.view.showFooterNotice("discarded retained speech recording", "default");
+    } catch (error) {
+      this.view.addTranscriptNotice("failed to discard speech recording", "error", [
+        (error as Error).message,
+        `recording retained at ${audioPath}`,
+      ]);
+    }
+  }
+
+  private async transcribeListenAudioFile(audioPath: string): Promise<void> {
+    let audio: Buffer;
+    try {
+      audio = await readListenAudio(audioPath);
+    } catch (error) {
+      this.view.addTranscriptNotice("failed to read speech recording", "error", [
+        (error as Error).message,
+      ]);
+      if (this.retainedListenAudioPath === audioPath) {
+        this.retainedListenAudioPath = undefined;
+      }
+      await cleanupListenTempFile(audioPath);
+      return;
+    }
+
+    if (audio.byteLength < LISTEN_RECORDING_MIN_BYTES) {
+      this.view.showFooterNotice("recording too short, try again", "default");
+      if (this.retainedListenAudioPath === audioPath) {
+        this.retainedListenAudioPath = undefined;
+      }
+      await cleanupListenTempFile(audioPath);
+      return;
+    }
+
+    this.listenActivityLabel = "transcribing voice input";
     this.refreshStatus();
     try {
-      const audio = await readListenAudio(recording.audioPath);
-      if (audio.byteLength < LISTEN_RECORDING_MIN_BYTES) {
-        this.view.showFooterNotice("recording too short, try again", "default");
-        return;
-      }
-
-      const transcript = await transcribeListenAudio({
+      const result = await transcribeListenAudio({
         config: this.config,
         deps: this.deps,
         audio,
         context: collectSpeechToTextContext(this.snapshot),
+        onProgress: (progress) => {
+          this.listenActivityLabel =
+            progress === "retrying"
+              ? "retrying voice transcription"
+              : "trying fallback transcription model";
+          this.refreshStatus();
+        },
       });
-      const text = transcript.trim();
-      if (!text) {
-        return;
+      this.view.insertEditorTextAtCursor(result.text);
+      if (result.usedFallback) {
+        this.view.showFooterNotice("transcribed with fallback model", "default");
       }
-
-      this.view.insertEditorTextAtCursor(text);
-    } catch (err) {
+      this.retainedListenAudioPath = undefined;
+      try {
+        await deleteListenTempFile(audioPath);
+      } catch (error) {
+        this.view.addTranscriptNotice("failed to delete speech recording", "error", [
+          (error as Error).message,
+          `recording remains at ${audioPath}; delete it manually`,
+        ]);
+      }
+    } catch (error) {
+      this.retainedListenAudioPath = audioPath;
       this.view.addTranscriptNotice("failed to transcribe speech", "error", [
-        (err as Error).message,
+        (error as Error).message,
+        `recording retained at ${audioPath}`,
+        "run /listen retry to try again, or /listen discard to delete it",
       ]);
     } finally {
-      this.isTranscribingListen = false;
+      this.listenActivityLabel = undefined;
       this.refreshStatus();
-      await cleanupListenTempFile(recording.audioPath);
     }
   }
 
@@ -1951,8 +2057,8 @@ export class SessionChatController {
     if (this.manualCompactionInProgress || this.hasRunningCompactionOperation(this.snapshot)) {
       return "compacting context";
     }
-    if (this.isTranscribingListen) {
-      return "transcribing voice input";
+    if (this.listenActivityLabel) {
+      return this.listenActivityLabel;
     }
     return this.diffReviewService.getActivityLabel(this.speechActivityLabel);
   }
@@ -2158,7 +2264,7 @@ export class SessionChatController {
       !this.isSessionOperationActive() &&
       !this.listenRecording &&
       !this.listenTransition &&
-      !this.isTranscribingListen &&
+      !this.listenActivityLabel &&
       !this.speakTask
     );
   }

--- a/src/tui/session_chat_controller.ts
+++ b/src/tui/session_chat_controller.ts
@@ -89,6 +89,7 @@ import {
   deleteListenTempFile,
   getSpeechToTextApiKey,
   getSpeechToTextApiKeyErrorMessage,
+  LISTEN_CAPTURE_START_TIMEOUT_MS,
   LISTEN_RECORDING_MAX_DURATION_MS,
   LISTEN_RECORDING_MIN_BYTES,
   type ListenRecording,
@@ -118,6 +119,8 @@ export type SessionChatControllerOptions = {
   themeIds?: string[];
   onExit?: () => void;
 };
+
+const LISTEN_CAPTURE_START_CANCELLED = Symbol("listen capture start cancelled");
 
 export class SessionChatController {
   private readonly view: ChatView;
@@ -168,6 +171,7 @@ export class SessionChatController {
   private listenRecording?: ListenRecording;
   private retainedListenAudioPath?: string;
   private listenTransition?: Promise<void>;
+  private listenStartupAbortController?: AbortController;
   private activeListenTranscription?: ListenRecording["transcription"];
   private listenActivityLabel?: string;
   private speechActivityLabel?: string;
@@ -249,6 +253,7 @@ export class SessionChatController {
     this.ephemeralUnsubscribe?.();
     this.pendingUserMessagesUnsubscribe?.();
     this.subagentActivitiesUnsubscribe?.();
+    this.listenStartupAbortController?.abort(LISTEN_CAPTURE_START_CANCELLED);
     this.activeListenTranscription?.abort();
     if (this.listenTransition) {
       await this.listenTransition;
@@ -704,6 +709,12 @@ export class SessionChatController {
       return;
     }
 
+    if (this.listenStartupAbortController) {
+      this.listenStartupAbortController.abort(LISTEN_CAPTURE_START_CANCELLED);
+      this.view.showFooterNotice("interrupted", "default");
+      return;
+    }
+
     if (this.listenRecording) {
       void this.runListenTransition(() => this.stopListenCapture());
       return;
@@ -751,7 +762,12 @@ export class SessionChatController {
 
   private async toggleListenCapture(): Promise<void> {
     if (this.listenTransition) {
-      this.view.showFooterNotice("speech recording state change already in progress", "default");
+      if (this.listenStartupAbortController) {
+        this.listenStartupAbortController.abort(LISTEN_CAPTURE_START_CANCELLED);
+        this.view.showFooterNotice("cancelled speech recording startup", "default");
+      } else {
+        this.view.showFooterNotice("speech recording state change already in progress", "default");
+      }
       return;
     }
 
@@ -820,8 +836,9 @@ export class SessionChatController {
     let completion: ListenRecording["completion"] | undefined;
     try {
       audioPath = await createListenTempFilePath(this.deps);
-      transcription = this.createSpeechTranscription();
+      transcription = this.createSpeechTranscription("streaming");
       abortController = new AbortController();
+      this.listenStartupAbortController = abortController;
       const capture = startListenAudioCapture({
         deps: this.deps,
         audioPath,
@@ -829,7 +846,13 @@ export class SessionChatController {
         onAudioChunk: (audio) => transcription?.appendAudio(audio),
       });
       completion = capture.completion;
-      await capture.started;
+      await this.waitForListenCaptureStart(capture.started, abortController);
+      if (abortController.signal.aborted) {
+        throw abortController.signal.reason;
+      }
+      if (this.listenStartupAbortController === abortController) {
+        this.listenStartupAbortController = undefined;
+      }
 
       if (retainedAudioPath) {
         try {
@@ -866,13 +889,44 @@ export class SessionChatController {
       this.refreshStatus();
       void this.watchListenRecording(recording);
     } catch (err) {
+      const cancelled = abortController?.signal.reason === LISTEN_CAPTURE_START_CANCELLED;
       abortController?.abort();
       transcription?.abort();
       await completion?.catch(() => undefined);
       if (audioPath) {
         await cleanupListenTempFile(audioPath);
       }
-      this.view.addTranscriptNotice("failed to start recording", "error", [(err as Error).message]);
+      if (!cancelled) {
+        this.view.addTranscriptNotice("failed to start recording", "error", [
+          (err as Error).message,
+        ]);
+      }
+    } finally {
+      if (this.listenStartupAbortController === abortController) {
+        this.listenStartupAbortController = undefined;
+      }
+    }
+  }
+
+  private async waitForListenCaptureStart(
+    started: Promise<void>,
+    abortController: AbortController,
+  ): Promise<void> {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        started,
+        new Promise<never>((_resolve, reject) => {
+          timeout = setTimeout(() => {
+            const error = new Error("timed out waiting for microphone audio");
+            abortController.abort(error);
+            reject(error);
+          }, LISTEN_CAPTURE_START_TIMEOUT_MS);
+          timeout.unref?.();
+        }),
+      ]);
+    } finally {
+      if (timeout) clearTimeout(timeout);
     }
   }
 
@@ -939,18 +993,12 @@ export class SessionChatController {
     }
   }
 
-  private createSpeechTranscription(): ListenRecording["transcription"] {
+  private createSpeechTranscription(mode: "streaming" | "file"): ListenRecording["transcription"] {
     return createListenTranscription({
       config: this.config,
       deps: this.deps,
+      mode,
       context: collectSpeechToTextContext(this.snapshot),
-      onProgress: (progress) => {
-        this.listenActivityLabel =
-          progress === "retrying"
-            ? "retrying voice transcription"
-            : "trying fallback transcription model";
-        this.refreshStatus();
-      },
       speechToTextDeps: this.speechToTextDeps,
     });
   }
@@ -988,18 +1036,15 @@ export class SessionChatController {
     this.listenActivityLabel = "transcribing voice input";
     this.refreshStatus();
     try {
-      activeTranscription ??= this.createSpeechTranscription();
+      activeTranscription ??= this.createSpeechTranscription("file");
       this.activeListenTranscription = activeTranscription;
-      const result = await activeTranscription.finish({
+      const text = await activeTranscription.finish({
         audio,
         mimeType: "audio/wav",
         fileName: "speech.wav",
         language: "en",
       });
-      this.view.insertEditorTextAtCursor(result.text);
-      if (result.usedFallback) {
-        this.view.showFooterNotice("transcribed with fallback model", "default");
-      }
+      this.view.insertEditorTextAtCursor(text);
       this.retainedListenAudioPath = undefined;
       try {
         await deleteListenTempFile(audioPath);

--- a/src/tui/speech_playback.ts
+++ b/src/tui/speech_playback.ts
@@ -1,11 +1,13 @@
 import { unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { CoreDeps } from "../core/runtime/deps.js";
 import {
   GEMINI_SPEECH_PLAYBACK_RATE,
   streamGeminiSpeechAudio,
 } from "../core/utils/gemini_speech.js";
 
-export const SPEAK_TEMP_FILE_TEMPLATE = "/tmp/tau-speak.XXXXXX";
+export const SPEAK_TEMP_FILE_TEMPLATE = join(tmpdir(), "tau-speak.XXXXXX");
 
 export async function runSpeechPlaybackTask(args: {
   deps: CoreDeps;

--- a/test/config_layers.test.js
+++ b/test/config_layers.test.js
@@ -14,6 +14,7 @@ import { describe, expect, it } from "vitest";
 import { resolveConfigLevels } from "../dist/core/config/paths.js";
 import {
   getApiKeyForProvider,
+  getOpenAIApiKey,
   loadConfig,
   loadConfigWithDiagnostics,
 } from "../dist/core/config/schema.js";
@@ -179,6 +180,7 @@ describe("config paths", () => {
         JSON.stringify({
           defaultPersona: "custom-persona",
           agentContextFiles: ["AGENTS.md"],
+          speechToText: { provider: "openai" },
         }),
       );
 
@@ -209,7 +211,7 @@ describe("config paths", () => {
       expect(config.subagents).toEqual({
         defaultLaunchModels: ["openai/gpt-5.4:high"],
       });
-      expect(config.speechToText).toEqual({ provider: "gemini" });
+      expect(config.speechToText).toEqual({ provider: "openai" });
       expect(config.history).toEqual({
         endpoint: "https://history.example.com",
         apiKeyEnv: "HISTORY_KEY",
@@ -416,6 +418,18 @@ describe("config paths", () => {
     } finally {
       fx.cleanup();
     }
+  });
+
+  it("prefers OPENAI_API_KEY for OpenAI speech transcription", () => {
+    expect(
+      getOpenAIApiKey(
+        { apiKeys: { openai: "configured-openai-key" } },
+        { OPENAI_API_KEY: "environment-openai-key" },
+      ),
+    ).toBe("environment-openai-key");
+    expect(getOpenAIApiKey({ apiKeys: { openai: "configured-openai-key" } }, {})).toBe(
+      "configured-openai-key",
+    );
   });
 
   it("rejects modelSystemNotices for unknown model ids", () => {

--- a/test/gemini_transcription.test.js
+++ b/test/gemini_transcription.test.js
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { transcribeGeminiAudio } from "../dist/core/utils/gemini_transcription.js";
 
 describe("gemini transcription", () => {
-  it("transcribes audio with low thinking", async () => {
+  it("transcribes audio with Gemini 3.7 Flash and low thinking", async () => {
     const fetchMock = vi.fn(
       async () =>
         new Response(
@@ -38,7 +38,7 @@ describe("gemini transcription", () => {
       },
     });
 
-    expect(transcript).toEqual({ text: "ship the fix", usedFallback: false });
+    expect(transcript).toBe("ship the fix");
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock.mock.calls[0][0]).toContain(
       "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.7-flash:generateContent",
@@ -91,90 +91,7 @@ describe("gemini transcription", () => {
     expect(request.generationConfig.thinkingConfig.thinkingLevel).toBe("low");
   });
 
-  it("retries a transient failure on the primary model", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ error: { message: "service unavailable" } }), {
-          status: 503,
-          headers: { "Retry-After": "0" },
-        }),
-      )
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            candidates: [
-              {
-                content: {
-                  parts: [{ text: JSON.stringify({ transcription: "recovered transcript" }) }],
-                },
-              },
-            ],
-          }),
-        ),
-      );
-    const onProgress = vi.fn();
-
-    const result = await transcribeGeminiAudio({
-      apiKey: "gemini-key",
-      audio: Buffer.from("audio payload"),
-      fetchImpl: fetchMock,
-      onProgress,
-    });
-
-    expect(result).toEqual({ text: "recovered transcript", usedFallback: false });
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
-      expect.stringContaining("gemini-3.7-flash"),
-      expect.stringContaining("gemini-3.7-flash"),
-    ]);
-    expect(onProgress).toHaveBeenCalledWith("retrying");
-  });
-
-  it("uses Gemini 3.6 with minimal thinking after primary attempts fail", async () => {
-    const unavailable = () =>
-      new Response(
-        JSON.stringify({ error: { message: "model unavailable", status: "UNAVAILABLE" } }),
-        { status: 503, headers: { "Retry-After": "0" } },
-      );
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(unavailable())
-      .mockResolvedValueOnce(unavailable())
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            candidates: [
-              {
-                content: {
-                  parts: [{ text: JSON.stringify({ transcription: "fallback transcript" }) }],
-                },
-              },
-            ],
-          }),
-        ),
-      );
-    const onProgress = vi.fn();
-
-    const result = await transcribeGeminiAudio({
-      apiKey: "gemini-key",
-      audio: Buffer.from("audio payload"),
-      fetchImpl: fetchMock,
-      onProgress,
-    });
-
-    expect(result).toEqual({ text: "fallback transcript", usedFallback: true });
-    expect(fetchMock).toHaveBeenCalledTimes(3);
-    expect(fetchMock.mock.calls[2][0]).toContain("gemini-3.6-flash");
-    const fallbackRequest = JSON.parse(fetchMock.mock.calls[2][1].body);
-    expect(fallbackRequest.generationConfig.thinkingConfig.thinkingLevel).toBe("minimal");
-    expect(onProgress.mock.calls.map(([progress]) => progress)).toEqual([
-      "retrying",
-      "trying-fallback",
-    ]);
-  });
-
-  it("advances through the fallback chain for malformed successful responses", async () => {
+  it("rejects malformed successful responses without retrying", async () => {
     const fetchMock = vi.fn(async () => new Response(JSON.stringify({ candidates: [] })));
 
     await expect(
@@ -184,14 +101,15 @@ describe("gemini transcription", () => {
         fetchImpl: fetchMock,
       }),
     ).rejects.toThrow("transcription result was empty or malformed");
-    expect(fetchMock).toHaveBeenCalledTimes(3);
-    expect(fetchMock.mock.calls[2][0]).toContain("gemini-3.6-flash");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it("does not retry permanent request failures", async () => {
+  it("reports provider failures without retrying", async () => {
     const fetchMock = vi.fn(
       async () =>
-        new Response(JSON.stringify({ error: { message: "invalid API key" } }), { status: 401 }),
+        new Response(JSON.stringify({ error: { message: "service unavailable" } }), {
+          status: 503,
+        }),
     );
 
     await expect(
@@ -200,7 +118,7 @@ describe("gemini transcription", () => {
         audio: Buffer.from("audio payload"),
         fetchImpl: fetchMock,
       }),
-    ).rejects.toThrow("invalid API key");
+    ).rejects.toThrow("service unavailable");
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/gemini_transcription.test.js
+++ b/test/gemini_transcription.test.js
@@ -38,7 +38,7 @@ describe("gemini transcription", () => {
       },
     });
 
-    expect(transcript).toBe("ship the fix");
+    expect(transcript).toEqual({ text: "ship the fix", usedFallback: false });
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock.mock.calls[0][0]).toContain(
       "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.7-flash:generateContent",
@@ -89,5 +89,118 @@ describe("gemini transcription", () => {
       required: ["transcription"],
     });
     expect(request.generationConfig.thinkingConfig.thinkingLevel).toBe("low");
+  });
+
+  it("retries a transient failure on the primary model", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: { message: "service unavailable" } }), {
+          status: 503,
+          headers: { "Retry-After": "0" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            candidates: [
+              {
+                content: {
+                  parts: [{ text: JSON.stringify({ transcription: "recovered transcript" }) }],
+                },
+              },
+            ],
+          }),
+        ),
+      );
+    const onProgress = vi.fn();
+
+    const result = await transcribeGeminiAudio({
+      apiKey: "gemini-key",
+      audio: Buffer.from("audio payload"),
+      fetchImpl: fetchMock,
+      onProgress,
+    });
+
+    expect(result).toEqual({ text: "recovered transcript", usedFallback: false });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      expect.stringContaining("gemini-3.7-flash"),
+      expect.stringContaining("gemini-3.7-flash"),
+    ]);
+    expect(onProgress).toHaveBeenCalledWith("retrying");
+  });
+
+  it("uses Gemini 3.6 with minimal thinking after primary attempts fail", async () => {
+    const unavailable = () =>
+      new Response(
+        JSON.stringify({ error: { message: "model unavailable", status: "UNAVAILABLE" } }),
+        { status: 503, headers: { "Retry-After": "0" } },
+      );
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(unavailable())
+      .mockResolvedValueOnce(unavailable())
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            candidates: [
+              {
+                content: {
+                  parts: [{ text: JSON.stringify({ transcription: "fallback transcript" }) }],
+                },
+              },
+            ],
+          }),
+        ),
+      );
+    const onProgress = vi.fn();
+
+    const result = await transcribeGeminiAudio({
+      apiKey: "gemini-key",
+      audio: Buffer.from("audio payload"),
+      fetchImpl: fetchMock,
+      onProgress,
+    });
+
+    expect(result).toEqual({ text: "fallback transcript", usedFallback: true });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[2][0]).toContain("gemini-3.6-flash");
+    const fallbackRequest = JSON.parse(fetchMock.mock.calls[2][1].body);
+    expect(fallbackRequest.generationConfig.thinkingConfig.thinkingLevel).toBe("minimal");
+    expect(onProgress.mock.calls.map(([progress]) => progress)).toEqual([
+      "retrying",
+      "trying-fallback",
+    ]);
+  });
+
+  it("advances through the fallback chain for malformed successful responses", async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ candidates: [] })));
+
+    await expect(
+      transcribeGeminiAudio({
+        apiKey: "gemini-key",
+        audio: Buffer.from("audio payload"),
+        fetchImpl: fetchMock,
+      }),
+    ).rejects.toThrow("transcription result was empty or malformed");
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[2][0]).toContain("gemini-3.6-flash");
+  });
+
+  it("does not retry permanent request failures", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ error: { message: "invalid API key" } }), { status: 401 }),
+    );
+
+    await expect(
+      transcribeGeminiAudio({
+        apiKey: "gemini-key",
+        audio: Buffer.from("audio payload"),
+        fetchImpl: fetchMock,
+      }),
+    ).rejects.toThrow("invalid API key");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/openai_transcription.test.js
+++ b/test/openai_transcription.test.js
@@ -105,7 +105,7 @@ describe("OpenAI transcription", () => {
             format: { type: "audio/pcm", rate: 24000 },
             transcription: {
               model: "gpt-live-transcribe",
-              delay: "low",
+              delay: "medium",
               prompt: expect.stringContaining("The repository is called Tau."),
             },
             turn_detection: null,

--- a/test/openai_transcription.test.js
+++ b/test/openai_transcription.test.js
@@ -1,0 +1,196 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import {
+  startOpenAITranscription,
+  transcribeOpenAIAudio,
+} from "../dist/core/utils/openai_transcription.js";
+
+class FakeOpenAISocket extends EventEmitter {
+  sent = [];
+  closed = false;
+  terminated = false;
+
+  constructor(transcript = "streamed transcript") {
+    super();
+    this.transcript = transcript;
+  }
+
+  open() {
+    this.emit("open");
+  }
+
+  send(data, callback) {
+    const event = JSON.parse(data);
+    this.sent.push(event);
+    callback?.();
+
+    if (event.type === "session.update") {
+      queueMicrotask(() =>
+        this.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" }))),
+      );
+    }
+    if (event.type === "input_audio_buffer.commit") {
+      queueMicrotask(() =>
+        this.emit(
+          "message",
+          Buffer.from(
+            JSON.stringify({
+              type: "conversation.item.input_audio_transcription.completed",
+              item_id: "item-1",
+              content_index: 0,
+              transcript: this.transcript,
+            }),
+          ),
+        ),
+      );
+    }
+  }
+
+  close() {
+    this.closed = true;
+  }
+
+  terminate() {
+    this.terminated = true;
+  }
+}
+
+function createWebSocketHarness(transcript) {
+  const socket = new FakeOpenAISocket(transcript);
+  const factory = vi.fn((_url, _options) => {
+    queueMicrotask(() => socket.open());
+    return socket;
+  });
+  return { socket, factory };
+}
+
+function successfulSpawnResult() {
+  return {
+    stdout: "",
+    stderr: "",
+    output: undefined,
+    exitCode: 0,
+    captureLimitExceeded: false,
+    timedOut: false,
+    aborted: false,
+    closeSignal: null,
+  };
+}
+
+describe("OpenAI transcription", () => {
+  it("streams live PCM and returns only the completed transcript", async () => {
+    const harness = createWebSocketHarness("final transcript");
+    const transcription = await startOpenAITranscription({
+      apiKey: "openai-key",
+      context: {
+        messages: [{ role: "assistant", text: "The repository is called Tau." }],
+      },
+      webSocketFactory: harness.factory,
+    });
+
+    transcription.appendAudio(Buffer.from([1, 2, 3, 4]));
+    const transcript = await transcription.finish();
+
+    expect(transcript).toBe("final transcript");
+    expect(harness.factory).toHaveBeenCalledWith(
+      "wss://api.openai.com/v1/realtime?intent=transcription",
+      { headers: { Authorization: "Bearer openai-key" } },
+    );
+    expect(harness.socket.sent[0]).toMatchObject({
+      type: "session.update",
+      session: {
+        type: "transcription",
+        audio: {
+          input: {
+            format: { type: "audio/pcm", rate: 24000 },
+            transcription: {
+              model: "gpt-live-transcribe",
+              delay: "low",
+              prompt: expect.stringContaining("The repository is called Tau."),
+            },
+            turn_detection: null,
+          },
+        },
+      },
+    });
+    expect(harness.socket.sent.slice(1)).toEqual([
+      {
+        type: "input_audio_buffer.append",
+        audio: Buffer.from([1, 2, 3, 4]).toString("base64"),
+      },
+      { type: "input_audio_buffer.commit" },
+    ]);
+    expect(harness.socket.closed).toBe(true);
+  });
+
+  it("decodes completed audio to PCM before replaying it through a realtime session", async () => {
+    const harness = createWebSocketHarness("telegram transcript");
+    const audio = Buffer.from("encoded audio");
+    const pcm = Buffer.from([5, 6, 7, 8]);
+    const spawnImpl = vi.fn(async (_command, _args, options) => {
+      const stdout = new EventEmitter();
+      options.onSpawn({ stdout });
+      stdout.emit("data", pcm);
+      return successfulSpawnResult();
+    });
+
+    const transcript = await transcribeOpenAIAudio({
+      apiKey: "openai-key",
+      audio,
+      webSocketFactory: harness.factory,
+      spawnImpl,
+    });
+
+    expect(transcript).toBe("telegram transcript");
+    expect(spawnImpl).toHaveBeenCalledWith(
+      "ffmpeg",
+      expect.arrayContaining(["-i", "pipe:0", "-ar", "24000", "-f", "s16le", "pipe:1"]),
+      expect.objectContaining({
+        input: audio,
+        captureOutput: "stderr",
+        stdio: ["pipe", "pipe", "pipe"],
+      }),
+    );
+    expect(harness.socket.sent).toContainEqual({
+      type: "input_audio_buffer.append",
+      audio: pcm.toString("base64"),
+    });
+  });
+
+  it("rejects an empty completed transcript", async () => {
+    const socket = new FakeOpenAISocket();
+    socket.send = function send(data, callback) {
+      const event = JSON.parse(data);
+      this.sent.push(event);
+      callback?.();
+      if (event.type === "session.update") {
+        queueMicrotask(() => this.emit("message", JSON.stringify({ type: "session.updated" })));
+      }
+      if (event.type === "input_audio_buffer.commit") {
+        queueMicrotask(() =>
+          this.emit(
+            "message",
+            JSON.stringify({
+              type: "conversation.item.input_audio_transcription.completed",
+              transcript: "",
+            }),
+          ),
+        );
+      }
+    };
+    const factory = () => {
+      queueMicrotask(() => socket.open());
+      return socket;
+    };
+    const transcription = await startOpenAITranscription({
+      apiKey: "openai-key",
+      webSocketFactory: factory,
+    });
+    transcription.appendAudio(Buffer.from([1, 2]));
+
+    await expect(transcription.finish()).rejects.toThrow(
+      "transcription result was empty or malformed",
+    );
+    expect(socket.terminated).toBe(true);
+  });
+});

--- a/test/openai_transcription.test.js
+++ b/test/openai_transcription.test.js
@@ -7,6 +7,7 @@ import {
 
 class FakeOpenAISocket extends EventEmitter {
   sent = [];
+  bufferedAmount = 0;
   closed = false;
   terminated = false;
 
@@ -155,6 +156,140 @@ describe("OpenAI transcription", () => {
       type: "input_audio_buffer.append",
       audio: pcm.toString("base64"),
     });
+  });
+
+  it("cancels audio decoding when the realtime session fails", async () => {
+    const harness = createWebSocketHarness();
+    let decoderSignal;
+    const spawnImpl = vi.fn(async (_command, _args, options) => {
+      decoderSignal = options.signal;
+      options.onSpawn({ stdout: new EventEmitter() });
+      return await new Promise((resolve) => {
+        options.signal.addEventListener("abort", () => {
+          resolve({ ...successfulSpawnResult(), aborted: true });
+        });
+      });
+    });
+
+    const transcription = transcribeOpenAIAudio({
+      apiKey: "openai-key",
+      audio: Buffer.from("encoded audio"),
+      webSocketFactory: harness.factory,
+      spawnImpl,
+    });
+    await vi.waitFor(() => expect(spawnImpl).toHaveBeenCalledOnce());
+
+    harness.socket.emit("error", new Error("connection lost"));
+
+    await expect(transcription).rejects.toThrow(
+      "OpenAI transcription connection failed: connection lost",
+    );
+    expect(decoderSignal.aborted).toBe(true);
+  });
+
+  it("cancels audio decoding when the owner aborts", async () => {
+    const harness = createWebSocketHarness();
+    const abortController = new AbortController();
+    let decoderSignal;
+    const spawnImpl = vi.fn(async (_command, _args, options) => {
+      decoderSignal = options.signal;
+      options.onSpawn({ stdout: new EventEmitter() });
+      return await new Promise((resolve) => {
+        options.signal.addEventListener("abort", () => {
+          resolve({ ...successfulSpawnResult(), aborted: true });
+        });
+      });
+    });
+
+    const transcription = transcribeOpenAIAudio({
+      apiKey: "openai-key",
+      audio: Buffer.from("encoded audio"),
+      signal: abortController.signal,
+      webSocketFactory: harness.factory,
+      spawnImpl,
+    });
+    await vi.waitFor(() => expect(spawnImpl).toHaveBeenCalledOnce());
+
+    abortController.abort();
+
+    await expect(transcription).rejects.toThrow("OpenAI transcription was aborted");
+    expect(decoderSignal.aborted).toBe(true);
+  });
+
+  it("backpressures decoded audio while the websocket send buffer is full", async () => {
+    const harness = createWebSocketHarness("backpressured transcript");
+    let resolveAudioSend;
+    harness.socket.send = function send(data, callback) {
+      const event = JSON.parse(data);
+      this.sent.push(event);
+      if (event.type === "session.update") {
+        callback?.();
+        queueMicrotask(() => this.emit("message", JSON.stringify({ type: "session.updated" })));
+        return;
+      }
+      if (event.type === "input_audio_buffer.append") {
+        this.bufferedAmount = 2 * 1024 * 1024;
+        resolveAudioSend = callback;
+        return;
+      }
+      callback?.();
+      if (event.type === "input_audio_buffer.commit") {
+        queueMicrotask(() =>
+          this.emit(
+            "message",
+            JSON.stringify({
+              type: "conversation.item.input_audio_transcription.completed",
+              transcript: this.transcript,
+            }),
+          ),
+        );
+      }
+    };
+    const pause = vi.fn();
+    const resume = vi.fn();
+    const spawnImpl = vi.fn(async (_command, _args, options) => {
+      const stdout = Object.assign(new EventEmitter(), { pause, resume });
+      options.onSpawn({ stdout });
+      stdout.emit("data", Buffer.from([1, 2, 3, 4]));
+      expect(pause).toHaveBeenCalledOnce();
+      harness.socket.bufferedAmount = 0;
+      resolveAudioSend();
+      await vi.waitFor(() => expect(resume).toHaveBeenCalledOnce());
+      return successfulSpawnResult();
+    });
+
+    await expect(
+      transcribeOpenAIAudio({
+        apiKey: "openai-key",
+        audio: Buffer.from("encoded audio"),
+        webSocketFactory: harness.factory,
+        spawnImpl,
+      }),
+    ).resolves.toBe("backpressured transcript");
+  });
+
+  it("rejects decoded audio longer than five minutes", async () => {
+    const harness = createWebSocketHarness();
+    const spawnImpl = vi.fn(async (_command, _args, options) => {
+      const stdout = Object.assign(new EventEmitter(), { pause: vi.fn(), resume: vi.fn() });
+      options.onSpawn({ stdout });
+      const completion = new Promise((resolve) => {
+        options.signal.addEventListener("abort", () => {
+          resolve({ ...successfulSpawnResult(), aborted: true });
+        });
+      });
+      stdout.emit("data", Buffer.alloc(24_000 * 2 * 300 + 1));
+      return await completion;
+    });
+
+    await expect(
+      transcribeOpenAIAudio({
+        apiKey: "openai-key",
+        audio: Buffer.from("encoded audio"),
+        webSocketFactory: harness.factory,
+        spawnImpl,
+      }),
+    ).rejects.toThrow("audio exceeds the five-minute OpenAI transcription limit");
   });
 
   it("rejects an empty completed transcript", async () => {

--- a/test/openai_transcription.test.js
+++ b/test/openai_transcription.test.js
@@ -7,7 +7,6 @@ import {
 
 class FakeOpenAISocket extends EventEmitter {
   sent = [];
-  bufferedAmount = 0;
   closed = false;
   terminated = false;
 
@@ -81,7 +80,7 @@ function successfulSpawnResult() {
 describe("OpenAI transcription", () => {
   it("streams live PCM and returns only the completed transcript", async () => {
     const harness = createWebSocketHarness("final transcript");
-    const transcription = await startOpenAITranscription({
+    const transcription = startOpenAITranscription({
       apiKey: "openai-key",
       context: {
         messages: [{ role: "assistant", text: "The repository is called Tau." }],
@@ -124,8 +123,7 @@ describe("OpenAI transcription", () => {
     expect(harness.socket.closed).toBe(true);
   });
 
-  it("decodes completed audio to PCM before replaying it through a realtime session", async () => {
-    const harness = createWebSocketHarness("telegram transcript");
+  it("uploads completed audio through OpenAI file transcription", async () => {
     const audio = Buffer.from("encoded audio");
     const pcm = Buffer.from([5, 6, 7, 8]);
     const spawnImpl = vi.fn(async (_command, _args, options) => {
@@ -134,61 +132,53 @@ describe("OpenAI transcription", () => {
       stdout.emit("data", pcm);
       return successfulSpawnResult();
     });
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ text: "file transcript", languages: [{ code: "en" }] })),
+    );
 
     const transcript = await transcribeOpenAIAudio({
       apiKey: "openai-key",
       audio,
-      webSocketFactory: harness.factory,
+      context: {
+        messages: [{ role: "user", text: "We are discussing Tau." }],
+      },
+      fetchImpl,
       spawnImpl,
     });
 
-    expect(transcript).toBe("telegram transcript");
+    expect(transcript).toBe("file transcript");
     expect(spawnImpl).toHaveBeenCalledWith(
       "ffmpeg",
-      expect.arrayContaining(["-i", "pipe:0", "-ar", "24000", "-f", "s16le", "pipe:1"]),
+      expect.arrayContaining(["-i", "pipe:0", "-ar", "16000", "-f", "s16le", "pipe:1"]),
       expect.objectContaining({
         input: audio,
         captureOutput: "stderr",
         stdio: ["pipe", "pipe", "pipe"],
       }),
     );
-    expect(harness.socket.sent).toContainEqual({
-      type: "input_audio_buffer.append",
-      audio: pcm.toString("base64"),
-    });
-  });
-
-  it("cancels audio decoding when the realtime session fails", async () => {
-    const harness = createWebSocketHarness();
-    let decoderSignal;
-    const spawnImpl = vi.fn(async (_command, _args, options) => {
-      decoderSignal = options.signal;
-      options.onSpawn({ stdout: new EventEmitter() });
-      return await new Promise((resolve) => {
-        options.signal.addEventListener("abort", () => {
-          resolve({ ...successfulSpawnResult(), aborted: true });
-        });
-      });
-    });
-
-    const transcription = transcribeOpenAIAudio({
-      apiKey: "openai-key",
-      audio: Buffer.from("encoded audio"),
-      webSocketFactory: harness.factory,
-      spawnImpl,
-    });
-    await vi.waitFor(() => expect(spawnImpl).toHaveBeenCalledOnce());
-
-    harness.socket.emit("error", new Error("connection lost"));
-
-    await expect(transcription).rejects.toThrow(
-      "OpenAI transcription connection failed: connection lost",
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.openai.com/v1/audio/transcriptions",
+      expect.objectContaining({
+        method: "POST",
+        headers: { Authorization: "Bearer openai-key" },
+        body: expect.any(FormData),
+      }),
     );
-    expect(decoderSignal.aborted).toBe(true);
+    const form = fetchImpl.mock.calls[0][1].body;
+    expect(form.get("model")).toBe("gpt-transcribe");
+    expect(form.get("prompt")).toContain("We are discussing Tau.");
+    const file = form.get("file");
+    expect(file.name).toBe("speech.wav");
+    expect(file.type).toBe("audio/wav");
+    const wav = Buffer.from(await file.arrayBuffer());
+    expect(wav.subarray(0, 4).toString("ascii")).toBe("RIFF");
+    expect(wav.subarray(8, 12).toString("ascii")).toBe("WAVE");
+    expect(wav.readUInt32LE(24)).toBe(16_000);
+    expect(wav.subarray(44)).toEqual(pcm);
   });
 
-  it("cancels audio decoding when the owner aborts", async () => {
-    const harness = createWebSocketHarness();
+  it("cancels completed-audio decoding when the owner aborts", async () => {
     const abortController = new AbortController();
     let decoderSignal;
     const spawnImpl = vi.fn(async (_command, _args, options) => {
@@ -205,80 +195,27 @@ describe("OpenAI transcription", () => {
       apiKey: "openai-key",
       audio: Buffer.from("encoded audio"),
       signal: abortController.signal,
-      webSocketFactory: harness.factory,
+      fetchImpl: vi.fn(),
       spawnImpl,
     });
     await vi.waitFor(() => expect(spawnImpl).toHaveBeenCalledOnce());
 
-    abortController.abort();
+    abortController.abort(new Error("owner stopped"));
 
-    await expect(transcription).rejects.toThrow("OpenAI transcription was aborted");
+    await expect(transcription).rejects.toThrow("owner stopped");
     expect(decoderSignal.aborted).toBe(true);
   });
 
-  it("backpressures decoded audio while the websocket send buffer is full", async () => {
-    const harness = createWebSocketHarness("backpressured transcript");
-    let resolveAudioSend;
-    harness.socket.send = function send(data, callback) {
-      const event = JSON.parse(data);
-      this.sent.push(event);
-      if (event.type === "session.update") {
-        callback?.();
-        queueMicrotask(() => this.emit("message", JSON.stringify({ type: "session.updated" })));
-        return;
-      }
-      if (event.type === "input_audio_buffer.append") {
-        this.bufferedAmount = 2 * 1024 * 1024;
-        resolveAudioSend = callback;
-        return;
-      }
-      callback?.();
-      if (event.type === "input_audio_buffer.commit") {
-        queueMicrotask(() =>
-          this.emit(
-            "message",
-            JSON.stringify({
-              type: "conversation.item.input_audio_transcription.completed",
-              transcript: this.transcript,
-            }),
-          ),
-        );
-      }
-    };
-    const pause = vi.fn();
-    const resume = vi.fn();
-    const spawnImpl = vi.fn(async (_command, _args, options) => {
-      const stdout = Object.assign(new EventEmitter(), { pause, resume });
-      options.onSpawn({ stdout });
-      stdout.emit("data", Buffer.from([1, 2, 3, 4]));
-      expect(pause).toHaveBeenCalledOnce();
-      harness.socket.bufferedAmount = 0;
-      resolveAudioSend();
-      await vi.waitFor(() => expect(resume).toHaveBeenCalledOnce());
-      return successfulSpawnResult();
-    });
-
-    await expect(
-      transcribeOpenAIAudio({
-        apiKey: "openai-key",
-        audio: Buffer.from("encoded audio"),
-        webSocketFactory: harness.factory,
-        spawnImpl,
-      }),
-    ).resolves.toBe("backpressured transcript");
-  });
-
   it("rejects decoded audio longer than five minutes", async () => {
-    const harness = createWebSocketHarness();
     const spawnImpl = vi.fn(async (_command, _args, options) => {
-      const stdout = Object.assign(new EventEmitter(), { pause: vi.fn(), resume: vi.fn() });
+      const stdout = new EventEmitter();
       options.onSpawn({ stdout });
       const completion = new Promise((resolve) => {
         options.signal.addEventListener("abort", () => {
           resolve({ ...successfulSpawnResult(), aborted: true });
         });
       });
-      stdout.emit("data", Buffer.alloc(24_000 * 2 * 300 + 1));
+      stdout.emit("data", Buffer.alloc(16_000 * 2 * 300 + 1));
       return await completion;
     });
 
@@ -286,13 +223,53 @@ describe("OpenAI transcription", () => {
       transcribeOpenAIAudio({
         apiKey: "openai-key",
         audio: Buffer.from("encoded audio"),
-        webSocketFactory: harness.factory,
+        fetchImpl: vi.fn(),
         spawnImpl,
       }),
     ).rejects.toThrow("audio exceeds the five-minute OpenAI transcription limit");
   });
 
-  it("rejects an empty completed transcript", async () => {
+  it("reports OpenAI file transcription errors", async () => {
+    const spawnImpl = vi.fn(async (_command, _args, options) => {
+      const stdout = new EventEmitter();
+      options.onSpawn({ stdout });
+      stdout.emit("data", Buffer.from([1, 2]));
+      return successfulSpawnResult();
+    });
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ error: { message: "invalid audio" } }), { status: 400 }),
+    );
+
+    await expect(
+      transcribeOpenAIAudio({
+        apiKey: "openai-key",
+        audio: Buffer.from("encoded audio"),
+        fetchImpl,
+        spawnImpl,
+      }),
+    ).rejects.toThrow("invalid audio");
+  });
+
+  it("rejects an empty file transcript", async () => {
+    const spawnImpl = vi.fn(async (_command, _args, options) => {
+      const stdout = new EventEmitter();
+      options.onSpawn({ stdout });
+      stdout.emit("data", Buffer.from([1, 2]));
+      return successfulSpawnResult();
+    });
+
+    await expect(
+      transcribeOpenAIAudio({
+        apiKey: "openai-key",
+        audio: Buffer.from("encoded audio"),
+        fetchImpl: vi.fn(async () => new Response(JSON.stringify({ text: "" }))),
+        spawnImpl,
+      }),
+    ).rejects.toThrow("transcription result was empty or malformed");
+  });
+
+  it("rejects an empty completed realtime transcript", async () => {
     const socket = new FakeOpenAISocket();
     socket.send = function send(data, callback) {
       const event = JSON.parse(data);
@@ -317,7 +294,7 @@ describe("OpenAI transcription", () => {
       queueMicrotask(() => socket.open());
       return socket;
     };
-    const transcription = await startOpenAITranscription({
+    const transcription = startOpenAITranscription({
       apiKey: "openai-key",
       webSocketFactory: factory,
     });

--- a/test/session_chat_controller.test.js
+++ b/test/session_chat_controller.test.js
@@ -5258,7 +5258,7 @@ describe("SessionChatController", () => {
       snapshot: await session.snapshot(),
       targetLabel: "ws://host",
       deps: createMockDeps(spawn, "linux"),
-      config: { apiKeys: { mistral: "mistral-key" } },
+      config: { apiKeys: { openai: "openai-key" } },
     });
     controller.start();
 
@@ -5296,6 +5296,9 @@ describe("SessionChatController", () => {
       }
 
       if (cmd === "ffmpeg") {
+        const stdout = new EventEmitter();
+        options.onSpawn({ stdout });
+        queueMicrotask(() => stdout.emit("data", Buffer.from([1, 2, 3, 4])));
         return await new Promise((resolve) => {
           options.signal.addEventListener("abort", () => {
             resolve({
@@ -5327,7 +5330,10 @@ describe("SessionChatController", () => {
       snapshot: await session.snapshot(),
       targetLabel: "ws://host",
       deps: createMockDeps(spawn),
-      config: { apiKeys: { mistral: "mistral-key" } },
+      config: {
+        speechToText: { provider: "mistral" },
+        apiKeys: { mistral: "mistral-key" },
+      },
     });
 
     try {
@@ -5415,9 +5421,9 @@ describe("SessionChatController", () => {
       if (command === "ffmpeg") {
         const stdout = new EventEmitter();
         options.onSpawn({ stdout });
+        queueMicrotask(() => stdout.emit("data", pcm));
         return await new Promise((resolve) => {
           options.signal.addEventListener("abort", () => {
-            stdout.emit("data", pcm);
             resolve({
               stdout: "",
               stderr: "",
@@ -5441,10 +5447,7 @@ describe("SessionChatController", () => {
       snapshot: await session.snapshot(),
       targetLabel: "in-process",
       deps: createMockDeps(spawn),
-      config: {
-        speechToText: { provider: "openai" },
-        apiKeys: { openai: "openai-key" },
-      },
+      config: { apiKeys: { openai: "openai-key" } },
       speechToTextDeps: { webSocketFactory },
     });
 
@@ -5575,7 +5578,10 @@ describe("SessionChatController", () => {
       snapshot: await session.snapshot(),
       targetLabel: "in-process",
       deps: createMockDeps(),
-      config: { apiKeys: { mistral: "mistral-key" } },
+      config: {
+        speechToText: { provider: "mistral" },
+        apiKeys: { mistral: "mistral-key" },
+      },
     });
     controller.listenRecording = {
       audioPath,
@@ -5623,7 +5629,10 @@ describe("SessionChatController", () => {
       snapshot: await session.snapshot(),
       targetLabel: "in-process",
       deps: createMockDeps(),
-      config: { apiKeys: { mistral: "mistral-key" } },
+      config: {
+        speechToText: { provider: "mistral" },
+        apiKeys: { mistral: "mistral-key" },
+      },
     });
     controller.listenRecording = {
       audioPath,
@@ -5697,6 +5706,9 @@ describe("SessionChatController", () => {
         };
       }
       if (command === "ffmpeg") {
+        const stdout = new EventEmitter();
+        options.onSpawn({ stdout });
+        queueMicrotask(() => stdout.emit("data", Buffer.from([1, 2, 3, 4])));
         return await new Promise((resolve) => {
           options.signal.addEventListener("abort", () => {
             resolve({
@@ -5721,7 +5733,10 @@ describe("SessionChatController", () => {
       snapshot: await session.snapshot(),
       targetLabel: "in-process",
       deps: createMockDeps(spawn),
-      config: { apiKeys: { mistral: "mistral-key" } },
+      config: {
+        speechToText: { provider: "mistral" },
+        apiKeys: { mistral: "mistral-key" },
+      },
     });
     controller.retainedListenAudioPath = retainedPath;
 
@@ -5734,6 +5749,68 @@ describe("SessionChatController", () => {
       await rm(retainedPath, { force: true });
       await rm(nextPath, { force: true });
     }
+  });
+
+  it("keeps retained voice input when replacement capture fails to start", async () => {
+    const retainedPath = join(tmpdir(), `tau-session-listen-preserved-${Date.now()}.wav`);
+    const nextPath = join(tmpdir(), `tau-session-listen-failed-${Date.now()}.wav`);
+    await writeFile(retainedPath, Buffer.alloc(2048, 1));
+    const spawn = vi.fn(async (command) => {
+      if (command === "mktemp") {
+        return {
+          stdout: `${nextPath}\n`,
+          stderr: "",
+          output: undefined,
+          exitCode: 0,
+          captureLimitExceeded: false,
+          timedOut: false,
+          aborted: false,
+          closeSignal: null,
+        };
+      }
+      if (command === "ffmpeg") {
+        return {
+          stdout: "",
+          stderr: "audio device unavailable",
+          output: undefined,
+          exitCode: 1,
+          captureLimitExceeded: false,
+          timedOut: false,
+          aborted: false,
+          closeSignal: null,
+        };
+      }
+      throw new Error(`unexpected command: ${command}`);
+    });
+    const session = new FakeSession();
+    const view = new FakeView();
+    const controller = new SessionChatController({
+      view,
+      session,
+      snapshot: await session.snapshot(),
+      targetLabel: "in-process",
+      deps: createMockDeps(spawn),
+      config: {
+        speechToText: { provider: "mistral" },
+        apiKeys: { mistral: "mistral-key" },
+      },
+    });
+    controller.retainedListenAudioPath = retainedPath;
+
+    try {
+      await controller.onUserInput("/listen");
+      await expect(readFile(retainedPath)).resolves.toHaveLength(2048);
+    } finally {
+      await rm(retainedPath, { force: true });
+      await rm(nextPath, { force: true });
+    }
+
+    expect(controller.retainedListenAudioPath).toBe(retainedPath);
+    expect(view.transcriptNotices.at(-1)).toEqual({
+      text: "failed to start recording",
+      tone: "error",
+      content: ["ffmpeg failed to start recording: audio device unavailable"],
+    });
   });
 
   it("keeps retained voice input on shutdown", async () => {

--- a/test/session_chat_controller.test.js
+++ b/test/session_chat_controller.test.js
@@ -1,3 +1,4 @@
+import { EventEmitter } from "node:events";
 import { readFile, rm, writeFile } from "node:fs/promises";
 import { createConnection } from "node:net";
 import { tmpdir } from "node:os";
@@ -5368,6 +5369,119 @@ describe("SessionChatController", () => {
       }),
     );
     expect(session.submit).not.toHaveBeenCalled();
+  });
+
+  it("streams OpenAI transcription while recording and inserts only the final transcript", async () => {
+    const audioPath = join(tmpdir(), `tau-session-listen-openai-${Date.now()}.wav`);
+    const socket = new EventEmitter();
+    const socketEvents = [];
+    socket.send = vi.fn((data, callback) => {
+      const event = JSON.parse(data);
+      socketEvents.push(event);
+      callback?.();
+      if (event.type === "session.update") {
+        queueMicrotask(() => socket.emit("message", JSON.stringify({ type: "session.updated" })));
+      }
+      if (event.type === "input_audio_buffer.commit") {
+        queueMicrotask(() =>
+          socket.emit(
+            "message",
+            JSON.stringify({
+              type: "conversation.item.input_audio_transcription.completed",
+              transcript: "live transcript",
+            }),
+          ),
+        );
+      }
+    });
+    socket.close = vi.fn();
+    socket.terminate = vi.fn();
+    const webSocketFactory = vi.fn(() => {
+      queueMicrotask(() => socket.emit("open"));
+      return socket;
+    });
+    const pcm = Buffer.from([1, 2, 3, 4]);
+    const spawn = vi.fn(async (command, _args, options = {}) => {
+      if (command === "mktemp") {
+        return {
+          stdout: `${audioPath}\n`,
+          stderr: "",
+          output: undefined,
+          exitCode: 0,
+          captureLimitExceeded: false,
+          timedOut: false,
+          aborted: false,
+          closeSignal: null,
+        };
+      }
+      if (command === "ffmpeg") {
+        const stdout = new EventEmitter();
+        options.onSpawn({ stdout });
+        return await new Promise((resolve) => {
+          options.signal.addEventListener("abort", () => {
+            stdout.emit("data", pcm);
+            resolve({
+              stdout: "",
+              stderr: "",
+              output: undefined,
+              exitCode: 0,
+              captureLimitExceeded: false,
+              timedOut: false,
+              aborted: true,
+              closeSignal: null,
+            });
+          });
+        });
+      }
+      throw new Error(`unexpected command: ${command}`);
+    });
+    const session = new FakeSession();
+    const view = new FakeView();
+    const controller = new SessionChatController({
+      view,
+      session,
+      snapshot: await session.snapshot(),
+      targetLabel: "in-process",
+      deps: createMockDeps(spawn),
+      config: {
+        speechToText: { provider: "openai" },
+        apiKeys: { openai: "openai-key" },
+      },
+      speechToTextDeps: { webSocketFactory },
+    });
+
+    try {
+      controller.start();
+      await controller.onUserInput("/listen");
+      expect(view.status.editor.mode).toBe("recording");
+      await writeFile(audioPath, Buffer.alloc(2048, 1));
+
+      controller.getInputHandlers().onCtrlY();
+      for (let i = 0; i < 50 && view.editorText !== "live transcript"; i += 1) {
+        await flush();
+        await waitMs(1);
+      }
+    } finally {
+      await controller.dispose();
+      await rm(audioPath, { force: true });
+    }
+
+    expect(view.editorText).toBe("live transcript");
+    expect(socketEvents.map((event) => event.type)).toEqual([
+      "session.update",
+      "input_audio_buffer.append",
+      "input_audio_buffer.commit",
+    ]);
+    expect(socketEvents[1].audio).toBe(pcm.toString("base64"));
+    expect(spawn).toHaveBeenNthCalledWith(
+      2,
+      "ffmpeg",
+      expect.arrayContaining(["-ar", "24000", "-f", "s16le", "pipe:1"]),
+      expect.objectContaining({
+        captureOutput: "stderr",
+        stdio: ["ignore", "pipe", "pipe"],
+      }),
+    );
   });
 
   it("shows Gemini retry and fallback progress while transcribing voice input", async () => {

--- a/test/session_chat_controller.test.js
+++ b/test/session_chat_controller.test.js
@@ -23,6 +23,7 @@ import { TauSessionProtocolResponseError } from "../dist/transport/errors.js";
 import { formatDiffReviewUserMessage } from "../dist/tui/chat_controller/diff_review_user_message.js";
 import { formatRewindCandidateAge } from "../dist/tui/chat_controller/history_labels.js";
 import { copyTextToClipboard } from "../dist/tui/clipboard.js";
+import { LISTEN_CAPTURE_START_TIMEOUT_MS } from "../dist/tui/listen_capture.js";
 import { createTuiClientTools, SessionChatApp } from "../dist/tui/session_chat_app.js";
 import { SessionChatController } from "../dist/tui/session_chat_controller.js";
 import {
@@ -5363,7 +5364,7 @@ describe("SessionChatController", () => {
       }),
     );
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(spawn).toHaveBeenNthCalledWith(1, "mktemp", ["/tmp/tau-listen.XXXXXX"]);
+    expect(spawn).toHaveBeenNthCalledWith(1, "mktemp", [join(tmpdir(), "tau-listen.XXXXXX")]);
     expect(spawn).toHaveBeenNthCalledWith(
       2,
       "ffmpeg",
@@ -5487,34 +5488,28 @@ describe("SessionChatController", () => {
     );
   });
 
-  it("shows Gemini retry and fallback progress while transcribing voice input", async () => {
-    const audioPath = join(tmpdir(), `tau-session-listen-fallback-${Date.now()}.wav`);
+  it("retries retained OpenAI audio through file transcription", async () => {
+    const audioPath = join(tmpdir(), `tau-session-listen-openai-retry-${Date.now()}.wav`);
     await writeFile(audioPath, Buffer.alloc(2048, 1));
-    const unavailable = () =>
-      new Response(JSON.stringify({ error: { message: "model unavailable" } }), {
-        status: 503,
-        headers: { "Retry-After": "0" },
-      });
-    vi.stubGlobal(
-      "fetch",
-      vi
-        .fn()
-        .mockResolvedValueOnce(unavailable())
-        .mockResolvedValueOnce(unavailable())
-        .mockResolvedValueOnce(
-          new Response(
-            JSON.stringify({
-              candidates: [
-                {
-                  content: {
-                    parts: [{ text: JSON.stringify({ transcription: "fallback transcript" }) }],
-                  },
-                },
-              ],
-            }),
-          ),
-        ),
+    const spawnImpl = vi.fn(async (_command, _args, options) => {
+      const stdout = new EventEmitter();
+      options.onSpawn({ stdout });
+      stdout.emit("data", Buffer.from([1, 2, 3, 4]));
+      return {
+        stdout: "",
+        stderr: "",
+        output: undefined,
+        exitCode: 0,
+        captureLimitExceeded: false,
+        timedOut: false,
+        aborted: false,
+        closeSignal: null,
+      };
+    });
+    const fetchImpl = vi.fn(
+      async () => new Response(JSON.stringify({ text: "retried file transcript" })),
     );
+    const webSocketFactory = vi.fn();
     const session = new FakeSession();
     const view = new FakeView();
     const controller = new SessionChatController({
@@ -5523,42 +5518,24 @@ describe("SessionChatController", () => {
       snapshot: await session.snapshot(),
       targetLabel: "in-process",
       deps: createMockDeps(),
-      config: {
-        speechToText: { provider: "gemini" },
-        apiKeys: { google: "gemini-key" },
-      },
+      config: { apiKeys: { openai: "openai-key" } },
+      speechToTextDeps: { fetchImpl, spawnImpl, webSocketFactory },
     });
-    controller.listenRecording = {
-      audioPath,
-      stopRequested: false,
-      abortController: new AbortController(),
-      completion: Promise.resolve(),
-    };
+    controller.retainedListenAudioPath = audioPath;
 
     try {
-      await controller.stopListenCapture();
+      await controller.onUserInput("/listen retry");
+      await expect(readFile(audioPath)).rejects.toMatchObject({ code: "ENOENT" });
     } finally {
-      vi.unstubAllGlobals();
       await rm(audioPath, { force: true });
     }
 
-    expect(view.editorText).toBe("fallback transcript");
-    expect(
-      view.statusUpdates.flatMap((status) =>
-        status.footer.type === "activity" ? [status.footer.label] : [],
-      ),
-    ).toEqual(
-      expect.arrayContaining([
-        "transcribing voice input",
-        "retrying voice transcription",
-        "trying fallback transcription model",
-      ]),
+    expect(view.editorText).toBe("retried file transcript");
+    expect(webSocketFactory).not.toHaveBeenCalled();
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.openai.com/v1/audio/transcriptions",
+      expect.objectContaining({ body: expect.any(FormData) }),
     );
-    expect(view.footerNotices).toContainEqual({
-      text: "transcribed with fallback model",
-      tone: "default",
-      durationMs: 3000,
-    });
   });
 
   it("retains failed voice input and retries it into the editor", async () => {
@@ -5813,6 +5790,149 @@ describe("SessionChatController", () => {
     });
   });
 
+  it("times out stalled recording startup without deleting retained voice input", async () => {
+    const retainedPath = join(tmpdir(), `tau-session-listen-timeout-retained-${Date.now()}.wav`);
+    const nextPath = join(tmpdir(), `tau-session-listen-timeout-next-${Date.now()}.wav`);
+    await writeFile(retainedPath, Buffer.alloc(2048, 1));
+    const spawn = vi.fn(async (command, _args, options = {}) => {
+      if (command === "mktemp") {
+        return {
+          stdout: `${nextPath}\n`,
+          stderr: "",
+          output: undefined,
+          exitCode: 0,
+          captureLimitExceeded: false,
+          timedOut: false,
+          aborted: false,
+          closeSignal: null,
+        };
+      }
+      if (command === "ffmpeg") {
+        options.onSpawn({ stdout: new EventEmitter() });
+        return await new Promise((resolve) => {
+          options.signal.addEventListener("abort", () => {
+            resolve({
+              stdout: "",
+              stderr: "",
+              output: undefined,
+              exitCode: null,
+              captureLimitExceeded: false,
+              timedOut: false,
+              aborted: true,
+              closeSignal: "SIGTERM",
+            });
+          });
+        });
+      }
+      throw new Error(`unexpected command: ${command}`);
+    });
+    const session = new FakeSession();
+    const view = new FakeView();
+    const controller = new SessionChatController({
+      view,
+      session,
+      snapshot: await session.snapshot(),
+      targetLabel: "in-process",
+      deps: createMockDeps(spawn),
+      config: {
+        speechToText: { provider: "mistral" },
+        apiKeys: { mistral: "mistral-key" },
+      },
+    });
+    controller.retainedListenAudioPath = retainedPath;
+
+    vi.useFakeTimers();
+    try {
+      const start = controller.onUserInput("/listen");
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(LISTEN_CAPTURE_START_TIMEOUT_MS);
+      await start;
+      await expect(readFile(retainedPath)).resolves.toHaveLength(2048);
+    } finally {
+      vi.useRealTimers();
+      await rm(retainedPath, { force: true });
+      await rm(nextPath, { force: true });
+    }
+
+    expect(controller.retainedListenAudioPath).toBe(retainedPath);
+    expect(view.transcriptNotices.at(-1)).toEqual({
+      text: "failed to start recording",
+      tone: "error",
+      content: ["timed out waiting for microphone audio"],
+    });
+  });
+
+  it("cancels stalled recording startup during shutdown", async () => {
+    const retainedPath = join(tmpdir(), `tau-session-listen-cancel-retained-${Date.now()}.wav`);
+    const nextPath = join(tmpdir(), `tau-session-listen-cancel-next-${Date.now()}.wav`);
+    await writeFile(retainedPath, Buffer.alloc(2048, 1));
+    let captureSignal;
+    const spawn = vi.fn(async (command, _args, options = {}) => {
+      if (command === "mktemp") {
+        return {
+          stdout: `${nextPath}\n`,
+          stderr: "",
+          output: undefined,
+          exitCode: 0,
+          captureLimitExceeded: false,
+          timedOut: false,
+          aborted: false,
+          closeSignal: null,
+        };
+      }
+      if (command === "ffmpeg") {
+        captureSignal = options.signal;
+        options.onSpawn({ stdout: new EventEmitter() });
+        return await new Promise((resolve) => {
+          options.signal.addEventListener("abort", () => {
+            resolve({
+              stdout: "",
+              stderr: "",
+              output: undefined,
+              exitCode: null,
+              captureLimitExceeded: false,
+              timedOut: false,
+              aborted: true,
+              closeSignal: "SIGTERM",
+            });
+          });
+        });
+      }
+      throw new Error(`unexpected command: ${command}`);
+    });
+    const session = new FakeSession();
+    const view = new FakeView();
+    const controller = new SessionChatController({
+      view,
+      session,
+      snapshot: await session.snapshot(),
+      targetLabel: "in-process",
+      deps: createMockDeps(spawn),
+      config: {
+        speechToText: { provider: "mistral" },
+        apiKeys: { mistral: "mistral-key" },
+      },
+    });
+    controller.retainedListenAudioPath = retainedPath;
+
+    try {
+      const start = controller.onUserInput("/listen");
+      await waitUntil(() => captureSignal !== undefined);
+      await controller.dispose();
+      await start;
+      await expect(readFile(retainedPath)).resolves.toHaveLength(2048);
+    } finally {
+      await rm(retainedPath, { force: true });
+      await rm(nextPath, { force: true });
+    }
+
+    expect(captureSignal.aborted).toBe(true);
+    expect(controller.retainedListenAudioPath).toBe(retainedPath);
+    expect(view.transcriptNotices).not.toContainEqual(
+      expect.objectContaining({ text: "failed to start recording" }),
+    );
+  });
+
   it("keeps retained voice input on shutdown", async () => {
     const audioPath = join(tmpdir(), `tau-session-listen-shutdown-${Date.now()}.wav`);
     await writeFile(audioPath, Buffer.alloc(2048, 1));
@@ -5975,7 +6095,7 @@ describe("SessionChatController", () => {
       ]),
     );
     expect(view.status.footer.type).toBe("regular");
-    expect(spawn).toHaveBeenNthCalledWith(1, "mktemp", ["/tmp/tau-speak.XXXXXX"]);
+    expect(spawn).toHaveBeenNthCalledWith(1, "mktemp", [join(tmpdir(), "tau-speak.XXXXXX")]);
     expect(spawn).toHaveBeenNthCalledWith(
       2,
       "afplay",

--- a/test/session_chat_controller.test.js
+++ b/test/session_chat_controller.test.js
@@ -1,4 +1,4 @@
-import { rm, writeFile } from "node:fs/promises";
+import { readFile, rm, writeFile } from "node:fs/promises";
 import { createConnection } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -5370,13 +5370,88 @@ describe("SessionChatController", () => {
     expect(session.submit).not.toHaveBeenCalled();
   });
 
-  it("shows voice transcription failures as temporary footer errors", async () => {
-    const audioPath = join(tmpdir(), `tau-session-listen-failure-${Date.now()}.wav`);
+  it("shows Gemini retry and fallback progress while transcribing voice input", async () => {
+    const audioPath = join(tmpdir(), `tau-session-listen-fallback-${Date.now()}.wav`);
     await writeFile(audioPath, Buffer.alloc(2048, 1));
+    const unavailable = () =>
+      new Response(JSON.stringify({ error: { message: "model unavailable" } }), {
+        status: 503,
+        headers: { "Retry-After": "0" },
+      });
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => Promise.reject(new Error("service unavailable"))),
+      vi
+        .fn()
+        .mockResolvedValueOnce(unavailable())
+        .mockResolvedValueOnce(unavailable())
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              candidates: [
+                {
+                  content: {
+                    parts: [{ text: JSON.stringify({ transcription: "fallback transcript" }) }],
+                  },
+                },
+              ],
+            }),
+          ),
+        ),
     );
+    const session = new FakeSession();
+    const view = new FakeView();
+    const controller = new SessionChatController({
+      view,
+      session,
+      snapshot: await session.snapshot(),
+      targetLabel: "in-process",
+      deps: createMockDeps(),
+      config: {
+        speechToText: { provider: "gemini" },
+        apiKeys: { google: "gemini-key" },
+      },
+    });
+    controller.listenRecording = {
+      audioPath,
+      stopRequested: false,
+      abortController: new AbortController(),
+      completion: Promise.resolve(),
+    };
+
+    try {
+      await controller.stopListenCapture();
+    } finally {
+      vi.unstubAllGlobals();
+      await rm(audioPath, { force: true });
+    }
+
+    expect(view.editorText).toBe("fallback transcript");
+    expect(
+      view.statusUpdates.flatMap((status) =>
+        status.footer.type === "activity" ? [status.footer.label] : [],
+      ),
+    ).toEqual(
+      expect.arrayContaining([
+        "transcribing voice input",
+        "retrying voice transcription",
+        "trying fallback transcription model",
+      ]),
+    );
+    expect(view.footerNotices).toContainEqual({
+      text: "transcribed with fallback model",
+      tone: "default",
+      durationMs: 3000,
+    });
+  });
+
+  it("retains failed voice input and retries it into the editor", async () => {
+    const audioPath = join(tmpdir(), `tau-session-listen-failure-${Date.now()}.wav`);
+    await writeFile(audioPath, Buffer.alloc(2048, 1));
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("service unavailable"))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ text: "recovered transcript" })));
+    vi.stubGlobal("fetch", fetchMock);
 
     const session = new FakeSession();
     const view = new FakeView();
@@ -5397,16 +5472,175 @@ describe("SessionChatController", () => {
 
     try {
       await controller.stopListenCapture();
+      await expect(readFile(audioPath)).resolves.toHaveLength(2048);
+      expect(view.transcriptNotices.at(-1)).toEqual({
+        text: "failed to transcribe speech",
+        tone: "error",
+        content: [
+          "service unavailable",
+          `recording retained at ${audioPath}`,
+          "run /listen retry to try again, or /listen discard to delete it",
+        ],
+      });
+
+      await controller.onUserInput("/listen retry");
+      expect(view.editorText).toBe("recovered transcript");
+      await expect(readFile(audioPath)).rejects.toMatchObject({ code: "ENOENT" });
     } finally {
       vi.unstubAllGlobals();
       await rm(audioPath, { force: true });
     }
 
-    expect(view.transcriptNotices.at(-1)).toEqual({
-      text: "failed to transcribe speech",
-      tone: "error",
-      content: ["service unavailable"],
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retains voice input when a provider returns an empty transcript", async () => {
+    const audioPath = join(tmpdir(), `tau-session-listen-empty-${Date.now()}.wav`);
+    await writeFile(audioPath, Buffer.alloc(2048, 1));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify({ text: "" }))),
+    );
+    const session = new FakeSession();
+    const view = new FakeView();
+    const controller = new SessionChatController({
+      view,
+      session,
+      snapshot: await session.snapshot(),
+      targetLabel: "in-process",
+      deps: createMockDeps(),
+      config: { apiKeys: { mistral: "mistral-key" } },
     });
+    controller.listenRecording = {
+      audioPath,
+      stopRequested: false,
+      abortController: new AbortController(),
+      completion: Promise.resolve(),
+    };
+
+    try {
+      await controller.stopListenCapture();
+      await expect(readFile(audioPath)).resolves.toHaveLength(2048);
+    } finally {
+      vi.unstubAllGlobals();
+      await rm(audioPath, { force: true });
+    }
+
+    expect(view.transcriptNotices.at(-1)).toMatchObject({
+      text: "failed to transcribe speech",
+      content: [
+        "transcription result was empty or malformed",
+        `recording retained at ${audioPath}`,
+        "run /listen retry to try again, or /listen discard to delete it",
+      ],
+    });
+  });
+
+  it("discards retained voice input only when requested", async () => {
+    const audioPath = join(tmpdir(), `tau-session-listen-discard-${Date.now()}.wav`);
+    await writeFile(audioPath, Buffer.alloc(2048, 1));
+    const session = new FakeSession();
+    const view = new FakeView();
+    const controller = new SessionChatController({
+      view,
+      session,
+      snapshot: await session.snapshot(),
+      targetLabel: "in-process",
+      deps: createMockDeps(),
+    });
+    controller.retainedListenAudioPath = audioPath;
+
+    try {
+      await controller.onUserInput("/listen discard");
+      await expect(readFile(audioPath)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await rm(audioPath, { force: true });
+    }
+
+    expect(view.footerNotices.at(-1)).toEqual({
+      text: "discarded retained speech recording",
+      tone: "default",
+      durationMs: 3000,
+    });
+    expect(controller.retainedListenAudioPath).toBeUndefined();
+  });
+
+  it("deletes retained voice input when a new recording replaces it", async () => {
+    const retainedPath = join(tmpdir(), `tau-session-listen-replaced-${Date.now()}.wav`);
+    const nextPath = join(tmpdir(), `tau-session-listen-next-${Date.now()}.wav`);
+    await writeFile(retainedPath, Buffer.alloc(2048, 1));
+    const spawn = vi.fn(async (command, _args, options = {}) => {
+      if (command === "mktemp") {
+        return {
+          stdout: `${nextPath}\n`,
+          stderr: "",
+          output: undefined,
+          exitCode: 0,
+          captureLimitExceeded: false,
+          timedOut: false,
+          aborted: false,
+          closeSignal: null,
+        };
+      }
+      if (command === "ffmpeg") {
+        return await new Promise((resolve) => {
+          options.signal.addEventListener("abort", () => {
+            resolve({
+              stdout: "",
+              stderr: "",
+              output: undefined,
+              exitCode: 0,
+              captureLimitExceeded: false,
+              timedOut: false,
+              aborted: true,
+              closeSignal: null,
+            });
+          });
+        });
+      }
+      throw new Error(`unexpected command: ${command}`);
+    });
+    const session = new FakeSession();
+    const controller = new SessionChatController({
+      view: new FakeView(),
+      session,
+      snapshot: await session.snapshot(),
+      targetLabel: "in-process",
+      deps: createMockDeps(spawn),
+      config: { apiKeys: { mistral: "mistral-key" } },
+    });
+    controller.retainedListenAudioPath = retainedPath;
+
+    try {
+      await controller.onUserInput("/listen");
+      await expect(readFile(retainedPath)).rejects.toMatchObject({ code: "ENOENT" });
+      expect(controller.listenRecording?.audioPath).toBe(nextPath);
+      await controller.dispose();
+    } finally {
+      await rm(retainedPath, { force: true });
+      await rm(nextPath, { force: true });
+    }
+  });
+
+  it("keeps retained voice input on shutdown", async () => {
+    const audioPath = join(tmpdir(), `tau-session-listen-shutdown-${Date.now()}.wav`);
+    await writeFile(audioPath, Buffer.alloc(2048, 1));
+    const session = new FakeSession();
+    const controller = new SessionChatController({
+      view: new FakeView(),
+      session,
+      snapshot: await session.snapshot(),
+      targetLabel: "in-process",
+      deps: createMockDeps(),
+    });
+    controller.retainedListenAudioPath = audioPath;
+
+    try {
+      await controller.dispose();
+      await expect(readFile(audioPath)).resolves.toHaveLength(2048);
+    } finally {
+      await rm(audioPath, { force: true });
+    }
   });
 
   it("routes /speak as a client-side command in session attach", async () => {

--- a/test/session_chat_controller.test.js
+++ b/test/session_chat_controller.test.js
@@ -5361,11 +5361,12 @@ describe("SessionChatController", () => {
     expect(spawn).toHaveBeenNthCalledWith(
       2,
       "ffmpeg",
-      expect.arrayContaining(["-f", "avfoundation", "-i", ":0"]),
+      expect.arrayContaining(["-f", "avfoundation", "-i", ":0", "-f", "s16le", "pipe:1"]),
       expect.objectContaining({
         detached: true,
         killProcessGroup: true,
-        stdio: ["ignore", "ignore", "ignore"],
+        captureOutput: "stderr",
+        stdio: ["ignore", "pipe", "pipe"],
       }),
     );
     expect(session.submit).not.toHaveBeenCalled();
@@ -5396,10 +5397,7 @@ describe("SessionChatController", () => {
     });
     socket.close = vi.fn();
     socket.terminate = vi.fn();
-    const webSocketFactory = vi.fn(() => {
-      queueMicrotask(() => socket.emit("open"));
-      return socket;
-    });
+    const webSocketFactory = vi.fn(() => socket);
     const pcm = Buffer.from([1, 2, 3, 4]);
     const spawn = vi.fn(async (command, _args, options = {}) => {
       if (command === "mktemp") {
@@ -5454,9 +5452,11 @@ describe("SessionChatController", () => {
       controller.start();
       await controller.onUserInput("/listen");
       expect(view.status.editor.mode).toBe("recording");
+      expect(socketEvents).toEqual([]);
       await writeFile(audioPath, Buffer.alloc(2048, 1));
 
       controller.getInputHandlers().onCtrlY();
+      socket.emit("open");
       for (let i = 0; i < 50 && view.editorText !== "live transcript"; i += 1) {
         await flush();
         await waitMs(1);

--- a/test/speech_to_text.test.js
+++ b/test/speech_to_text.test.js
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSpeechToTextTranscription } from "../dist/core/utils/speech_to_text.js";
+
+describe("speech-to-text transcription", () => {
+  it.each(["gemini", "mistral"])("aborts an active %s request", async (provider) => {
+    let requestSignal;
+    const fetchMock = vi.fn(
+      async (_url, options) =>
+        await new Promise((_resolve, reject) => {
+          requestSignal = options.signal;
+          options.signal.addEventListener("abort", () => reject(options.signal.reason), {
+            once: true,
+          });
+        }),
+    );
+    const transcription = createSpeechToTextTranscription({
+      provider,
+      mode: "file",
+      apiKey: "provider-key",
+      deps: { fetchImpl: fetchMock },
+    });
+
+    const result = transcription.finish({ audio: Buffer.from("audio") });
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    transcription.abort();
+
+    expect(requestSignal.aborted).toBe(true);
+    await expect(result).rejects.toThrow("speech transcription was aborted");
+  });
+});

--- a/test/telegram_adapter.test.js
+++ b/test/telegram_adapter.test.js
@@ -2316,7 +2316,7 @@ describe("telegram adapter", () => {
     }
   });
 
-  it("transcribes Telegram audio with OpenAI realtime transcription by default", async () => {
+  it("transcribes Telegram audio with OpenAI file transcription by default", async () => {
     const apiHarness = createApiHarness([
       [
         {
@@ -2344,33 +2344,6 @@ describe("telegram adapter", () => {
       ],
       { defaultOwnerId: ownerIdForChat(212) },
     );
-    const socket = new EventEmitter();
-    const socketEvents = [];
-    socket.send = vi.fn((data, callback) => {
-      const event = JSON.parse(data);
-      socketEvents.push(event);
-      callback?.();
-      if (event.type === "session.update") {
-        queueMicrotask(() => socket.emit("message", JSON.stringify({ type: "session.updated" })));
-      }
-      if (event.type === "input_audio_buffer.commit") {
-        queueMicrotask(() =>
-          socket.emit(
-            "message",
-            JSON.stringify({
-              type: "conversation.item.input_audio_transcription.completed",
-              transcript: "use realtime transcription",
-            }),
-          ),
-        );
-      }
-    });
-    socket.close = vi.fn();
-    socket.terminate = vi.fn();
-    const webSocketFactory = vi.fn(() => {
-      queueMicrotask(() => socket.emit("open"));
-      return socket;
-    });
     const spawnImpl = vi.fn(async (_command, _args, options) => {
       const stdout = new EventEmitter();
       options.onSpawn({ stdout });
@@ -2386,13 +2359,17 @@ describe("telegram adapter", () => {
         closeSignal: null,
       };
     });
+    const openaiFetch = vi.fn(async () =>
+      createJsonResponse({ text: "use file transcription", languages: [{ code: "en" }] }),
+    );
     const adapter = await startAdapter({
       botToken: "token",
       projects: { demo: { repo: "git@example.com:demo.git" } },
       openaiApiKey: "openai-key",
-      speechToTextDeps: { webSocketFactory, spawnImpl },
+      speechToTextDeps: { spawnImpl },
       sessionManager: managerHarness.manager,
       api: apiHarness.api,
+      fetchImpl: openaiFetch,
       pollIntervalMs: 1,
       requestTimeoutSeconds: 1,
     });
@@ -2401,19 +2378,25 @@ describe("telegram adapter", () => {
       await waitFor(() => managerHarness.manager.sendMessage.mock.calls.length === 1);
       expect(managerHarness.manager.sendMessage).toHaveBeenCalledWith(
         "s23",
-        "use realtime transcription",
+        "use file transcription",
         { mode: "auto" },
       );
-      expect(socketEvents.map((event) => event.type)).toEqual([
-        "session.update",
-        "input_audio_buffer.append",
-        "input_audio_buffer.commit",
-      ]);
       expect(spawnImpl).toHaveBeenCalledWith(
         "ffmpeg",
-        expect.arrayContaining(["-i", "pipe:0", "-ar", "24000", "pipe:1"]),
+        expect.arrayContaining(["-i", "pipe:0", "-ar", "16000", "pipe:1"]),
         expect.objectContaining({ input: Buffer.from("telegram audio payload") }),
       );
+      expect(openaiFetch).toHaveBeenCalledWith(
+        "https://api.openai.com/v1/audio/transcriptions",
+        expect.objectContaining({
+          method: "POST",
+          headers: { Authorization: "Bearer openai-key" },
+          body: expect.any(FormData),
+        }),
+      );
+      const form = openaiFetch.mock.calls[0][1].body;
+      expect(form.get("model")).toBe("gpt-transcribe");
+      expect(form.get("file").type).toBe("audio/wav");
     } finally {
       await adapter.close();
     }

--- a/test/telegram_adapter.test.js
+++ b/test/telegram_adapter.test.js
@@ -1,3 +1,4 @@
+import { EventEmitter } from "node:events";
 import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { describe, expect, it, vi } from "vitest";
@@ -2308,6 +2309,110 @@ describe("telegram adapter", () => {
       expect(request.generationConfig.responseSchema.required).toEqual(["transcription"]);
       expect(request.generationConfig.thinkingConfig.thinkingLevel).toBe("low");
       expect(request.contents[0].parts[1].inlineData.mimeType).toBe("audio/ogg");
+    } finally {
+      await adapter.close();
+    }
+  });
+
+  it("transcribes Telegram audio with OpenAI realtime transcription when configured", async () => {
+    const apiHarness = createApiHarness([
+      [
+        {
+          update_id: 1,
+          message: {
+            chat: { id: 212, type: "private" },
+            from: { id: 7 },
+            voice: {
+              file_id: "voice-789",
+              mime_type: "audio/ogg",
+            },
+          },
+        },
+      ],
+    ]);
+    const managerHarness = createSessionManagerHarness(
+      [
+        {
+          id: "s23",
+          projectId: "demo",
+          state: "waiting-input",
+          createdAt: "2024-01-01T00:00:00.000Z",
+          updatedAt: "2024-01-01T00:00:00.000Z",
+        },
+      ],
+      { defaultOwnerId: ownerIdForChat(212) },
+    );
+    const socket = new EventEmitter();
+    const socketEvents = [];
+    socket.send = vi.fn((data, callback) => {
+      const event = JSON.parse(data);
+      socketEvents.push(event);
+      callback?.();
+      if (event.type === "session.update") {
+        queueMicrotask(() => socket.emit("message", JSON.stringify({ type: "session.updated" })));
+      }
+      if (event.type === "input_audio_buffer.commit") {
+        queueMicrotask(() =>
+          socket.emit(
+            "message",
+            JSON.stringify({
+              type: "conversation.item.input_audio_transcription.completed",
+              transcript: "use realtime transcription",
+            }),
+          ),
+        );
+      }
+    });
+    socket.close = vi.fn();
+    socket.terminate = vi.fn();
+    const webSocketFactory = vi.fn(() => {
+      queueMicrotask(() => socket.emit("open"));
+      return socket;
+    });
+    const spawnImpl = vi.fn(async (_command, _args, options) => {
+      const stdout = new EventEmitter();
+      options.onSpawn({ stdout });
+      stdout.emit("data", Buffer.from([1, 2, 3, 4]));
+      return {
+        stdout: "",
+        stderr: "",
+        output: undefined,
+        exitCode: 0,
+        captureLimitExceeded: false,
+        timedOut: false,
+        aborted: false,
+        closeSignal: null,
+      };
+    });
+    const adapter = await startAdapter({
+      botToken: "token",
+      projects: { demo: { repo: "git@example.com:demo.git" } },
+      speechToTextProvider: "openai",
+      openaiApiKey: "openai-key",
+      speechToTextDeps: { webSocketFactory, spawnImpl },
+      sessionManager: managerHarness.manager,
+      api: apiHarness.api,
+      pollIntervalMs: 1,
+      requestTimeoutSeconds: 1,
+    });
+
+    try {
+      await waitFor(() => managerHarness.manager.sendMessage.mock.calls.length === 1);
+      expect(managerHarness.manager.sendMessage).toHaveBeenCalledWith(
+        "s23",
+        "use realtime transcription",
+        { mode: "auto" },
+      );
+      expect(socketEvents.map((event) => event.type)).toEqual([
+        "session.update",
+        "input_audio_buffer.append",
+        "input_audio_buffer.commit",
+      ]);
+      expect(spawnImpl).toHaveBeenCalledWith(
+        "ffmpeg",
+        expect.arrayContaining(["-i", "pipe:0", "-ar", "24000", "pipe:1"]),
+        expect.objectContaining({ input: Buffer.from("telegram audio payload") }),
+      );
     } finally {
       await adapter.close();
     }

--- a/test/telegram_adapter.test.js
+++ b/test/telegram_adapter.test.js
@@ -1705,6 +1705,7 @@ describe("telegram adapter", () => {
       botToken: "token",
       projects: { demo: { repo: "git@example.com:demo.git" } },
       allowedChatIds: [groupChatId],
+      speechToTextProvider: "mistral",
       mistralApiKey: "mistral-key",
       sessionManager: managerHarness.manager,
       api: apiHarness.api,
@@ -2207,6 +2208,7 @@ describe("telegram adapter", () => {
     const adapter = await startAdapter({
       botToken: "token",
       projects: { demo: { repo: "git@example.com:demo.git" } },
+      speechToTextProvider: "mistral",
       mistralApiKey: "mistral-key",
       sessionManager: managerHarness.manager,
       api: apiHarness.api,
@@ -2314,7 +2316,7 @@ describe("telegram adapter", () => {
     }
   });
 
-  it("transcribes Telegram audio with OpenAI realtime transcription when configured", async () => {
+  it("transcribes Telegram audio with OpenAI realtime transcription by default", async () => {
     const apiHarness = createApiHarness([
       [
         {
@@ -2387,7 +2389,6 @@ describe("telegram adapter", () => {
     const adapter = await startAdapter({
       botToken: "token",
       projects: { demo: { repo: "git@example.com:demo.git" } },
-      speechToTextProvider: "openai",
       openaiApiKey: "openai-key",
       speechToTextDeps: { webSocketFactory, spawnImpl },
       sessionManager: managerHarness.manager,


### PR DESCRIPTION
## why

Failed speech transcription currently deletes the completed WAV, so a transient provider outage or malformed response loses the original voice input. Existing providers also wait until recording finishes before uploading audio, leaving avoidable latency for interactive dictation.

## what

- Retain one failed local recording and report its exact path.
- Add `/listen retry` to transcribe retained audio with the current provider and fresh conversation context, plus `/listen discard` for explicit deletion.
- Keep retained audio until a replacement capture is producing audio, so replacement startup failures do not destroy the recoverable recording.
- Retry transient Gemini failures once on Gemini 3.7 Flash, then use Gemini 3.6 Flash as a final fallback. Permanent request failures stop immediately.
- Add `speechToText.provider: "openai"` using `OPENAI_API_KEY` or `apiKeys.openai`, and make OpenAI the default provider when the setting is absent.
- Stream `/listen` microphone audio to `gpt-live-transcribe` while recording, then insert only the final transcript after recording stops.
- Support OpenAI for Telegram by decoding downloaded audio to PCM with runner-side `ffmpeg`, with owner cancellation, a five-minute decoded-audio limit, and WebSocket backpressure.
- Cover provider configuration, credentials, Realtime protocol events, live capture, retained-audio replay, lifecycle cancellation, resource bounds, and Telegram transcription.
- Document the provider defaults, credential ownership, ffmpeg requirement, and privacy-sensitive retention lifecycle.

## details

OpenAI is the default provider. Its transcription path opens the official transcription-specific Realtime WebSocket, configures a `gpt-live-transcribe` session with 24 kHz mono PCM and conversation context, streams audio with `input_audio_buffer.append`, and manually commits the turn when capture ends. Partial deltas remain internal; Tau waits for `conversation.item.input_audio_transcription.completed` before changing the editor. Mistral and Gemini remain selectable through `speechToText.provider`.

The TUI writes a WAV while streaming PCM so the recovery contract remains available when the connection or transcription fails. `/listen retry` decodes that retained WAV and replays it through a fresh provider request. The retained path is client-local controller state, not session state, and exiting leaves the file at the reported path for manual recovery. Starting a replacement preserves the old WAV through temp-file creation, provider setup, and capture startup, then removes it only after the new capture emits PCM.

OpenAI batch replay waits for the Realtime session before starting `ffmpeg`. Decoder cancellation follows socket failure, transcription abort, TUI disposal, and Telegram shutdown. Decoded PCM is limited to five minutes, and ffmpeg stdout pauses while the WebSocket send buffer exceeds the configured high-water mark.

The Gemini fallback remains inside the configured Google provider and also applies to Telegram through the shared speech-to-text owner. Retryable failures include transport errors, HTTP 408/429/5xx responses, provider availability statuses, and invalid model output. Retry delays use short backoff and honor `Retry-After` up to five seconds.

fixes #438
