### PR TITLE
preserve metadata while pursuing goals

### DIFF
--- a/src/tui/ui/footer.ts
+++ b/src/tui/ui/footer.ts
@@ -174,14 +174,14 @@ export class FooterComponent implements Component {
     const activityStyle = this.working || isCompleting ? palette.brandAccent : palette.textDim;
     const icon = activityStyle(iconChar);
     const iconWidth = visibleWidth(iconChar);
-    const availableWidth = Math.max(0, width - iconWidth - 3);
-    const goalStatus = this.working && this.status?.pursuingGoal ? "pursuing goal" : "";
-    const rawText = goalStatus || this.buildStatusLine(availableWidth);
-    const style = goalStatus ? activityStyle : palette.textDim;
-    const text = truncateFromEndByWidth(rawText, availableWidth);
+    const goalStatus = this.working && this.status?.pursuingGoal ? "goal" : "";
+    const goalPrefix = goalStatus ? `${activityStyle(goalStatus)} ${palette.textDim("·")} ` : "";
+    const goalPrefixWidth = goalStatus ? visibleWidth(goalStatus) + 3 : 0;
+    const availableWidth = Math.max(0, width - iconWidth - goalPrefixWidth - 3);
+    const text = truncateFromEndByWidth(this.buildStatusLine(availableWidth), availableWidth);
     const padding = " ".repeat(Math.max(0, availableWidth - visibleWidth(text)));
 
-    return [` ${icon} ${style(text)}${padding} `];
+    return [` ${icon} ${goalPrefix}${palette.textDim(text)}${padding} `];
   }
 
   private syncAnimation(): void {

--- a/test/ui_components.test.js
+++ b/test/ui_components.test.js
@@ -626,15 +626,14 @@ test("FooterComponent animates active goal work and settles after completion", (
 
   try {
     const idleLine = renderLines(footer, 120)[0];
-    expect(idleLine).not.toContain("pursuing goal");
+    expect(idleLine).not.toContain("goal");
     expect(idleLine).toContain("<textDim>24s · ~/Code/tau-one · ctx 10/100 · $0.01</textDim>");
 
     footer.startWorkingIcon();
     const activeLine = renderLines(footer, 120)[0];
     expect(activeLine).toContain(
-      "<brandAccent>⠋</brandAccent> <brandAccent>pursuing goal</brandAccent>",
+      "<brandAccent>⠋</brandAccent> <brandAccent>goal</brandAccent> <textDim>·</textDim> <textDim>24s · ~/Code/tau-one · ctx 10/100 · $0.01</textDim>",
     );
-    expect(activeLine).not.toContain("tau-one");
 
     footer.stop();
     expect(renderLines(footer, 120)[0]).toContain("<brandAccent>●</brandAccent>");


### PR DESCRIPTION
## why

Goal pursuit replaced the footer's normal duration, working directory, context usage, and cost metadata with a long activity label.

## what

Render a compact accent-colored `goal` badge before the normal footer metadata. Keep the separator and metadata dim, and account for the badge when compacting the status line to fit the terminal width.

Update the footer component test to cover the badge styling and preserved metadata.

fixes #440
