### PR TITLE
stream Gemini speech playback

### DIFF
--- a/docs/tui.md
+++ b/docs/tui.md
@@ -205,7 +205,7 @@ brew install ffmpeg
 
 OpenAI is the default and needs `OPENAI_API_KEY` or `apiKeys.openai`. Set `speechToText.provider` to `gemini` to use `GEMINI_API_KEY` or `apiKeys.google`, or to `mistral` to use `MISTRAL_API_KEY` or `apiKeys.mistral`. These settings and credentials are read by the TUI process, including during remote attachment.
 
-`/speak` is also macOS-only. It rewrites the last assistant response for speech, generates audio with Gemini, and plays it through the local `afplay` command. It requires `GEMINI_API_KEY` or `apiKeys.google`, runs only while the session is idle, and can be stopped with Escape. Speech source and rewritten text are limited to 10,000 Unicode characters, and generation stops after 32 MiB of raw audio.
+`/speak` is also macOS-only. It rewrites the last assistant response for speech, streams audio from Gemini, and plays it through the local `ffplay` command included with `ffmpeg`. It requires `GEMINI_API_KEY` or `apiKeys.google`, runs only while the session is idle, and can be stopped with Escape. Longer responses are divided into balanced segments targeting at most two minutes of generated speech each. Speech source and rewritten text are limited to 10,000 Unicode characters, and generation stops after 32 MiB of raw audio.
 
 ## Reload the right component
 

--- a/src/core/telegram/tts.ts
+++ b/src/core/telegram/tts.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { GEMINI_SPEECH_PLAYBACK_RATE, streamGeminiSpeechAudio } from "../utils/gemini_speech.js";
+import { GEMINI_SPEECH_PLAYBACK_RATE, generateGeminiSpeechAudio } from "../utils/gemini_speech.js";
 import { spawnWithCapture } from "../utils/spawn_capture.js";
 
 const TELEGRAM_TTS_TEMP_DIR_PREFIX = "tau-telegram-tts-";
@@ -33,7 +33,7 @@ export type GenerateTelegramVoiceOptions = {
   fetchImpl?: typeof fetch;
   signal?: AbortSignal;
   deps?: {
-    streamSpeechAudio?: typeof streamGeminiSpeechAudio;
+    generateSpeechAudio?: typeof generateGeminiSpeechAudio;
     spawn?: typeof spawnWithCapture;
   };
 };
@@ -41,7 +41,7 @@ export type GenerateTelegramVoiceOptions = {
 export async function generateTelegramVoice(
   options: GenerateTelegramVoiceOptions,
 ): Promise<Buffer> {
-  const streamSpeechAudio = options.deps?.streamSpeechAudio ?? streamGeminiSpeechAudio;
+  const generateSpeechAudio = options.deps?.generateSpeechAudio ?? generateGeminiSpeechAudio;
   const spawn = options.deps?.spawn ?? spawnWithCapture;
   const temporaryDirectory = await mkdtemp(join(tmpdir(), TELEGRAM_TTS_TEMP_DIR_PREFIX));
   const manifestPath = join(temporaryDirectory, "speech.ffconcat");
@@ -51,10 +51,9 @@ export async function generateTelegramVoice(
     const chunkNames: string[] = [];
     let waveFormat: Buffer | undefined;
 
-    for await (const chunk of streamSpeechAudio({
+    for await (const chunk of generateSpeechAudio({
       apiKey: options.apiKey,
       sourceText: options.sourceText,
-      deliveryMode: "complete",
       fetchImpl: options.fetchImpl,
       signal: options.signal,
     })) {

--- a/src/core/utils/gemini_speech.ts
+++ b/src/core/utils/gemini_speech.ts
@@ -52,6 +52,10 @@ export type GeminiSpeechOptions = {
   onSegmentProgress?: (progress: GeminiSpeechSegmentProgress) => void | Promise<void>;
 };
 
+export type GeminiSpeechPcmOptions = GeminiSpeechOptions & {
+  initialBufferBytes?: number;
+};
+
 export type GeminiSpeechAudioChunk = {
   index: number;
   total: number;
@@ -137,7 +141,7 @@ export async function* generateGeminiSpeechAudio(
 }
 
 export async function* streamGeminiSpeechPcm(
-  options: GeminiSpeechOptions,
+  options: GeminiSpeechPcmOptions,
 ): AsyncGenerator<GeminiSpeechPcmChunk> {
   const abortController = createLinkedAbortController(options.signal);
   let completed = false;
@@ -168,6 +172,7 @@ export async function* streamGeminiSpeechPcm(
       ...prepared,
       spokenText: prepared.spokenSegments[0]!,
       signal: abortController.signal,
+      initialBufferBytes: Math.max(0, Math.trunc(options.initialBufferBytes ?? 0)),
     });
     const firstIterator = firstStream[Symbol.asyncIterator]();
     let nextAudio = firstIterator.next();
@@ -463,17 +468,34 @@ async function synthesizeSpeechAudioSegment(
 type StreamSpeechSegmentArgs = SynthesizeSpeechAudioSegmentArgs;
 
 async function* streamSpeechSegmentWithRetries(
-  args: StreamSpeechSegmentArgs,
+  args: StreamSpeechSegmentArgs & { initialBufferBytes: number },
 ): AsyncGenerator<Buffer> {
   const maxAttempts = Math.max(1, Math.trunc(args.maxAttempts));
   let lastError: unknown;
 
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const bufferedAudio: Buffer[] = [];
+    let bufferedAudioBytes = 0;
     let emittedAudio = false;
     try {
       for await (const audio of requestGeminiSpeechStream(args)) {
+        if (!emittedAudio && bufferedAudioBytes < args.initialBufferBytes) {
+          bufferedAudio.push(audio);
+          bufferedAudioBytes += audio.length;
+          if (bufferedAudioBytes < args.initialBufferBytes) {
+            continue;
+          }
+          emittedAudio = true;
+          yield Buffer.concat(bufferedAudio);
+          continue;
+        }
+
         emittedAudio = true;
         yield audio;
+      }
+      if (bufferedAudio.length > 0 && !emittedAudio) {
+        emittedAudio = true;
+        yield Buffer.concat(bufferedAudio);
       }
       return;
     } catch (error) {

--- a/src/core/utils/gemini_speech.ts
+++ b/src/core/utils/gemini_speech.ts
@@ -6,15 +6,16 @@ const DEFAULT_GEMINI_SPEECH_REWRITE_MODEL = "gemini-3.7-flash";
 const DEFAULT_GEMINI_SPEECH_REWRITE_THINKING_LEVEL = "low";
 const DEFAULT_GEMINI_SPEECH_TTS_MODEL = "gemini-3.1-flash-tts-preview";
 const DEFAULT_GEMINI_TTS_VOICE_NAME = "Despina";
-const DEFAULT_TTS_SAMPLE_RATE_HZ = 24000;
-const DEFAULT_TTS_CHANNEL_COUNT = 1;
-const DEFAULT_TTS_BITS_PER_SAMPLE = 16;
+export const GEMINI_SPEECH_SAMPLE_RATE_HZ = 24000;
+export const GEMINI_SPEECH_CHANNEL_COUNT = 1;
+export const GEMINI_SPEECH_BITS_PER_SAMPLE = 16;
 const DEFAULT_TTS_MAX_ATTEMPTS = 3;
 const SPEECH_REWRITE_TIMEOUT_MS = 60_000;
-const PROGRESSIVE_TTS_CONCURRENCY = 6;
 const COMPLETE_TTS_CONCURRENCY = 3;
-const PROGRESSIVE_SPEECH_CHUNK_CHARACTERS = 500;
-const COMPLETE_SPEECH_CHUNK_CHARACTERS = 1000;
+const MAX_SPEECH_SEGMENT_SECONDS = 120;
+const ESTIMATED_SPEECH_CHARACTERS_PER_SECOND = 17;
+const MAX_SPEECH_SEGMENT_WEIGHT =
+  MAX_SPEECH_SEGMENT_SECONDS * ESTIMATED_SPEECH_CHARACTERS_PER_SECOND;
 const MAX_SPEECH_SOURCE_CHARACTERS = 10_000;
 const MAX_SPOKEN_TEXT_CHARACTERS = 10_000;
 const MAX_SPEECH_PCM_BYTES = 32 * 1024 * 1024;
@@ -32,9 +33,8 @@ const errorPayloadSchema = z.object({
 });
 
 export type GeminiSpeechStage = "rewriting" | "generating";
-export type GeminiSpeechDeliveryMode = "progressive" | "complete";
 
-export type GeminiSpeechChunkProgress = {
+export type GeminiSpeechSegmentProgress = {
   ready: number;
   total: number;
 };
@@ -42,7 +42,6 @@ export type GeminiSpeechChunkProgress = {
 export type GeminiSpeechOptions = {
   apiKey: string;
   sourceText: string;
-  deliveryMode: GeminiSpeechDeliveryMode;
   rewriteModel?: string;
   ttsModel?: string;
   voiceName?: string;
@@ -50,7 +49,7 @@ export type GeminiSpeechOptions = {
   signal?: AbortSignal;
   maxTtsAttempts?: number;
   onStageChange?: (stage: GeminiSpeechStage) => void | Promise<void>;
-  onChunkProgress?: (progress: GeminiSpeechChunkProgress) => void | Promise<void>;
+  onSegmentProgress?: (progress: GeminiSpeechSegmentProgress) => void | Promise<void>;
 };
 
 export type GeminiSpeechAudioChunk = {
@@ -58,6 +57,12 @@ export type GeminiSpeechAudioChunk = {
   total: number;
   audio: Buffer;
   mimeType: "audio/wav";
+};
+
+export type GeminiSpeechPcmChunk = {
+  index: number;
+  total: number;
+  audio: Buffer;
 };
 
 class GeminiApiError extends Error {
@@ -84,9 +89,131 @@ class GeminiTtsOutputLimitError extends Error {
   }
 }
 
-export async function* streamGeminiSpeechAudio(
+type PreparedGeminiSpeech = {
+  apiKey: string;
+  model: string;
+  voiceName: string;
+  spokenSegments: string[];
+  fetchImpl: typeof fetch;
+  maxAttempts: number;
+};
+
+export async function* generateGeminiSpeechAudio(
   options: GeminiSpeechOptions,
 ): AsyncGenerator<GeminiSpeechAudioChunk> {
+  const abortController = createLinkedAbortController(options.signal);
+  let completed = false;
+
+  try {
+    const prepared = await prepareGeminiSpeech(options, abortController.signal);
+
+    for await (const chunk of synthesizeSpeechAudioSegmentsInOrder({
+      ...prepared,
+      signal: abortController.signal,
+      concurrency: COMPLETE_TTS_CONCURRENCY,
+      onSegmentProgress: options.onSegmentProgress,
+      abortOnFailure: () => abortController.abort(),
+    })) {
+      yield {
+        index: chunk.index,
+        total: prepared.spokenSegments.length,
+        audio: encodeWaveFile({
+          pcmAudio: chunk.pcmAudio,
+          sampleRateHz: GEMINI_SPEECH_SAMPLE_RATE_HZ,
+          channelCount: GEMINI_SPEECH_CHANNEL_COUNT,
+          bitsPerSample: GEMINI_SPEECH_BITS_PER_SAMPLE,
+        }),
+        mimeType: "audio/wav",
+      };
+    }
+
+    completed = true;
+  } finally {
+    if (!completed) {
+      abortController.abort();
+    }
+    abortController.dispose();
+  }
+}
+
+export async function* streamGeminiSpeechPcm(
+  options: GeminiSpeechOptions,
+): AsyncGenerator<GeminiSpeechPcmChunk> {
+  const abortController = createLinkedAbortController(options.signal);
+  let completed = false;
+  let totalPcmBytes = 0;
+
+  try {
+    const prepared = await prepareGeminiSpeech(options, abortController.signal);
+    const total = prepared.spokenSegments.length;
+    const accountAudio = (audio: Buffer): void => {
+      totalPcmBytes += audio.length;
+      if (totalPcmBytes > MAX_SPEECH_PCM_BYTES) {
+        throw new Error("generated speech audio exceeds the 32 MiB limit");
+      }
+    };
+    const prefetch = (index: number): Promise<PrefetchedSpeechSegment> =>
+      collectStreamingSpeechSegment({
+        ...prepared,
+        spokenText: prepared.spokenSegments[index]!,
+        signal: abortController.signal,
+        accountAudio,
+      }).then(
+        (audio) => ({ audio }),
+        (error: unknown) => ({ error }),
+      );
+
+    let ready = 0;
+    const firstStream = streamSpeechSegmentWithRetries({
+      ...prepared,
+      spokenText: prepared.spokenSegments[0]!,
+      signal: abortController.signal,
+    });
+    const firstIterator = firstStream[Symbol.asyncIterator]();
+    let nextAudio = firstIterator.next();
+    let prefetched = total > 1 ? prefetch(1) : undefined;
+
+    while (true) {
+      const next = await nextAudio;
+      if (next.done) {
+        break;
+      }
+      accountAudio(next.value);
+      yield { index: 0, total, audio: next.value };
+      nextAudio = firstIterator.next();
+    }
+    ready += 1;
+    await options.onSegmentProgress?.({ ready, total });
+
+    for (let index = 1; index < total; index += 1) {
+      const outcome = await prefetched!;
+      if ("error" in outcome) {
+        throw outcome.error instanceof Error
+          ? outcome.error
+          : new Error("Gemini TTS request failed");
+      }
+
+      prefetched = index + 1 < total ? prefetch(index + 1) : undefined;
+      yield { index, total, audio: outcome.audio };
+      ready += 1;
+      await options.onSegmentProgress?.({ ready, total });
+    }
+
+    completed = true;
+  } finally {
+    if (!completed) {
+      abortController.abort();
+    }
+    abortController.dispose();
+  }
+}
+
+type PrefetchedSpeechSegment = { audio: Buffer } | { error: unknown };
+
+async function prepareGeminiSpeech(
+  options: GeminiSpeechOptions,
+  signal: AbortSignal,
+): Promise<PreparedGeminiSpeech> {
   const sourceText = options.sourceText.trim();
   if (!sourceText) {
     throw new Error("speech source text was empty");
@@ -101,78 +228,45 @@ export async function* streamGeminiSpeechAudio(
   }
 
   const fetchImpl = options.fetchImpl ?? fetch;
-  const rewriteModel = options.rewriteModel ?? DEFAULT_GEMINI_SPEECH_REWRITE_MODEL;
-  const ttsModel = options.ttsModel ?? DEFAULT_GEMINI_SPEECH_TTS_MODEL;
-  const voiceName = options.voiceName ?? DEFAULT_GEMINI_TTS_VOICE_NAME;
-  const abortController = createLinkedAbortController(options.signal);
-  let completed = false;
-
+  await options.onStageChange?.("rewriting");
+  const rewriteController = createLinkedAbortController(signal);
+  const rewriteTimeout = setTimeout(() => rewriteController.abort(), SPEECH_REWRITE_TIMEOUT_MS);
+  rewriteTimeout.unref?.();
+  let spokenText: string;
   try {
-    await options.onStageChange?.("rewriting");
-    const rewriteController = createLinkedAbortController(abortController.signal);
-    const rewriteTimeout = setTimeout(() => rewriteController.abort(), SPEECH_REWRITE_TIMEOUT_MS);
-    rewriteTimeout.unref?.();
-    let spokenText: string;
-    try {
-      spokenText = await rewriteTextForSpeech({
-        apiKey,
-        model: rewriteModel,
-        sourceText,
-        fetchImpl,
-        signal: rewriteController.signal,
-      });
-    } catch (error) {
-      if (!abortController.signal.aborted && rewriteController.signal.aborted) {
-        throw new Error("speech rewrite timed out after 1 minute");
-      }
-      throw error;
-    } finally {
-      clearTimeout(rewriteTimeout);
-      rewriteController.dispose();
-    }
-    if (exceedsUnicodeCharacterLimit(spokenText, MAX_SPOKEN_TEXT_CHARACTERS)) {
-      throw new Error("rewritten speech text exceeds 10,000 characters");
-    }
-
-    const spokenChunks = splitSpeechChunks(spokenText, options.deliveryMode);
-    await options.onStageChange?.("generating");
-    await options.onChunkProgress?.({ ready: 0, total: spokenChunks.length });
-
-    for await (const chunk of synthesizeSpeechAudioChunksInOrder({
+    spokenText = await rewriteTextForSpeech({
       apiKey,
-      model: ttsModel,
-      voiceName,
-      spokenChunks,
+      model: options.rewriteModel ?? DEFAULT_GEMINI_SPEECH_REWRITE_MODEL,
+      sourceText,
       fetchImpl,
-      signal: abortController.signal,
-      maxAttempts: options.maxTtsAttempts ?? DEFAULT_TTS_MAX_ATTEMPTS,
-      concurrency:
-        options.deliveryMode === "progressive"
-          ? PROGRESSIVE_TTS_CONCURRENCY
-          : COMPLETE_TTS_CONCURRENCY,
-      onChunkProgress: options.onChunkProgress,
-      abortOnFailure: () => abortController.abort(),
-    })) {
-      yield {
-        index: chunk.index,
-        total: spokenChunks.length,
-        audio: encodeWaveFile({
-          pcmAudio: chunk.pcmAudio,
-          sampleRateHz: DEFAULT_TTS_SAMPLE_RATE_HZ,
-          channelCount: DEFAULT_TTS_CHANNEL_COUNT,
-          bitsPerSample: DEFAULT_TTS_BITS_PER_SAMPLE,
-        }),
-        mimeType: "audio/wav",
-      };
+      signal: rewriteController.signal,
+    });
+  } catch (error) {
+    if (!signal.aborted && rewriteController.signal.aborted) {
+      throw new Error("speech rewrite timed out after 1 minute");
     }
-
-    completed = true;
+    throw error;
   } finally {
-    if (!completed) {
-      abortController.abort();
-    }
-    abortController.dispose();
+    clearTimeout(rewriteTimeout);
+    rewriteController.dispose();
   }
+
+  if (exceedsUnicodeCharacterLimit(spokenText, MAX_SPOKEN_TEXT_CHARACTERS)) {
+    throw new Error("rewritten speech text exceeds 10,000 characters");
+  }
+
+  const spokenSegments = splitSpeechSegments(spokenText);
+  await options.onStageChange?.("generating");
+  await options.onSegmentProgress?.({ ready: 0, total: spokenSegments.length });
+
+  return {
+    apiKey,
+    model: options.ttsModel ?? DEFAULT_GEMINI_SPEECH_TTS_MODEL,
+    voiceName: options.voiceName ?? DEFAULT_GEMINI_TTS_VOICE_NAME,
+    spokenSegments,
+    fetchImpl,
+    maxAttempts: options.maxTtsAttempts ?? DEFAULT_TTS_MAX_ATTEMPTS,
+  };
 }
 
 type RewriteTextForSpeechArgs = {
@@ -214,31 +308,25 @@ async function rewriteTextForSpeech(args: RewriteTextForSpeechArgs): Promise<str
   return rewrittenText;
 }
 
-type SynthesizeSpeechAudioChunksArgs = {
-  apiKey: string;
-  model: string;
-  voiceName: string;
-  spokenChunks: string[];
-  fetchImpl: typeof fetch;
+type SynthesizeSpeechAudioSegmentsArgs = PreparedGeminiSpeech & {
   signal?: AbortSignal;
-  maxAttempts: number;
   concurrency: number;
-  onChunkProgress?: (progress: GeminiSpeechChunkProgress) => void | Promise<void>;
+  onSegmentProgress?: (progress: GeminiSpeechSegmentProgress) => void | Promise<void>;
 };
 
-type SynthesizedSpeechAudioChunk = {
+type SynthesizedSpeechAudioSegment = {
   index: number;
   pcmAudio: Buffer;
 };
 
-type SynthesizeSpeechAudioChunksInOrderArgs = SynthesizeSpeechAudioChunksArgs & {
+type SynthesizeSpeechAudioSegmentsInOrderArgs = SynthesizeSpeechAudioSegmentsArgs & {
   abortOnFailure?: () => void;
 };
 
-async function* synthesizeSpeechAudioChunksInOrder(
-  args: SynthesizeSpeechAudioChunksInOrderArgs,
-): AsyncGenerator<SynthesizedSpeechAudioChunk> {
-  const total = args.spokenChunks.length;
+async function* synthesizeSpeechAudioSegmentsInOrder(
+  args: SynthesizeSpeechAudioSegmentsInOrderArgs,
+): AsyncGenerator<SynthesizedSpeechAudioSegment> {
+  const total = args.spokenSegments.length;
   const results = new Array<Buffer | undefined>(total);
   const concurrency = Math.max(1, Math.trunc(args.concurrency));
   let nextIndex = 0;
@@ -283,14 +371,9 @@ async function* synthesizeSpeechAudioChunksInOrder(
       }
 
       try {
-        const pcmAudio = await synthesizeSpeechAudioChunk({
-          apiKey: args.apiKey,
-          model: args.model,
-          voiceName: args.voiceName,
-          spokenText: args.spokenChunks[index]!,
-          fetchImpl: args.fetchImpl,
-          signal: args.signal,
-          maxAttempts: args.maxAttempts,
+        const pcmAudio = await synthesizeSpeechAudioSegment({
+          ...args,
+          spokenText: args.spokenSegments[index]!,
         });
         totalPcmBytes += pcmAudio.length;
         if (totalPcmBytes > MAX_SPEECH_PCM_BYTES) {
@@ -298,11 +381,11 @@ async function* synthesizeSpeechAudioChunksInOrder(
         }
         results[index] = pcmAudio;
         ready += 1;
-        await args.onChunkProgress?.({ ready, total });
+        await args.onSegmentProgress?.({ ready, total });
         wake();
-      } catch (err) {
+      } catch (error) {
         if (failure === undefined) {
-          failure = err;
+          failure = error;
         }
         args.abortOnFailure?.();
         wake();
@@ -337,52 +420,28 @@ async function* synthesizeSpeechAudioChunksInOrder(
   }
 }
 
-type SynthesizeSpeechAudioChunkArgs = {
-  apiKey: string;
-  model: string;
-  voiceName: string;
+type SynthesizeSpeechAudioSegmentArgs = Omit<PreparedGeminiSpeech, "spokenSegments"> & {
   spokenText: string;
-  fetchImpl: typeof fetch;
   signal?: AbortSignal;
-  maxAttempts: number;
 };
 
-async function synthesizeSpeechAudioChunk(args: SynthesizeSpeechAudioChunkArgs): Promise<Buffer> {
+async function synthesizeSpeechAudioSegment(
+  args: SynthesizeSpeechAudioSegmentArgs,
+): Promise<Buffer> {
   const maxAttempts = Math.max(1, Math.trunc(args.maxAttempts));
   let lastError: unknown;
 
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     try {
       const payload = await requestGeminiGenerateContent({
         apiKey: args.apiKey,
         model: args.model,
         fetchImpl: args.fetchImpl,
         signal: args.signal,
-        body: {
-          contents: [
-            {
-              parts: [
-                {
-                  text: buildSpeechSynthesisPrompt(args.spokenText),
-                },
-              ],
-            },
-          ],
-          generationConfig: {
-            responseModalities: ["AUDIO"],
-            maxOutputTokens: TTS_MAX_OUTPUT_TOKENS,
-            speechConfig: {
-              voiceConfig: {
-                prebuiltVoiceConfig: {
-                  voiceName: args.voiceName,
-                },
-              },
-            },
-          },
-        },
+        body: buildSpeechSynthesisRequest(args.spokenText, args.voiceName),
       });
 
-      assertGeminiTtsDidNotReachOutputLimit(payload);
+      assertGeminiTtsCompleted(payload);
       const audioData = extractGeminiInlineAudioData(payload);
       if (!audioData) {
         throw new GeminiTtsResponseError("Gemini TTS response did not include audio data");
@@ -401,6 +460,132 @@ async function synthesizeSpeechAudioChunk(args: SynthesizeSpeechAudioChunkArgs):
   throw lastError instanceof Error ? lastError : new Error("Gemini TTS request failed");
 }
 
+type StreamSpeechSegmentArgs = SynthesizeSpeechAudioSegmentArgs;
+
+async function* streamSpeechSegmentWithRetries(
+  args: StreamSpeechSegmentArgs,
+): AsyncGenerator<Buffer> {
+  const maxAttempts = Math.max(1, Math.trunc(args.maxAttempts));
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    let emittedAudio = false;
+    try {
+      for await (const audio of requestGeminiSpeechStream(args)) {
+        emittedAudio = true;
+        yield audio;
+      }
+      return;
+    } catch (error) {
+      lastError = error;
+      if (
+        emittedAudio ||
+        args.signal?.aborted ||
+        !isRetryableTtsError(error) ||
+        attempt >= maxAttempts
+      ) {
+        throw error;
+      }
+      await waitForRetryDelay(attempt, args.signal);
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error("Gemini TTS request failed");
+}
+
+async function collectStreamingSpeechSegment(
+  args: StreamSpeechSegmentArgs & { accountAudio: (audio: Buffer) => void },
+): Promise<Buffer> {
+  const maxAttempts = Math.max(1, Math.trunc(args.maxAttempts));
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const chunks: Buffer[] = [];
+    try {
+      for await (const audio of requestGeminiSpeechStream(args)) {
+        chunks.push(audio);
+      }
+    } catch (error) {
+      lastError = error;
+      if (args.signal?.aborted || !isRetryableTtsError(error) || attempt >= maxAttempts) {
+        throw error;
+      }
+      await waitForRetryDelay(attempt, args.signal);
+      continue;
+    }
+
+    const audio = Buffer.concat(chunks);
+    args.accountAudio(audio);
+    return audio;
+  }
+
+  throw lastError instanceof Error ? lastError : new Error("Gemini TTS request failed");
+}
+
+async function* requestGeminiSpeechStream(args: StreamSpeechSegmentArgs): AsyncGenerator<Buffer> {
+  const response = await requestGeminiResponse({
+    apiKey: args.apiKey,
+    model: args.model,
+    method: "streamGenerateContent?alt=sse",
+    fetchImpl: args.fetchImpl,
+    signal: args.signal,
+    body: buildSpeechSynthesisRequest(args.spokenText, args.voiceName),
+  });
+  if (!response.body) {
+    throw new GeminiTtsResponseError("Gemini TTS streaming response did not include a body");
+  }
+
+  let receivedAudio = false;
+  let completed = false;
+  for await (const payload of parseGeminiSse(response.body)) {
+    const finishReason = getGeminiFinishReason(payload);
+    if (finishReason) {
+      assertGeminiTtsFinishReason(finishReason);
+      completed = finishReason === "STOP";
+    }
+
+    for (const audioData of extractGeminiInlineAudioDataParts(payload)) {
+      receivedAudio = true;
+      yield Buffer.from(audioData, "base64");
+    }
+  }
+
+  if (!receivedAudio) {
+    throw new GeminiTtsResponseError("Gemini TTS response did not include audio data");
+  }
+  if (!completed) {
+    throw new GeminiTtsResponseError("Gemini TTS stream ended without a stop response");
+  }
+}
+
+function buildSpeechSynthesisRequest(
+  spokenText: string,
+  voiceName: string,
+): Record<string, unknown> {
+  return {
+    contents: [
+      {
+        parts: [
+          {
+            text: buildSpeechSynthesisPrompt(spokenText),
+          },
+        ],
+      },
+    ],
+    generationConfig: {
+      responseModalities: ["AUDIO"],
+      maxOutputTokens: TTS_MAX_OUTPUT_TOKENS,
+      speechConfig: {
+        voiceConfig: {
+          prebuiltVoiceConfig: {
+            voiceName,
+          },
+        },
+      },
+    },
+  };
+}
+
 type RequestGeminiGenerateContentArgs = {
   apiKey: string;
   model: string;
@@ -409,11 +594,25 @@ type RequestGeminiGenerateContentArgs = {
   signal?: AbortSignal;
 };
 
+type RequestGeminiResponseArgs = RequestGeminiGenerateContentArgs & {
+  method: string;
+};
+
 async function requestGeminiGenerateContent(
   args: RequestGeminiGenerateContentArgs,
 ): Promise<unknown> {
+  const response = await requestGeminiResponse({ ...args, method: "generateContent" });
+  const responseText = await response.text();
+  try {
+    return responseText ? (JSON.parse(responseText) as unknown) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function requestGeminiResponse(args: RequestGeminiResponseArgs): Promise<Response> {
   const response = await args.fetchImpl(
-    `${GEMINI_GENERATE_CONTENT_BASE_URL}/${encodeURIComponent(args.model)}:generateContent`,
+    `${GEMINI_GENERATE_CONTENT_BASE_URL}/${encodeURIComponent(args.model)}:${args.method}`,
     {
       method: "POST",
       headers: {
@@ -424,6 +623,9 @@ async function requestGeminiGenerateContent(
       signal: args.signal,
     },
   );
+  if (response.ok) {
+    return response;
+  }
 
   const responseText = await response.text();
   let payload: unknown;
@@ -432,17 +634,69 @@ async function requestGeminiGenerateContent(
   } catch {
     payload = undefined;
   }
+  const parsed = errorPayloadSchema.safeParse(payload);
+  const fallbackMessage = responseText.trim() || `HTTP ${response.status}`;
+  const message = parsed.success
+    ? (parsed.data.error?.message ?? fallbackMessage)
+    : fallbackMessage;
+  throw new GeminiApiError(message, response.status);
+}
 
-  if (!response.ok) {
-    const parsed = errorPayloadSchema.safeParse(payload);
-    const fallbackMessage = responseText.trim() || `HTTP ${response.status}`;
-    const message = parsed.success
-      ? (parsed.data.error?.message ?? fallbackMessage)
-      : fallbackMessage;
-    throw new GeminiApiError(message, response.status);
+async function* parseGeminiSse(body: ReadableStream<Uint8Array>): AsyncGenerator<unknown> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffered = "";
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      buffered += decoder.decode(value, { stream: !done });
+
+      let boundary = findSseEventBoundary(buffered);
+      while (boundary) {
+        const event = buffered.slice(0, boundary.index);
+        buffered = buffered.slice(boundary.index + boundary.length);
+        const payload = parseSseEvent(event);
+        if (payload !== undefined) {
+          yield payload;
+        }
+        boundary = findSseEventBoundary(buffered);
+      }
+
+      if (done) {
+        const payload = parseSseEvent(buffered);
+        if (payload !== undefined) {
+          yield payload;
+        }
+        return;
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function findSseEventBoundary(text: string): { index: number; length: number } | undefined {
+  const match = /\r?\n\r?\n/u.exec(text);
+  return match ? { index: match.index, length: match[0].length } : undefined;
+}
+
+function parseSseEvent(event: string): unknown {
+  const data = event
+    .split(/\r?\n/u)
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => line.slice(5).trimStart())
+    .join("\n")
+    .trim();
+  if (!data || data === "[DONE]") {
+    return undefined;
   }
 
-  return payload;
+  try {
+    return JSON.parse(data) as unknown;
+  } catch {
+    throw new GeminiTtsResponseError("Gemini TTS returned malformed streaming data");
+  }
 }
 
 function extractGeminiText(payload: unknown): string {
@@ -471,25 +725,45 @@ function extractGeminiText(payload: unknown): string {
   return "";
 }
 
-function assertGeminiTtsDidNotReachOutputLimit(payload: unknown): void {
-  if (!isObject(payload) || !Array.isArray(payload.candidates)) {
-    return;
-  }
-
-  if (
-    payload.candidates.some(
-      (candidate) => isObject(candidate) && candidate.finishReason === "MAX_TOKENS",
-    )
-  ) {
-    throw new GeminiTtsOutputLimitError();
+function assertGeminiTtsCompleted(payload: unknown): void {
+  const finishReason = getGeminiFinishReason(payload);
+  if (finishReason) {
+    assertGeminiTtsFinishReason(finishReason);
   }
 }
 
-function extractGeminiInlineAudioData(payload: unknown): string | undefined {
+function assertGeminiTtsFinishReason(finishReason: string): void {
+  if (finishReason === "MAX_TOKENS") {
+    throw new GeminiTtsOutputLimitError();
+  }
+  if (finishReason !== "STOP") {
+    throw new GeminiTtsResponseError(`Gemini TTS stopped with finish reason '${finishReason}'`);
+  }
+}
+
+function getGeminiFinishReason(payload: unknown): string | undefined {
   if (!isObject(payload) || !Array.isArray(payload.candidates)) {
     return undefined;
   }
 
+  for (const candidate of payload.candidates) {
+    if (isObject(candidate) && typeof candidate.finishReason === "string") {
+      return candidate.finishReason;
+    }
+  }
+  return undefined;
+}
+
+function extractGeminiInlineAudioData(payload: unknown): string | undefined {
+  return extractGeminiInlineAudioDataParts(payload)[0];
+}
+
+function extractGeminiInlineAudioDataParts(payload: unknown): string[] {
+  if (!isObject(payload) || !Array.isArray(payload.candidates)) {
+    return [];
+  }
+
+  const audioData: string[] = [];
   for (const candidate of payload.candidates) {
     if (
       !isObject(candidate) ||
@@ -509,12 +783,12 @@ function extractGeminiInlineAudioData(payload: unknown): string | undefined {
       }
       const data = part.inlineData.data.trim();
       if (data) {
-        return data;
+        audioData.push(data);
       }
     }
   }
 
-  return undefined;
+  return audioData;
 }
 
 function buildSpeechRewritePrompt(sourceText: string): string {
@@ -559,55 +833,113 @@ function exceedsUnicodeCharacterLimit(text: string, limit: number): boolean {
   return false;
 }
 
-function splitSpeechChunks(spokenText: string, deliveryMode: GeminiSpeechDeliveryMode): string[] {
+function splitSpeechSegments(spokenText: string): string[] {
   const normalizedText = spokenText
     .trim()
     .split(/\n\s*\n/gu)
     .map((paragraph) => paragraph.replace(/\s+/gu, " ").trim())
     .filter(Boolean)
     .join("\n\n");
-  const maxCharacters =
-    deliveryMode === "progressive"
-      ? PROGRESSIVE_SPEECH_CHUNK_CHARACTERS
-      : COMPLETE_SPEECH_CHUNK_CHARACTERS;
-  const chunks: string[] = [];
-  let remaining = Array.from(normalizedText);
-
-  while (remaining.length > maxCharacters) {
-    const boundary = findSpeechChunkBoundary(remaining, maxCharacters);
-    chunks.push(remaining.slice(0, boundary).join("").trim());
-    remaining = Array.from(remaining.slice(boundary).join("").trim());
+  const characters = Array.from(normalizedText);
+  const cumulativeWeights = [0];
+  for (const character of characters) {
+    cumulativeWeights.push(cumulativeWeights.at(-1)! + speechCharacterWeight(character));
   }
 
-  if (remaining.length > 0) {
-    chunks.push(remaining.join(""));
+  const totalWeight = cumulativeWeights.at(-1)!;
+  const segmentCount = Math.max(1, Math.ceil(totalWeight / MAX_SPEECH_SEGMENT_WEIGHT));
+  if (segmentCount === 1) {
+    return [normalizedText];
   }
 
-  return chunks.length > 0 ? chunks : [spokenText.trim()];
+  const boundaries = [0];
+  for (let segment = 1; segment < segmentCount; segment += 1) {
+    const previousBoundary = boundaries.at(-1)!;
+    const previousWeight = cumulativeWeights[previousBoundary]!;
+    const remainingSegments = segmentCount - segment;
+    const minimumWeight = Math.max(
+      previousWeight + 1,
+      totalWeight - remainingSegments * MAX_SPEECH_SEGMENT_WEIGHT,
+    );
+    const maximumWeight = Math.min(
+      previousWeight + MAX_SPEECH_SEGMENT_WEIGHT,
+      totalWeight - remainingSegments,
+    );
+    const idealWeight = (totalWeight * segment) / segmentCount;
+    const maximumBoundary = characters.length - remainingSegments;
+    const candidates = Array.from(
+      { length: maximumBoundary - previousBoundary },
+      (_, offset) => previousBoundary + offset + 1,
+    ).filter((index) => {
+      const weight = cumulativeWeights[index]!;
+      return weight >= minimumWeight && weight <= maximumWeight;
+    });
+    const naturalCandidates = candidates.filter((index) =>
+      isNaturalSpeechBoundary(characters, index),
+    );
+    const wordCandidates = candidates.filter((index) => /\s/u.test(characters[index] ?? ""));
+    boundaries.push(
+      selectSpeechBoundary(
+        naturalCandidates,
+        wordCandidates.length > 0 ? wordCandidates : candidates,
+        cumulativeWeights,
+        idealWeight,
+      ),
+    );
+  }
+  boundaries.push(characters.length);
+
+  return boundaries
+    .slice(1)
+    .map((boundary, index) => characters.slice(boundaries[index], boundary).join("").trim());
 }
 
-function findSpeechChunkBoundary(characters: string[], maxCharacters: number): number {
-  const preferredMinimum = Math.floor(maxCharacters * 0.6);
+function speechCharacterWeight(character: string): number {
+  return /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u.test(character)
+    ? 3
+    : 1;
+}
 
-  for (let index = maxCharacters; index >= preferredMinimum; index -= 1) {
-    if (characters[index] === "\n" && characters[index + 1] === "\n") {
-      return index;
-    }
+function isNaturalSpeechBoundary(characters: string[], index: number): boolean {
+  const previous = characters[index - 1] ?? "";
+  const next = characters[index] ?? "";
+  return (previous === "\n" && next === "\n") || isSpeechSentenceBoundary(previous, next);
+}
+
+function selectSpeechBoundary(
+  naturalCandidates: number[],
+  fallbackCandidates: number[],
+  cumulativeWeights: number[],
+  idealWeight: number,
+): number {
+  const fallback = closestSpeechBoundary(fallbackCandidates, cumulativeWeights, idealWeight);
+  if (naturalCandidates.length === 0) {
+    return fallback;
   }
 
-  for (let index = maxCharacters; index >= preferredMinimum; index -= 1) {
-    if (isSpeechSentenceBoundary(characters[index - 1] ?? "", characters[index] ?? "")) {
-      return index;
+  const natural = closestSpeechBoundary(naturalCandidates, cumulativeWeights, idealWeight);
+  const naturalDistance = Math.abs(cumulativeWeights[natural]! - idealWeight);
+  const fallbackDistance = Math.abs(cumulativeWeights[fallback]! - idealWeight);
+  return naturalDistance <= fallbackDistance + MAX_SPEECH_SEGMENT_WEIGHT * 0.05
+    ? natural
+    : fallback;
+}
+
+function closestSpeechBoundary(
+  candidates: number[],
+  cumulativeWeights: number[],
+  idealWeight: number,
+): number {
+  let closest = candidates[0]!;
+  let closestDistance = Math.abs(cumulativeWeights[closest]! - idealWeight);
+  for (const candidate of candidates.slice(1)) {
+    const distance = Math.abs(cumulativeWeights[candidate]! - idealWeight);
+    if (distance < closestDistance) {
+      closest = candidate;
+      closestDistance = distance;
     }
   }
-
-  for (let index = maxCharacters; index >= 1; index -= 1) {
-    if (/\s/u.test(characters[index] ?? "")) {
-      return index;
-    }
-  }
-
-  return maxCharacters;
+  return closest;
 }
 
 function isSpeechSentenceBoundary(previous: string, next: string): boolean {

--- a/src/core/utils/gemini_speech.ts
+++ b/src/core/utils/gemini_speech.ts
@@ -646,6 +646,7 @@ async function* parseGeminiSse(body: ReadableStream<Uint8Array>): AsyncGenerator
   const reader = body.getReader();
   const decoder = new TextDecoder();
   let buffered = "";
+  let completed = false;
 
   try {
     while (true) {
@@ -668,10 +669,14 @@ async function* parseGeminiSse(body: ReadableStream<Uint8Array>): AsyncGenerator
         if (payload !== undefined) {
           yield payload;
         }
+        completed = true;
         return;
       }
     }
   } finally {
+    if (!completed) {
+      await reader.cancel().catch(() => {});
+    }
     reader.releaseLock();
   }
 }
@@ -847,7 +852,8 @@ function splitSpeechSegments(spokenText: string): string[] {
   }
 
   const totalWeight = cumulativeWeights.at(-1)!;
-  const segmentCount = Math.max(1, Math.ceil(totalWeight / MAX_SPEECH_SEGMENT_WEIGHT));
+  const minimumSegmentCounts = minimumSpeechSegmentCounts(cumulativeWeights);
+  const segmentCount = minimumSegmentCounts[0]!;
   if (segmentCount === 1) {
     return [normalizedText];
   }
@@ -857,23 +863,16 @@ function splitSpeechSegments(spokenText: string): string[] {
     const previousBoundary = boundaries.at(-1)!;
     const previousWeight = cumulativeWeights[previousBoundary]!;
     const remainingSegments = segmentCount - segment;
-    const minimumWeight = Math.max(
-      previousWeight + 1,
-      totalWeight - remainingSegments * MAX_SPEECH_SEGMENT_WEIGHT,
-    );
-    const maximumWeight = Math.min(
-      previousWeight + MAX_SPEECH_SEGMENT_WEIGHT,
-      totalWeight - remainingSegments,
-    );
     const idealWeight = (totalWeight * segment) / segmentCount;
     const maximumBoundary = characters.length - remainingSegments;
     const candidates = Array.from(
       { length: maximumBoundary - previousBoundary },
       (_, offset) => previousBoundary + offset + 1,
-    ).filter((index) => {
-      const weight = cumulativeWeights[index]!;
-      return weight >= minimumWeight && weight <= maximumWeight;
-    });
+    ).filter(
+      (index) =>
+        cumulativeWeights[index]! - previousWeight <= MAX_SPEECH_SEGMENT_WEIGHT &&
+        minimumSegmentCounts[index]! <= remainingSegments,
+    );
     const naturalCandidates = candidates.filter((index) =>
       isNaturalSpeechBoundary(characters, index),
     );
@@ -898,6 +897,18 @@ function speechCharacterWeight(character: string): number {
   return /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u.test(character)
     ? 3
     : 1;
+}
+
+function minimumSpeechSegmentCounts(cumulativeWeights: number[]): number[] {
+  const counts = new Array<number>(cumulativeWeights.length).fill(0);
+  let boundary = cumulativeWeights.length - 1;
+  for (let index = cumulativeWeights.length - 2; index >= 0; index -= 1) {
+    while (cumulativeWeights[boundary]! - cumulativeWeights[index]! > MAX_SPEECH_SEGMENT_WEIGHT) {
+      boundary -= 1;
+    }
+    counts[index] = counts[boundary]! + 1;
+  }
+  return counts;
 }
 
 function isNaturalSpeechBoundary(characters: string[], index: number): boolean {

--- a/src/tui/speech_playback.ts
+++ b/src/tui/speech_playback.ts
@@ -85,10 +85,6 @@ export async function runSpeechPlaybackTask(args: {
         refreshSpeechProgress();
       },
     })) {
-      if (args.signal.aborted) {
-        return;
-      }
-
       playbackStarted = true;
       totalSegments = chunk.total;
       refreshSpeechProgress();
@@ -117,6 +113,9 @@ export async function runSpeechPlaybackTask(args: {
       ("error" in outcome && isMissingExecutableError(outcome.error))
     ) {
       throw new Error("ffplay not found. Install ffmpeg to use /speak.");
+    }
+    if ("result" in outcome && !outcome.result.aborted) {
+      throw playbackFailure(outcome.result);
     }
     throw error;
   } finally {

--- a/src/tui/speech_playback.ts
+++ b/src/tui/speech_playback.ts
@@ -1,13 +1,12 @@
-import { unlink, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import type { ChildProcess } from "node:child_process";
+import type { Writable } from "node:stream";
 import type { CoreDeps } from "../core/runtime/deps.js";
 import {
+  GEMINI_SPEECH_CHANNEL_COUNT,
   GEMINI_SPEECH_PLAYBACK_RATE,
-  streamGeminiSpeechAudio,
+  GEMINI_SPEECH_SAMPLE_RATE_HZ,
+  streamGeminiSpeechPcm,
 } from "../core/utils/gemini_speech.js";
-
-export const SPEAK_TEMP_FILE_TEMPLATE = join(tmpdir(), "tau-speak.XXXXXX");
 
 export async function runSpeechPlaybackTask(args: {
   deps: CoreDeps;
@@ -16,33 +15,73 @@ export async function runSpeechPlaybackTask(args: {
   signal: AbortSignal;
   onActivityLabel: (hint: string) => void;
 }): Promise<void> {
-  let audioPath: string | undefined;
-  let readyChunks = 0;
-  let totalChunks = 0;
-  let playedChunks = 0;
+  const abortController = createLinkedAbortController(args.signal);
+  let playbackInput: Writable | null = null;
+  let readySegments = 0;
+  let totalSegments = 0;
   let playbackStarted = false;
 
   const refreshSpeechProgress = (): void => {
-    if (totalChunks <= 0) return;
+    if (totalSegments <= 0) return;
     args.onActivityLabel(
       playbackStarted
-        ? formatSpeechPlaybackProgressMessage(playedChunks, readyChunks, totalChunks)
-        : formatSpeechChunkProgressMessage(readyChunks, totalChunks),
+        ? formatSpeechPlaybackProgressMessage(readySegments, totalSegments)
+        : formatSpeechGenerationProgressMessage(readySegments, totalSegments),
     );
   };
 
+  const playback = args.deps
+    .spawn(
+      "ffplay",
+      [
+        "-nodisp",
+        "-autoexit",
+        "-loglevel",
+        "error",
+        "-f",
+        "s16le",
+        "-ar",
+        String(GEMINI_SPEECH_SAMPLE_RATE_HZ),
+        "-ac",
+        String(GEMINI_SPEECH_CHANNEL_COUNT),
+        "-af",
+        `atempo=${GEMINI_SPEECH_PLAYBACK_RATE}`,
+        "pipe:0",
+      ],
+      {
+        detached: true,
+        killProcessGroup: true,
+        signal: abortController.signal,
+        stdio: ["pipe", "ignore", "pipe"],
+        captureOutput: "stderr",
+        maxCaptureBytes: 20_000,
+        onSpawn: (child: ChildProcess) => {
+          playbackInput = child.stdin;
+          playbackInput?.on("error", () => {});
+        },
+      },
+    )
+    .then(
+      (result) => ({ result }),
+      (error: unknown) => ({ error }),
+    );
+
   try {
-    for await (const chunk of streamGeminiSpeechAudio({
+    if (!playbackInput) {
+      const outcome = await playback;
+      throw "error" in outcome ? outcome.error : playbackFailure(outcome.result);
+    }
+
+    for await (const chunk of streamGeminiSpeechPcm({
       apiKey: args.apiKey,
       sourceText: args.sourceText,
-      deliveryMode: "progressive",
-      signal: args.signal,
+      signal: abortController.signal,
       onStageChange: (stage) => {
         args.onActivityLabel(stage === "rewriting" ? "rewriting for speech" : "generating speech");
       },
-      onChunkProgress: ({ ready, total }) => {
-        readyChunks = ready;
-        totalChunks = total;
+      onSegmentProgress: ({ ready, total }) => {
+        readySegments = ready;
+        totalSegments = total;
         refreshSpeechProgress();
       },
     })) {
@@ -51,84 +90,126 @@ export async function runSpeechPlaybackTask(args: {
       }
 
       playbackStarted = true;
-      totalChunks = chunk.total;
+      totalSegments = chunk.total;
       refreshSpeechProgress();
-
-      audioPath = await createTempFilePath(args.deps, SPEAK_TEMP_FILE_TEMPLATE);
-      await writeFile(audioPath, chunk.audio);
-
-      const playback = await args.deps.spawn(
-        "afplay",
-        ["-r", String(GEMINI_SPEECH_PLAYBACK_RATE), audioPath],
-        {
-          detached: true,
-          killProcessGroup: true,
-          signal: args.signal,
-          stdio: ["ignore", "ignore", "ignore"],
-        },
-      );
-      await cleanupTempFile(audioPath);
-      audioPath = undefined;
-
-      if (args.signal.aborted || playback.aborted) {
-        return;
-      }
-      if (playback.exitCode !== 0) {
-        const detail =
-          playback.exitCode !== null
-            ? `afplay exited with code ${playback.exitCode}`
-            : playback.closeSignal
-              ? `afplay terminated by signal ${playback.closeSignal}`
-              : "afplay exited";
-        throw new Error(detail);
-      }
-
-      playedChunks = chunk.index + 1;
-      refreshSpeechProgress();
+      await writePlaybackAudio(playbackInput, chunk.audio, abortController.signal);
     }
-  } catch (err) {
-    if (args.signal.aborted) {
+
+    await endPlayback(playbackInput);
+    const outcome = await playback;
+    if ("error" in outcome) {
+      throw outcome.error;
+    }
+    if (args.signal.aborted || outcome.result.aborted) {
       return;
     }
-    const error = err as NodeJS.ErrnoException;
-    if (error.name === "AbortError") {
+    if (outcome.result.exitCode !== 0) {
+      throw playbackFailure(outcome.result);
+    }
+  } catch (error) {
+    abortController.abort();
+    const outcome = await playback;
+    if (args.signal.aborted || (error instanceof Error && error.name === "AbortError")) {
       return;
     }
-    if (error.code === "ENOENT") {
-      throw new Error("afplay not found.");
+    if (
+      isMissingExecutableError(error) ||
+      ("error" in outcome && isMissingExecutableError(outcome.error))
+    ) {
+      throw new Error("ffplay not found. Install ffmpeg to use /speak.");
     }
-    throw err;
+    throw error;
   } finally {
-    if (audioPath) {
-      await cleanupTempFile(audioPath);
-    }
+    abortController.abort();
+    abortController.dispose();
   }
 }
 
-async function createTempFilePath(deps: CoreDeps, template: string): Promise<string> {
-  const result = await deps.spawn("mktemp", [template]);
-  if (result.exitCode !== 0) {
-    throw new Error(result.stderr || result.stdout || "mktemp failed");
+async function writePlaybackAudio(
+  input: Writable,
+  audio: Buffer,
+  signal: AbortSignal,
+): Promise<void> {
+  if (signal.aborted) {
+    throw abortError();
   }
-  const path = result.stdout.trim();
-  if (!path) {
-    throw new Error("mktemp returned an empty path");
-  }
-  return path;
+
+  await new Promise<void>((resolve, reject) => {
+    input.write(audio, (error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
 }
 
-async function cleanupTempFile(path: string): Promise<void> {
-  try {
-    await unlink(path);
-  } catch {
-    // best-effort cleanup
+async function endPlayback(input: Writable): Promise<void> {
+  if (input.destroyed || input.writableEnded) {
+    return;
   }
+  await new Promise<void>((resolve) => input.end(resolve));
 }
 
-function formatSpeechChunkProgressMessage(ready: number, total: number): string {
-  return `generating speech chunks (${ready} out of ${total} ready)`;
+function playbackFailure(result: {
+  stderr: string;
+  exitCode: number | null;
+  closeSignal: NodeJS.Signals | null;
+}): Error {
+  const detail = result.stderr.trim();
+  if (detail) {
+    return new Error(`ffplay failed: ${detail}`);
+  }
+  if (result.exitCode !== null) {
+    return new Error(`ffplay exited with code ${result.exitCode}`);
+  }
+  if (result.closeSignal) {
+    return new Error(`ffplay terminated by signal ${result.closeSignal}`);
+  }
+  return new Error("ffplay exited");
 }
 
-function formatSpeechPlaybackProgressMessage(played: number, ready: number, total: number): string {
-  return `playing speech (${played}/${total} played, ${ready}/${total} ready)`;
+function formatSpeechGenerationProgressMessage(ready: number, total: number): string {
+  return `generating speech segments (${ready} out of ${total} ready)`;
+}
+
+function formatSpeechPlaybackProgressMessage(ready: number, total: number): string {
+  return `playing speech (${ready}/${total} generated)`;
+}
+
+function isMissingExecutableError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as NodeJS.ErrnoException).code === "ENOENT"
+  );
+}
+
+function createLinkedAbortController(parent: AbortSignal): {
+  signal: AbortSignal;
+  abort: () => void;
+  dispose: () => void;
+} {
+  const controller = new AbortController();
+  const onAbort = () => controller.abort(parent.reason);
+
+  if (parent.aborted) {
+    onAbort();
+  } else {
+    parent.addEventListener("abort", onAbort, { once: true });
+  }
+
+  return {
+    signal: controller.signal,
+    abort: () => controller.abort(),
+    dispose: () => parent.removeEventListener("abort", onAbort),
+  };
+}
+
+function abortError(): Error {
+  const error = new Error("Speech playback was aborted");
+  error.name = "AbortError";
+  return error;
 }

--- a/src/tui/speech_playback.ts
+++ b/src/tui/speech_playback.ts
@@ -28,10 +28,10 @@ export async function runSpeechPlaybackTask(args: {
   onActivityLabel: (hint: string) => void;
 }): Promise<void> {
   const abortController = createLinkedAbortController(args.signal);
-  const bufferedAudio: Buffer[] = [];
-  let bufferedAudioBytes = 0;
   let playback: Promise<PlaybackOutcome> | undefined;
   let playbackInput: Writable | null = null;
+  let playbackEnding = false;
+  let earlyPlaybackOutcome: PlaybackOutcome | undefined;
 
   const startPlayback = async (): Promise<Writable> => {
     if (!playback) {
@@ -70,6 +70,12 @@ export async function runSpeechPlaybackTask(args: {
           (result) => ({ result }),
           (error: unknown) => ({ error }),
         );
+      void playback.then((outcome) => {
+        if (!playbackEnding && !abortController.signal.aborted) {
+          earlyPlaybackOutcome = outcome;
+          abortController.abort();
+        }
+      });
     }
 
     if (!playbackInput) {
@@ -81,40 +87,21 @@ export async function runSpeechPlaybackTask(args: {
     return playbackInput;
   };
 
-  const flushBufferedAudio = async (): Promise<void> => {
-    const input = await startPlayback();
-    for (const audio of bufferedAudio) {
-      await writePlaybackAudio(input, audio, abortController.signal);
-    }
-    bufferedAudio.length = 0;
-    bufferedAudioBytes = 0;
-  };
-
   try {
     for await (const chunk of streamGeminiSpeechPcm({
       apiKey: args.apiKey,
       sourceText: args.sourceText,
       signal: abortController.signal,
+      initialBufferBytes: SPEECH_PLAYBACK_START_BUFFER_BYTES,
       onStageChange: (stage) => {
         args.onActivityLabel(stage === "rewriting" ? "rewriting for speech" : "preparing speech");
       },
     })) {
-      if (!playback) {
-        bufferedAudio.push(chunk.audio);
-        bufferedAudioBytes += chunk.audio.length;
-        if (bufferedAudioBytes < SPEECH_PLAYBACK_START_BUFFER_BYTES) {
-          continue;
-        }
-        await flushBufferedAudio();
-        continue;
-      }
-
-      await writePlaybackAudio(playbackInput!, chunk.audio, abortController.signal);
+      const input = await startPlayback();
+      await writePlaybackAudio(input, chunk.audio, abortController.signal);
     }
 
-    if (!playback) {
-      await flushBufferedAudio();
-    }
+    playbackEnding = true;
     await endPlayback(playbackInput!);
     const outcome = await playback!;
     if ("error" in outcome) {
@@ -128,7 +115,16 @@ export async function runSpeechPlaybackTask(args: {
     }
   } catch (error) {
     abortController.abort();
-    const outcome = playback ? await playback : undefined;
+    const outcome = earlyPlaybackOutcome ?? (playback ? await playback : undefined);
+    if (earlyPlaybackOutcome) {
+      if ("error" in earlyPlaybackOutcome) {
+        if (isMissingExecutableError(earlyPlaybackOutcome.error)) {
+          throw new Error("ffplay not found. Install ffmpeg to use /speak.");
+        }
+        throw earlyPlaybackOutcome.error;
+      }
+      throw playbackFailure(earlyPlaybackOutcome.result);
+    }
     if (args.signal.aborted || (error instanceof Error && error.name === "AbortError")) {
       return;
     }

--- a/src/tui/speech_playback.ts
+++ b/src/tui/speech_playback.ts
@@ -2,11 +2,23 @@ import type { ChildProcess } from "node:child_process";
 import type { Writable } from "node:stream";
 import type { CoreDeps } from "../core/runtime/deps.js";
 import {
+  GEMINI_SPEECH_BITS_PER_SAMPLE,
   GEMINI_SPEECH_CHANNEL_COUNT,
   GEMINI_SPEECH_PLAYBACK_RATE,
   GEMINI_SPEECH_SAMPLE_RATE_HZ,
   streamGeminiSpeechPcm,
 } from "../core/utils/gemini_speech.js";
+import type { SpawnCaptureResult } from "../core/utils/spawn_capture.js";
+
+const SPEECH_PLAYBACK_START_BUFFER_MS = 500;
+const SPEECH_PLAYBACK_START_BUFFER_BYTES = Math.ceil(
+  GEMINI_SPEECH_SAMPLE_RATE_HZ *
+    GEMINI_SPEECH_CHANNEL_COUNT *
+    (GEMINI_SPEECH_BITS_PER_SAMPLE / 8) *
+    (SPEECH_PLAYBACK_START_BUFFER_MS / 1000),
+);
+
+type PlaybackOutcome = { result: SpawnCaptureResult } | { error: unknown };
 
 export async function runSpeechPlaybackTask(args: {
   deps: CoreDeps;
@@ -16,83 +28,95 @@ export async function runSpeechPlaybackTask(args: {
   onActivityLabel: (hint: string) => void;
 }): Promise<void> {
   const abortController = createLinkedAbortController(args.signal);
+  const bufferedAudio: Buffer[] = [];
+  let bufferedAudioBytes = 0;
+  let playback: Promise<PlaybackOutcome> | undefined;
   let playbackInput: Writable | null = null;
-  let readySegments = 0;
-  let totalSegments = 0;
-  let playbackStarted = false;
 
-  const refreshSpeechProgress = (): void => {
-    if (totalSegments <= 0) return;
-    args.onActivityLabel(
-      playbackStarted
-        ? formatSpeechPlaybackProgressMessage(readySegments, totalSegments)
-        : formatSpeechGenerationProgressMessage(readySegments, totalSegments),
-    );
-  };
+  const startPlayback = async (): Promise<Writable> => {
+    if (!playback) {
+      playback = args.deps
+        .spawn(
+          "ffplay",
+          [
+            "-nodisp",
+            "-autoexit",
+            "-loglevel",
+            "error",
+            "-f",
+            "s16le",
+            "-ar",
+            String(GEMINI_SPEECH_SAMPLE_RATE_HZ),
+            "-ch_layout",
+            "mono",
+            "-af",
+            `atempo=${GEMINI_SPEECH_PLAYBACK_RATE}`,
+            "pipe:0",
+          ],
+          {
+            detached: true,
+            killProcessGroup: true,
+            signal: abortController.signal,
+            stdio: ["pipe", "ignore", "pipe"],
+            captureOutput: "stderr",
+            maxCaptureBytes: 20_000,
+            onSpawn: (child: ChildProcess) => {
+              playbackInput = child.stdin;
+              playbackInput?.on("error", () => {});
+            },
+          },
+        )
+        .then(
+          (result) => ({ result }),
+          (error: unknown) => ({ error }),
+        );
+    }
 
-  const playback = args.deps
-    .spawn(
-      "ffplay",
-      [
-        "-nodisp",
-        "-autoexit",
-        "-loglevel",
-        "error",
-        "-f",
-        "s16le",
-        "-ar",
-        String(GEMINI_SPEECH_SAMPLE_RATE_HZ),
-        "-ac",
-        String(GEMINI_SPEECH_CHANNEL_COUNT),
-        "-af",
-        `atempo=${GEMINI_SPEECH_PLAYBACK_RATE}`,
-        "pipe:0",
-      ],
-      {
-        detached: true,
-        killProcessGroup: true,
-        signal: abortController.signal,
-        stdio: ["pipe", "ignore", "pipe"],
-        captureOutput: "stderr",
-        maxCaptureBytes: 20_000,
-        onSpawn: (child: ChildProcess) => {
-          playbackInput = child.stdin;
-          playbackInput?.on("error", () => {});
-        },
-      },
-    )
-    .then(
-      (result) => ({ result }),
-      (error: unknown) => ({ error }),
-    );
-
-  try {
     if (!playbackInput) {
       const outcome = await playback;
       throw "error" in outcome ? outcome.error : playbackFailure(outcome.result);
     }
 
+    args.onActivityLabel("playing speech");
+    return playbackInput;
+  };
+
+  const flushBufferedAudio = async (): Promise<void> => {
+    const input = await startPlayback();
+    for (const audio of bufferedAudio) {
+      await writePlaybackAudio(input, audio, abortController.signal);
+    }
+    bufferedAudio.length = 0;
+    bufferedAudioBytes = 0;
+  };
+
+  try {
     for await (const chunk of streamGeminiSpeechPcm({
       apiKey: args.apiKey,
       sourceText: args.sourceText,
       signal: abortController.signal,
       onStageChange: (stage) => {
-        args.onActivityLabel(stage === "rewriting" ? "rewriting for speech" : "generating speech");
-      },
-      onSegmentProgress: ({ ready, total }) => {
-        readySegments = ready;
-        totalSegments = total;
-        refreshSpeechProgress();
+        args.onActivityLabel(stage === "rewriting" ? "rewriting for speech" : "preparing speech");
       },
     })) {
-      playbackStarted = true;
-      totalSegments = chunk.total;
-      refreshSpeechProgress();
-      await writePlaybackAudio(playbackInput, chunk.audio, abortController.signal);
+      if (!playback) {
+        bufferedAudio.push(chunk.audio);
+        bufferedAudioBytes += chunk.audio.length;
+        if (bufferedAudioBytes < SPEECH_PLAYBACK_START_BUFFER_BYTES) {
+          continue;
+        }
+        await flushBufferedAudio();
+        continue;
+      }
+
+      await writePlaybackAudio(playbackInput!, chunk.audio, abortController.signal);
     }
 
-    await endPlayback(playbackInput);
-    const outcome = await playback;
+    if (!playback) {
+      await flushBufferedAudio();
+    }
+    await endPlayback(playbackInput!);
+    const outcome = await playback!;
     if ("error" in outcome) {
       throw outcome.error;
     }
@@ -104,17 +128,17 @@ export async function runSpeechPlaybackTask(args: {
     }
   } catch (error) {
     abortController.abort();
-    const outcome = await playback;
+    const outcome = playback ? await playback : undefined;
     if (args.signal.aborted || (error instanceof Error && error.name === "AbortError")) {
       return;
     }
     if (
       isMissingExecutableError(error) ||
-      ("error" in outcome && isMissingExecutableError(outcome.error))
+      (outcome && "error" in outcome && isMissingExecutableError(outcome.error))
     ) {
       throw new Error("ffplay not found. Install ffmpeg to use /speak.");
     }
-    if ("result" in outcome && !outcome.result.aborted) {
+    if (outcome && "result" in outcome && !outcome.result.aborted) {
       throw playbackFailure(outcome.result);
     }
     throw error;
@@ -167,14 +191,6 @@ function playbackFailure(result: {
     return new Error(`ffplay terminated by signal ${result.closeSignal}`);
   }
   return new Error("ffplay exited");
-}
-
-function formatSpeechGenerationProgressMessage(ready: number, total: number): string {
-  return `generating speech segments (${ready} out of ${total} ready)`;
-}
-
-function formatSpeechPlaybackProgressMessage(ready: number, total: number): string {
-  return `playing speech (${ready}/${total} generated)`;
 }
 
 function isMissingExecutableError(error: unknown): boolean {

--- a/test/gemini_speech.test.js
+++ b/test/gemini_speech.test.js
@@ -371,6 +371,62 @@ describe("gemini speech", () => {
     expect(transcripts).toEqual([firstSentence, secondSentence]);
   });
 
+  it("uses feasible boundaries when weighted cuts cannot reach the aggregate capacity", async () => {
+    const rewrittenText = "これは音声です。".repeat(1020);
+    let requestIndex = 0;
+    const fetchMock = vi.fn(async () => {
+      if (requestIndex++ === 0) {
+        return new Response(
+          JSON.stringify({
+            candidates: [{ content: { parts: [{ text: rewrittenText }] } }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      return new Response(
+        JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [{ inlineData: { data: Buffer.from([1, 2]).toString("base64") } }],
+              },
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+
+    for await (const _chunk of generateGeminiSpeechAudio({
+      apiKey: "gemini-key",
+      sourceText: "Original response.",
+      fetchImpl: fetchMock,
+    })) {
+      void _chunk;
+    }
+
+    const transcripts = fetchMock.mock.calls
+      .slice(1)
+      .map(([, init]) =>
+        JSON.parse(init.body).contents[0].parts[0].text.split("### TRANSCRIPT\n")[1].trim(),
+      );
+    const speechWeight = (text) =>
+      Array.from(text).reduce(
+        (total, character) =>
+          total +
+          (/[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u.test(
+            character,
+          )
+            ? 3
+            : 1),
+        0,
+      );
+    expect(transcripts).toHaveLength(12);
+    expect(transcripts.join("")).toBe(rewrittenText);
+    expect(transcripts.every((transcript) => speechWeight(transcript) <= 2040)).toBe(true);
+  });
+
   it("streams incremental PCM and validates the terminal response", async () => {
     const fetchMock = vi
       .fn()
@@ -481,6 +537,47 @@ describe("gemini speech", () => {
     }
 
     expect(chunks.map((chunk) => chunk.audio)).toEqual([Buffer.from([1, 2])]);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("cancels a failed SSE body before retrying", async () => {
+    const cancel = vi.fn();
+    const encoder = new TextEncoder();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            candidates: [{ content: { parts: [{ text: "Spoken version." }] } }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(encoder.encode("data: {\n\n"));
+            },
+            cancel,
+          }),
+          { status: 200, headers: { "Content-Type": "text/event-stream" } },
+        ),
+      )
+      .mockResolvedValueOnce(createSseResponse([createStreamingAudioPayload([1, 2], "STOP")]));
+    const chunks = [];
+
+    for await (const chunk of streamGeminiSpeechPcm({
+      apiKey: "gemini-key",
+      sourceText: "Original response.",
+      fetchImpl: fetchMock,
+      maxTtsAttempts: 2,
+    })) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks.map((chunk) => chunk.audio)).toEqual([Buffer.from([1, 2])]);
+    expect(cancel).toHaveBeenCalledOnce();
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 

--- a/test/gemini_speech.test.js
+++ b/test/gemini_speech.test.js
@@ -1,5 +1,37 @@
 import { describe, expect, it, vi } from "vitest";
-import { streamGeminiSpeechAudio } from "../dist/core/utils/gemini_speech.js";
+import {
+  generateGeminiSpeechAudio,
+  streamGeminiSpeechPcm,
+} from "../dist/core/utils/gemini_speech.js";
+
+function createSseResponse(payloads) {
+  const encoder = new TextEncoder();
+  const body = payloads.map((payload) => `data: ${JSON.stringify(payload)}\n\n`).join("");
+  const midpoint = Math.floor(body.length / 2);
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(body.slice(0, midpoint)));
+        controller.enqueue(encoder.encode(body.slice(midpoint)));
+        controller.close();
+      },
+    }),
+    { status: 200, headers: { "Content-Type": "text/event-stream" } },
+  );
+}
+
+function createStreamingAudioPayload(audio, finishReason) {
+  return {
+    candidates: [
+      {
+        ...(finishReason ? { finishReason } : {}),
+        content: {
+          parts: [{ inlineData: { data: Buffer.from(audio).toString("base64") } }],
+        },
+      },
+    ],
+  };
+}
 
 describe("gemini speech", () => {
   it("rewrites text, requests TTS audio, and returns a wav buffer", async () => {
@@ -43,15 +75,14 @@ describe("gemini speech", () => {
     const stages = [];
     const chunkProgress = [];
     const chunks = [];
-    for await (const chunk of streamGeminiSpeechAudio({
+    for await (const chunk of generateGeminiSpeechAudio({
       apiKey: "gemini-key",
       sourceText: "Use src/app.ts:42 for the fix.",
-      deliveryMode: "progressive",
       fetchImpl: fetchMock,
       onStageChange: (stage) => {
         stages.push(stage);
       },
-      onChunkProgress: (progress) => {
+      onSegmentProgress: (progress) => {
         chunkProgress.push(progress);
       },
     })) {
@@ -172,12 +203,11 @@ describe("gemini speech", () => {
 
     const chunkProgress = [];
     const chunks = [];
-    for await (const chunk of streamGeminiSpeechAudio({
+    for await (const chunk of generateGeminiSpeechAudio({
       apiKey: "gemini-key",
       sourceText: "## Setup\n\n- First short point.\n- Second short point.",
-      deliveryMode: "progressive",
       fetchImpl: fetchMock,
-      onChunkProgress: (progress) => {
+      onSegmentProgress: (progress) => {
         chunkProgress.push(progress);
       },
     })) {
@@ -195,10 +225,12 @@ describe("gemini speech", () => {
     expect(ttsRequest.contents[0].parts[0].text).toContain(rewrittenText);
   });
 
-  it("prefers paragraph boundaries over later sentence endings", async () => {
-    const firstParagraph = `${"A".repeat(348)}.`;
-    const secondParagraph = `${"B".repeat(100)}. ${"C".repeat(100)}`;
-    const rewrittenText = `${firstParagraph}\n\n${secondParagraph}`;
+  it("balances segments under the estimated two-minute maximum", async () => {
+    const sentences = Array.from(
+      { length: 10 },
+      (_, index) => `Sentence ${index + 1} ${"A".repeat(238)}.`,
+    );
+    const rewrittenText = sentences.join(" ");
     let requestIndex = 0;
     const fetchMock = vi.fn(async () => {
       if (requestIndex++ === 0) {
@@ -224,10 +256,9 @@ describe("gemini speech", () => {
       );
     });
 
-    for await (const _chunk of streamGeminiSpeechAudio({
+    for await (const _chunk of generateGeminiSpeechAudio({
       apiKey: "gemini-key",
       sourceText: "Original response.",
-      deliveryMode: "progressive",
       fetchImpl: fetchMock,
     })) {
       void _chunk;
@@ -238,97 +269,23 @@ describe("gemini speech", () => {
       .map(([, init]) =>
         JSON.parse(init.body).contents[0].parts[0].text.split("### TRANSCRIPT\n")[1].trim(),
       );
-    expect(transcripts).toEqual([firstParagraph, secondParagraph]);
+    expect(transcripts).toHaveLength(2);
+    expect(transcripts[0]).toBe(sentences.slice(0, 5).join(" "));
+    expect(transcripts[1]).toBe(sentences.slice(5).join(" "));
   });
 
-  it.each([
-    {
-      name: "no-space sentence punctuation",
-      rewrittenText: `${"語".repeat(449)}。${"文".repeat(100)}`,
-      expectedChunkLengths: [450, 100],
-    },
-    {
-      name: "supplementary Unicode characters",
-      rewrittenText: "😀".repeat(501),
-      expectedChunkLengths: [500, 1],
-    },
-  ])("uses Unicode-safe progressive chunk boundaries for $name", async (testCase) => {
-    let requestIndex = 0;
-    const fetchMock = vi.fn(async () => {
-      if (requestIndex++ === 0) {
-        return new Response(
-          JSON.stringify({
-            candidates: [{ content: { parts: [{ text: testCase.rewrittenText }] } }],
-          }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        );
-      }
-
-      return new Response(
-        JSON.stringify({
-          candidates: [
-            {
-              content: {
-                parts: [{ inlineData: { data: Buffer.from([1, 2]).toString("base64") } }],
-              },
-            },
-          ],
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      );
-    });
-
-    for await (const _chunk of streamGeminiSpeechAudio({
-      apiKey: "gemini-key",
-      sourceText: "Original response.",
-      deliveryMode: "progressive",
-      fetchImpl: fetchMock,
-    })) {
-      void _chunk;
-    }
-
-    const transcripts = fetchMock.mock.calls
-      .slice(1)
-      .map(([, init]) =>
-        JSON.parse(init.body).contents[0].parts[0].text.split("### TRANSCRIPT\n")[1].trim(),
-      );
-    expect(transcripts.map((transcript) => Array.from(transcript).length)).toEqual(
-      testCase.expectedChunkLengths,
+  it("balances several segments at natural paragraph boundaries", async () => {
+    const paragraphs = Array.from(
+      { length: 9 },
+      (_, index) => `Paragraph ${index + 1} ${"A".repeat(485)}.`,
     );
-    expect(transcripts.join("")).toBe(testCase.rewrittenText);
-  });
-
-  it.each([
-    {
-      name: "short",
-      rewrittenText: "A short response stays in one complete-audio chunk.",
-      expectedChunks: 1,
-    },
-    {
-      name: "medium",
-      rewrittenText: Array.from(
-        { length: 14 },
-        (_, index) =>
-          `Sentence ${index + 1} explains a distinct implementation detail while keeping the transcript natural and complete.`,
-      ).join(" "),
-      expectedChunks: 2,
-    },
-    {
-      name: "long",
-      rewrittenText: Array.from(
-        { length: 30 },
-        (_, index) =>
-          `Sentence ${index + 1} explains a distinct implementation detail while keeping the transcript natural and complete.`,
-      ).join(" "),
-      expectedChunks: 4,
-    },
-  ])("bounds complete-audio chunks for $name responses", async (testCase) => {
+    const rewrittenText = paragraphs.join("\n\n");
     let requestIndex = 0;
     const fetchMock = vi.fn(async () => {
       if (requestIndex++ === 0) {
         return new Response(
           JSON.stringify({
-            candidates: [{ content: { parts: [{ text: testCase.rewrittenText }] } }],
+            candidates: [{ content: { parts: [{ text: rewrittenText }] } }],
           }),
           { status: 200, headers: { "Content-Type": "application/json" } },
         );
@@ -348,30 +305,253 @@ describe("gemini speech", () => {
       );
     });
 
-    const chunks = [];
-    for await (const chunk of streamGeminiSpeechAudio({
+    for await (const _chunk of generateGeminiSpeechAudio({
       apiKey: "gemini-key",
       sourceText: "Original response.",
-      deliveryMode: "complete",
       fetchImpl: fetchMock,
+    })) {
+      void _chunk;
+    }
+
+    const transcripts = fetchMock.mock.calls
+      .slice(1)
+      .map(([, init]) =>
+        JSON.parse(init.body).contents[0].parts[0].text.split("### TRANSCRIPT\n")[1].trim(),
+      );
+    expect(transcripts).toHaveLength(3);
+    expect(transcripts).toEqual([
+      paragraphs.slice(0, 3).join("\n\n"),
+      paragraphs.slice(3, 6).join("\n\n"),
+      paragraphs.slice(6).join("\n\n"),
+    ]);
+  });
+
+  it("weights no-space CJK text and preserves Unicode boundaries", async () => {
+    const firstSentence = `${"語".repeat(499)}。`;
+    const secondSentence = `${"文".repeat(499)}。`;
+    const rewrittenText = `${firstSentence}${secondSentence}`;
+    let requestIndex = 0;
+    const fetchMock = vi.fn(async () => {
+      if (requestIndex++ === 0) {
+        return new Response(
+          JSON.stringify({
+            candidates: [{ content: { parts: [{ text: rewrittenText }] } }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      return new Response(
+        JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [{ inlineData: { data: Buffer.from([1, 2]).toString("base64") } }],
+              },
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+
+    for await (const _chunk of generateGeminiSpeechAudio({
+      apiKey: "gemini-key",
+      sourceText: "Original response.",
+      fetchImpl: fetchMock,
+    })) {
+      void _chunk;
+    }
+
+    const transcripts = fetchMock.mock.calls
+      .slice(1)
+      .map(([, init]) =>
+        JSON.parse(init.body).contents[0].parts[0].text.split("### TRANSCRIPT\n")[1].trim(),
+      );
+    expect(transcripts).toEqual([firstSentence, secondSentence]);
+  });
+
+  it("streams incremental PCM and validates the terminal response", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            candidates: [{ content: { parts: [{ text: "Spoken version." }] } }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        createSseResponse([
+          createStreamingAudioPayload([1, 2]),
+          createStreamingAudioPayload([3, 4], "STOP"),
+        ]),
+      );
+    const progress = [];
+    const chunks = [];
+
+    for await (const chunk of streamGeminiSpeechPcm({
+      apiKey: "gemini-key",
+      sourceText: "Original response.",
+      fetchImpl: fetchMock,
+      onSegmentProgress: (value) => progress.push(value),
     })) {
       chunks.push(chunk);
     }
 
-    expect(chunks).toHaveLength(testCase.expectedChunks);
-    const ttsRequests = fetchMock.mock.calls.slice(1).map(([, init]) => JSON.parse(init.body));
-    const transcripts = ttsRequests.map((request) =>
-      request.contents[0].parts[0].text.split("### TRANSCRIPT\n")[1].trim(),
+    expect(chunks.map((chunk) => chunk.audio)).toEqual([Buffer.from([1, 2]), Buffer.from([3, 4])]);
+    expect(chunks.every((chunk) => chunk.index === 0 && chunk.total === 1)).toBe(true);
+    expect(progress).toEqual([
+      { ready: 0, total: 1 },
+      { ready: 1, total: 1 },
+    ]);
+    expect(fetchMock.mock.calls[1][0]).toContain(
+      "gemini-3.1-flash-tts-preview:streamGenerateContent?alt=sse",
     );
-    expect(transcripts.every((transcript) => transcript.length <= 1000)).toBe(true);
-    expect(transcripts.join(" ")).toBe(testCase.rewrittenText);
-    for (const request of ttsRequests) {
-      expect(request.contents[0].parts[0].text).toContain(
-        "Pacing: Brisk conversational speed. Keep it clear, confident, and energetic without sounding rushed.",
-      );
-      expect(request.generationConfig.maxOutputTokens).toBe(8192);
-      expect(request.generationConfig.temperature).toBeUndefined();
+  });
+
+  it("prefetches the next balanced segment while streaming the first", async () => {
+    const sentences = Array.from(
+      { length: 10 },
+      (_, index) => `Sentence ${index + 1} ${"A".repeat(238)}.`,
+    );
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            candidates: [{ content: { parts: [{ text: sentences.join(" ") }] } }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(createSseResponse([createStreamingAudioPayload([1, 2], "STOP")]))
+      .mockResolvedValueOnce(createSseResponse([createStreamingAudioPayload([3, 4], "STOP")]));
+    const stream = streamGeminiSpeechPcm({
+      apiKey: "gemini-key",
+      sourceText: "Original response.",
+      fetchImpl: fetchMock,
+    });
+
+    const first = await stream.next();
+
+    expect(first.value).toMatchObject({ index: 0, total: 2, audio: Buffer.from([1, 2]) });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const remaining = [];
+    for await (const chunk of stream) {
+      remaining.push(chunk);
     }
+    expect(remaining).toEqual([{ index: 1, total: 2, audio: Buffer.from([3, 4]) }]);
+    const transcripts = fetchMock.mock.calls
+      .slice(1)
+      .map(([, init]) =>
+        JSON.parse(init.body).contents[0].parts[0].text.split("### TRANSCRIPT\n")[1].trim(),
+      );
+    expect(transcripts).toEqual([sentences.slice(0, 5).join(" "), sentences.slice(5).join(" ")]);
+  });
+
+  it("retries a stream failure only before audio has been emitted", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            candidates: [{ content: { parts: [{ text: "Spoken version." }] } }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: { message: "temporary failure" } }), {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(createSseResponse([createStreamingAudioPayload([1, 2], "STOP")]));
+    const chunks = [];
+
+    for await (const chunk of streamGeminiSpeechPcm({
+      apiKey: "gemini-key",
+      sourceText: "Original response.",
+      fetchImpl: fetchMock,
+      maxTtsAttempts: 2,
+    })) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks.map((chunk) => chunk.audio)).toEqual([Buffer.from([1, 2])]);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not replay a stream after audio has been emitted", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            candidates: [{ content: { parts: [{ text: "Spoken version." }] } }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        createSseResponse([
+          createStreamingAudioPayload([1, 2]),
+          { candidates: [{ finishReason: "OTHER" }] },
+        ]),
+      );
+    const stream = streamGeminiSpeechPcm({
+      apiKey: "gemini-key",
+      sourceText: "Original response.",
+      fetchImpl: fetchMock,
+      maxTtsAttempts: 3,
+    });
+
+    await expect(stream.next()).resolves.toMatchObject({
+      value: { audio: Buffer.from([1, 2]) },
+    });
+    await expect(stream.next()).rejects.toThrow("Gemini TTS stopped with finish reason 'OTHER'");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("cancels an active speech stream", async () => {
+    const abortController = new AbortController();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            candidates: [{ content: { parts: [{ text: "Spoken version." }] } }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockImplementationOnce(async (_url, init) => {
+        await new Promise((_, reject) => {
+          init.signal.addEventListener(
+            "abort",
+            () => {
+              const error = new Error("aborted");
+              error.name = "AbortError";
+              reject(error);
+            },
+            { once: true },
+          );
+        });
+      });
+    const stream = streamGeminiSpeechPcm({
+      apiKey: "gemini-key",
+      sourceText: "Original response.",
+      fetchImpl: fetchMock,
+      signal: abortController.signal,
+    });
+    const next = stream.next();
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    abortController.abort();
+
+    await expect(next).rejects.toMatchObject({ name: "AbortError" });
   });
 
   it("aborts speech rewriting after one minute", async () => {
@@ -390,10 +570,9 @@ describe("gemini speech", () => {
           );
         });
       });
-      const nextChunk = streamGeminiSpeechAudio({
+      const nextChunk = generateGeminiSpeechAudio({
         apiKey: "gemini-key",
         sourceText: "Original text.",
-        deliveryMode: "progressive",
         fetchImpl: fetchMock,
       }).next();
       const rejection = expect(nextChunk).rejects.toThrow(
@@ -411,10 +590,9 @@ describe("gemini speech", () => {
   it("rejects oversized source and rewritten speech text", async () => {
     const sourceFetch = vi.fn();
     await expect(async () => {
-      for await (const _chunk of streamGeminiSpeechAudio({
+      for await (const _chunk of generateGeminiSpeechAudio({
         apiKey: "gemini-key",
         sourceText: "😀".repeat(10_001),
-        deliveryMode: "progressive",
         fetchImpl: sourceFetch,
       })) {
         void _chunk;
@@ -432,10 +610,9 @@ describe("gemini speech", () => {
         ),
     );
     await expect(async () => {
-      for await (const _chunk of streamGeminiSpeechAudio({
+      for await (const _chunk of generateGeminiSpeechAudio({
         apiKey: "gemini-key",
         sourceText: "Original text.",
-        deliveryMode: "complete",
         fetchImpl: rewrittenFetch,
       })) {
         void _chunk;
@@ -466,10 +643,9 @@ describe("gemini speech", () => {
       });
 
     await expect(async () => {
-      for await (const _chunk of streamGeminiSpeechAudio({
+      for await (const _chunk of generateGeminiSpeechAudio({
         apiKey: "gemini-key",
         sourceText: "Original text.",
-        deliveryMode: "complete",
         fetchImpl: fetchMock,
         maxTtsAttempts: 1,
       })) {
@@ -512,10 +688,9 @@ describe("gemini speech", () => {
       );
 
     await expect(async () => {
-      for await (const _chunk of streamGeminiSpeechAudio({
+      for await (const _chunk of generateGeminiSpeechAudio({
         apiKey: "gemini-key",
         sourceText: "Original text.",
-        deliveryMode: "progressive",
         fetchImpl: fetchMock,
         maxTtsAttempts: 3,
       })) {
@@ -574,10 +749,9 @@ describe("gemini speech", () => {
       );
 
     const chunks = [];
-    for await (const chunk of streamGeminiSpeechAudio({
+    for await (const chunk of generateGeminiSpeechAudio({
       apiKey: "gemini-key",
       sourceText: "Original text.",
-      deliveryMode: "progressive",
       fetchImpl: fetchMock,
       maxTtsAttempts: 2,
     })) {

--- a/test/gemini_speech.test.js
+++ b/test/gemini_speech.test.js
@@ -540,6 +540,45 @@ describe("gemini speech", () => {
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
+  it("retries while initial stream audio remains buffered", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            candidates: [{ content: { parts: [{ text: "Spoken version." }] } }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        createSseResponse([
+          createStreamingAudioPayload([9, 9]),
+          { candidates: [{ finishReason: "OTHER" }] },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        createSseResponse([
+          createStreamingAudioPayload([1, 2]),
+          createStreamingAudioPayload([3, 4], "STOP"),
+        ]),
+      );
+    const chunks = [];
+
+    for await (const chunk of streamGeminiSpeechPcm({
+      apiKey: "gemini-key",
+      sourceText: "Original response.",
+      fetchImpl: fetchMock,
+      maxTtsAttempts: 2,
+      initialBufferBytes: 4,
+    })) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks.map((chunk) => chunk.audio)).toEqual([Buffer.from([1, 2, 3, 4])]);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
   it("cancels a failed SSE body before retrying", async () => {
     const cancel = vi.fn();
     const encoder = new TextEncoder();

--- a/test/session_chat_controller.test.js
+++ b/test/session_chat_controller.test.js
@@ -26,6 +26,7 @@ import { copyTextToClipboard } from "../dist/tui/clipboard.js";
 import { LISTEN_CAPTURE_START_TIMEOUT_MS } from "../dist/tui/listen_capture.js";
 import { createTuiClientTools, SessionChatApp } from "../dist/tui/session_chat_app.js";
 import { SessionChatController } from "../dist/tui/session_chat_controller.js";
+import { runSpeechPlaybackTask } from "../dist/tui/speech_playback.js";
 import {
   createProtocolBootstrap,
   createProtocolExecResult,
@@ -6127,6 +6128,174 @@ describe("SessionChatController", () => {
     expect(writtenAudio).toEqual([Buffer.from([1, 2]), Buffer.from([3, 4])]);
     expect(stdin.end).toHaveBeenCalledOnce();
     expect(session.submit).not.toHaveBeenCalled();
+  });
+
+  it("waits for ffplay shutdown when speech is cancelled before a write", async () => {
+    const abortController = new AbortController();
+    const stdin = new EventEmitter();
+    stdin.destroyed = false;
+    stdin.writableEnded = false;
+    stdin.write = vi.fn();
+    let releasePlayback;
+    const spawn = vi.fn((_command, _args, options) => {
+      options.onSpawn?.({ stdin });
+      return new Promise((resolve) => {
+        options.signal.addEventListener(
+          "abort",
+          () => {
+            releasePlayback = () =>
+              resolve({
+                stdout: "",
+                stderr: "",
+                output: undefined,
+                exitCode: null,
+                captureLimitExceeded: false,
+                timedOut: false,
+                aborted: true,
+                closeSignal: "SIGTERM",
+              });
+          },
+          { once: true },
+        );
+      });
+    });
+    const encoder = new TextEncoder();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            candidates: [{ content: { parts: [{ text: "Spoken version." }] } }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          new ReadableStream({
+            pull(controller) {
+              controller.enqueue(
+                encoder.encode(
+                  `data: ${JSON.stringify({
+                    candidates: [
+                      {
+                        finishReason: "STOP",
+                        content: {
+                          parts: [
+                            {
+                              inlineData: {
+                                data: Buffer.from([1, 2]).toString("base64"),
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  })}\n\n`,
+                ),
+              );
+              abortController.abort();
+              controller.close();
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "text/event-stream" } },
+        ),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const playback = runSpeechPlaybackTask({
+        deps: createMockDeps(spawn),
+        apiKey: "gemini-key",
+        sourceText: "Original response.",
+        signal: abortController.signal,
+        onActivityLabel: vi.fn(),
+      });
+      let settled = false;
+      void playback.then(
+        () => {
+          settled = true;
+        },
+        () => {
+          settled = true;
+        },
+      );
+
+      await vi.waitFor(() => expect(releasePlayback).toBeTypeOf("function"));
+      await Promise.resolve();
+      expect(settled).toBe(false);
+      releasePlayback();
+      await playback;
+    } finally {
+      vi.unstubAllGlobals();
+    }
+
+    expect(stdin.write).not.toHaveBeenCalled();
+  });
+
+  it("reports ffplay diagnostics when its stdin closes early", async () => {
+    const stdin = new EventEmitter();
+    stdin.destroyed = false;
+    stdin.writableEnded = false;
+    stdin.write = vi.fn((_audio, callback) => {
+      const error = new Error("write EPIPE");
+      error.code = "EPIPE";
+      callback(error);
+      return false;
+    });
+    const spawn = vi.fn(async (_command, _args, options) => {
+      options.onSpawn?.({ stdin });
+      return {
+        stdout: "",
+        stderr: "audio open failed",
+        output: undefined,
+        exitCode: 0,
+        captureLimitExceeded: false,
+        timedOut: false,
+        aborted: false,
+        closeSignal: null,
+      };
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            candidates: [{ content: { parts: [{ text: "Spoken version." }] } }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          `data: ${JSON.stringify({
+            candidates: [
+              {
+                finishReason: "STOP",
+                content: {
+                  parts: [{ inlineData: { data: Buffer.from([1, 2]).toString("base64") } }],
+                },
+              },
+            ],
+          })}\n\n`,
+          { status: 200, headers: { "Content-Type": "text/event-stream" } },
+        ),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      await expect(
+        runSpeechPlaybackTask({
+          deps: createMockDeps(spawn),
+          apiKey: "gemini-key",
+          sourceText: "Original response.",
+          signal: new AbortController().signal,
+          onActivityLabel: vi.fn(),
+        }),
+      ).rejects.toThrow("ffplay failed: audio open failed");
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it("exposes session catalog data for autocomplete", async () => {

--- a/test/session_chat_controller.test.js
+++ b/test/session_chat_controller.test.js
@@ -6033,12 +6033,14 @@ describe("SessionChatController", () => {
       deps: createMockDeps(spawn),
       config: { apiKeys: { google: "gemini-key" } },
     });
+    const firstAudio = Buffer.alloc(12_000, 1);
+    const secondAudio = Buffer.alloc(12_000, 2);
     const streamingBody = [
       {
         candidates: [
           {
             content: {
-              parts: [{ inlineData: { data: Buffer.from([1, 2]).toString("base64") } }],
+              parts: [{ inlineData: { data: firstAudio.toString("base64") } }],
             },
           },
         ],
@@ -6048,7 +6050,7 @@ describe("SessionChatController", () => {
           {
             finishReason: "STOP",
             content: {
-              parts: [{ inlineData: { data: Buffer.from([3, 4]).toString("base64") } }],
+              parts: [{ inlineData: { data: secondAudio.toString("base64") } }],
             },
           },
         ],
@@ -6096,12 +6098,7 @@ describe("SessionChatController", () => {
       .map((status) => (status.footer.type === "activity" ? status.footer.label : undefined))
       .filter((hint) => hint !== undefined);
     expect(speechHints).toEqual(
-      expect.arrayContaining([
-        "rewriting for speech",
-        "generating speech segments (0 out of 1 ready)",
-        "playing speech (0/1 generated)",
-        "playing speech (1/1 generated)",
-      ]),
+      expect.arrayContaining(["rewriting for speech", "preparing speech", "playing speech"]),
     );
     expect(view.status.footer.type).toBe("regular");
     expect(spawn).toHaveBeenCalledOnce();
@@ -6112,8 +6109,8 @@ describe("SessionChatController", () => {
         "s16le",
         "-ar",
         "24000",
-        "-ac",
-        "1",
+        "-ch_layout",
+        "mono",
         "-af",
         "atempo=1.15",
         "pipe:0",
@@ -6125,7 +6122,7 @@ describe("SessionChatController", () => {
         onSpawn: expect.any(Function),
       }),
     );
-    expect(writtenAudio).toEqual([Buffer.from([1, 2]), Buffer.from([3, 4])]);
+    expect(writtenAudio).toEqual([firstAudio, secondAudio]);
     expect(stdin.end).toHaveBeenCalledOnce();
     expect(session.submit).not.toHaveBeenCalled();
   });
@@ -6137,29 +6134,30 @@ describe("SessionChatController", () => {
     stdin.writableEnded = false;
     stdin.write = vi.fn();
     let releasePlayback;
-    const spawn = vi.fn((_command, _args, options) => {
-      options.onSpawn?.({ stdin });
-      return new Promise((resolve) => {
-        options.signal.addEventListener(
-          "abort",
-          () => {
-            releasePlayback = () =>
-              resolve({
-                stdout: "",
-                stderr: "",
-                output: undefined,
-                exitCode: null,
-                captureLimitExceeded: false,
-                timedOut: false,
-                aborted: true,
-                closeSignal: "SIGTERM",
-              });
-          },
-          { once: true },
-        );
-      });
-    });
-    const encoder = new TextEncoder();
+    const spawn = vi.fn(
+      (_command, _args, options) =>
+        new Promise((resolve) => {
+          options.signal.addEventListener(
+            "abort",
+            () => {
+              releasePlayback = () =>
+                resolve({
+                  stdout: "",
+                  stderr: "",
+                  output: undefined,
+                  exitCode: null,
+                  captureLimitExceeded: false,
+                  timedOut: false,
+                  aborted: true,
+                  closeSignal: "SIGTERM",
+                });
+            },
+            { once: true },
+          );
+          options.onSpawn?.({ stdin });
+          abortController.abort();
+        }),
+    );
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(
@@ -6172,32 +6170,22 @@ describe("SessionChatController", () => {
       )
       .mockResolvedValueOnce(
         new Response(
-          new ReadableStream({
-            pull(controller) {
-              controller.enqueue(
-                encoder.encode(
-                  `data: ${JSON.stringify({
-                    candidates: [
-                      {
-                        finishReason: "STOP",
-                        content: {
-                          parts: [
-                            {
-                              inlineData: {
-                                data: Buffer.from([1, 2]).toString("base64"),
-                              },
-                            },
-                          ],
-                        },
+          `data: ${JSON.stringify({
+            candidates: [
+              {
+                finishReason: "STOP",
+                content: {
+                  parts: [
+                    {
+                      inlineData: {
+                        data: Buffer.alloc(24_000, 1).toString("base64"),
                       },
-                    ],
-                  })}\n\n`,
-                ),
-              );
-              abortController.abort();
-              controller.close();
-            },
-          }),
+                    },
+                  ],
+                },
+              },
+            ],
+          })}\n\n`,
           { status: 200, headers: { "Content-Type": "text/event-stream" } },
         ),
       );

--- a/test/session_chat_controller.test.js
+++ b/test/session_chat_controller.test.js
@@ -5985,6 +5985,7 @@ describe("SessionChatController", () => {
 
   it("streams the last session assistant message through local playback", async () => {
     const writtenAudio = [];
+    const player = deferred();
     const stdin = new EventEmitter();
     stdin.destroyed = false;
     stdin.writableEnded = false;
@@ -5996,10 +5997,7 @@ describe("SessionChatController", () => {
     stdin.end = vi.fn((callback) => {
       stdin.writableEnded = true;
       callback();
-    });
-    const spawn = vi.fn(async (_cmd, _args, options) => {
-      options.onSpawn?.({ stdin });
-      return {
+      player.resolve({
         stdout: "",
         stderr: "",
         output: undefined,
@@ -6008,7 +6006,11 @@ describe("SessionChatController", () => {
         timedOut: false,
         aborted: false,
         closeSignal: null,
-      };
+      });
+    });
+    const spawn = vi.fn((_cmd, _args, options) => {
+      options.onSpawn?.({ stdin });
+      return player.promise;
     });
     const session = new FakeSession(
       createSnapshot([
@@ -6122,7 +6124,7 @@ describe("SessionChatController", () => {
         onSpawn: expect.any(Function),
       }),
     );
-    expect(writtenAudio).toEqual([firstAudio, secondAudio]);
+    expect(writtenAudio).toEqual([Buffer.concat([firstAudio, secondAudio])]);
     expect(stdin.end).toHaveBeenCalledOnce();
     expect(session.submit).not.toHaveBeenCalled();
   });
@@ -6219,6 +6221,101 @@ describe("SessionChatController", () => {
     }
 
     expect(stdin.write).not.toHaveBeenCalled();
+  });
+
+  it("aborts speech generation when ffplay exits early", async () => {
+    const stdin = new EventEmitter();
+    stdin.destroyed = false;
+    stdin.writableEnded = false;
+    stdin.write = vi.fn((_audio, callback) => {
+      callback();
+      return true;
+    });
+    const player = deferred();
+    const spawn = vi.fn((_command, _args, options) => {
+      options.onSpawn?.({ stdin });
+      return player.promise;
+    });
+    const streamAborted = vi.fn();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            candidates: [{ content: { parts: [{ text: "Spoken version." }] } }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockImplementationOnce(async (_url, init) => {
+        const encoder = new TextEncoder();
+        return new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(
+                encoder.encode(
+                  `data: ${JSON.stringify({
+                    candidates: [
+                      {
+                        content: {
+                          parts: [
+                            {
+                              inlineData: {
+                                data: Buffer.alloc(24_000, 1).toString("base64"),
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  })}\n\n`,
+                ),
+              );
+              init.signal.addEventListener(
+                "abort",
+                () => {
+                  streamAborted();
+                  const error = new Error("aborted");
+                  error.name = "AbortError";
+                  controller.error(error);
+                },
+                { once: true },
+              );
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "text/event-stream" } },
+        );
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const playback = runSpeechPlaybackTask({
+        deps: createMockDeps(spawn),
+        apiKey: "gemini-key",
+        sourceText: "Original response.",
+        signal: new AbortController().signal,
+        onActivityLabel: vi.fn(),
+      });
+      const rejection = expect(playback).rejects.toThrow("ffplay failed: audio sink closed");
+
+      await vi.waitFor(() => expect(stdin.write).toHaveBeenCalledOnce());
+      player.resolve({
+        stdout: "",
+        stderr: "audio sink closed",
+        output: undefined,
+        exitCode: 1,
+        captureLimitExceeded: false,
+        timedOut: false,
+        aborted: false,
+        closeSignal: null,
+      });
+
+      await rejection;
+    } finally {
+      vi.unstubAllGlobals();
+    }
+
+    expect(streamAborted).toHaveBeenCalledOnce();
   });
 
   it("reports ffplay diagnostics when its stdin closes early", async () => {

--- a/test/session_chat_controller.test.js
+++ b/test/session_chat_controller.test.js
@@ -5982,22 +5982,22 @@ describe("SessionChatController", () => {
     expect(session.submit).not.toHaveBeenCalled();
   });
 
-  it("speaks the last session assistant message using local playback", async () => {
-    const mktempPath = join(tmpdir(), `tau-session-speak-test-${Date.now()}.wav`);
-    const spawn = vi.fn(async (cmd) => {
-      if (cmd === "mktemp") {
-        return {
-          stdout: `${mktempPath}\n`,
-          stderr: "",
-          output: undefined,
-          exitCode: 0,
-          captureLimitExceeded: false,
-          timedOut: false,
-          aborted: false,
-          closeSignal: null,
-        };
-      }
-
+  it("streams the last session assistant message through local playback", async () => {
+    const writtenAudio = [];
+    const stdin = new EventEmitter();
+    stdin.destroyed = false;
+    stdin.writableEnded = false;
+    stdin.write = vi.fn((audio, callback) => {
+      writtenAudio.push(Buffer.from(audio));
+      callback();
+      return true;
+    });
+    stdin.end = vi.fn((callback) => {
+      stdin.writableEnded = true;
+      callback();
+    });
+    const spawn = vi.fn(async (_cmd, _args, options) => {
+      options.onSpawn?.({ stdin });
       return {
         stdout: "",
         stderr: "",
@@ -6032,6 +6032,29 @@ describe("SessionChatController", () => {
       deps: createMockDeps(spawn),
       config: { apiKeys: { google: "gemini-key" } },
     });
+    const streamingBody = [
+      {
+        candidates: [
+          {
+            content: {
+              parts: [{ inlineData: { data: Buffer.from([1, 2]).toString("base64") } }],
+            },
+          },
+        ],
+      },
+      {
+        candidates: [
+          {
+            finishReason: "STOP",
+            content: {
+              parts: [{ inlineData: { data: Buffer.from([3, 4]).toString("base64") } }],
+            },
+          },
+        ],
+      },
+    ]
+      .map((payload) => `data: ${JSON.stringify(payload)}\n\n`)
+      .join("");
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(
@@ -6053,24 +6076,10 @@ describe("SessionChatController", () => {
         ),
       )
       .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            candidates: [
-              {
-                content: {
-                  parts: [
-                    {
-                      inlineData: {
-                        data: Buffer.from([1, 2, 3, 4]).toString("base64"),
-                      },
-                    },
-                  ],
-                },
-              },
-            ],
-          }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        ),
+        new Response(streamingBody, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        }),
       );
     vi.stubGlobal("fetch", fetchMock);
 
@@ -6079,7 +6088,6 @@ describe("SessionChatController", () => {
       await controller.speakLastAssistantMessage();
     } finally {
       vi.unstubAllGlobals();
-      await rm(mktempPath, { force: true });
     }
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -6089,23 +6097,35 @@ describe("SessionChatController", () => {
     expect(speechHints).toEqual(
       expect.arrayContaining([
         "rewriting for speech",
-        "generating speech chunks (0 out of 1 ready)",
-        "generating speech chunks (1 out of 1 ready)",
-        "playing speech (0/1 played, 1/1 ready)",
+        "generating speech segments (0 out of 1 ready)",
+        "playing speech (0/1 generated)",
+        "playing speech (1/1 generated)",
       ]),
     );
     expect(view.status.footer.type).toBe("regular");
-    expect(spawn).toHaveBeenNthCalledWith(1, "mktemp", [join(tmpdir(), "tau-speak.XXXXXX")]);
-    expect(spawn).toHaveBeenNthCalledWith(
-      2,
-      "afplay",
-      ["-r", "1.15", mktempPath],
+    expect(spawn).toHaveBeenCalledOnce();
+    expect(spawn).toHaveBeenCalledWith(
+      "ffplay",
+      expect.arrayContaining([
+        "-f",
+        "s16le",
+        "-ar",
+        "24000",
+        "-ac",
+        "1",
+        "-af",
+        "atempo=1.15",
+        "pipe:0",
+      ]),
       expect.objectContaining({
         detached: true,
         killProcessGroup: true,
-        stdio: ["ignore", "ignore", "ignore"],
+        stdio: ["pipe", "ignore", "pipe"],
+        onSpawn: expect.any(Function),
       }),
     );
+    expect(writtenAudio).toEqual([Buffer.from([1, 2]), Buffer.from([3, 4])]);
+    expect(stdin.end).toHaveBeenCalledOnce();
     expect(session.submit).not.toHaveBeenCalled();
   });
 

--- a/test/telegram_tts.test.js
+++ b/test/telegram_tts.test.js
@@ -37,7 +37,7 @@ describe("telegram TTS", () => {
       createWaveAudio(Buffer.from([1, 2, 3, 4])),
       createWaveAudio(Buffer.from([5, 6, 7, 8])),
     ];
-    const streamSpeechAudio = vi.fn(async function* () {
+    const generateSpeechAudio = vi.fn(async function* () {
       for (const [index, audio] of waves.entries()) {
         yield { index, total: waves.length, audio, mimeType: "audio/wav" };
       }
@@ -66,12 +66,12 @@ describe("telegram TTS", () => {
     const voice = await generateTelegramVoice({
       apiKey: "gemini-key",
       sourceText: "final answer",
-      deps: { streamSpeechAudio, spawn },
+      deps: { generateSpeechAudio, spawn },
     });
 
     expect(voice).toEqual(Buffer.from("OggS voice"));
-    expect(streamSpeechAudio).toHaveBeenCalledWith(
-      expect.objectContaining({ deliveryMode: "complete" }),
+    expect(generateSpeechAudio).toHaveBeenCalledWith(
+      expect.objectContaining({ apiKey: "gemini-key", sourceText: "final answer" }),
     );
     expect(manifest).toBe("ffconcat version 1.0\nfile 'chunk-000.wav'\nfile 'chunk-001.wav'\n");
     expect(writtenWaves).toEqual(waves);


### PR DESCRIPTION
## why

Gemini 3.1 TTS can emit audio incrementally, but `/speak` waited for complete fixed-size chunks and restarted playback for each one. The TUI therefore paid avoidable startup latency and could introduce seams, while TUI and Telegram used different, uneven segmentation policies.

## what

Use one shared balanced speech segmentation policy for both TUI and Telegram. Segments estimate at most two minutes of unmodified Gemini speech, distribute the full transcript evenly, and prefer nearby sentence or paragraph boundaries.

Stream TUI speech as 24 kHz PCM through one long-lived `ffplay` process. Generate one future segment while the current segment plays, preserve ordering with bounded read-ahead, validate stream completion, and retry only before any audio from the active segment is emitted.

Keep Telegram completion-oriented for Ogg Opus encoding while using the same shared segments. Update speech documentation and cover balancing, SSE parsing, prefetch, cancellation, limits, retries, continuous playback, and Telegram encoding behavior.

fixes #442
