### PR TITLE
upgrade Gemini Flash persona

### DIFF
--- a/src/core/personas.ts
+++ b/src/core/personas.ts
@@ -212,10 +212,10 @@ type PersonaSpec = {
 
 const PERSONA_SPECS: PersonaSpec[] = [
   {
-    id: "gemini-3.6-flash",
-    description: "Gemini 3.6 Flash",
+    id: "gemini-3.7-flash",
+    description: "Gemini 3.7 Flash",
     provider: "google",
-    modelId: "gemini-3.6-flash",
+    modelId: "gemini-3.7-flash",
     allowedReasoningLevels: ["low", "medium", "high"],
     settings: { reasoning: "medium" },
     skills: "*",

--- a/test/persona_extends.test.js
+++ b/test/persona_extends.test.js
@@ -199,10 +199,11 @@ describe("custom personas", () => {
 
       expect(personas.find((persona) => persona.id === "gemini-3.1-pro-chat")).toBeUndefined();
       expect(personas.find((persona) => persona.id === "gemini-3-flash-chat")).toBeUndefined();
-      expect(personas.find((persona) => persona.id === "gemini-3.6-flash-chat")?.model.id).toBe(
-        "gemini-3.6-flash",
+      expect(personas.find((persona) => persona.id === "gemini-3.6-flash-chat")).toBeUndefined();
+      expect(personas.find((persona) => persona.id === "gemini-3.7-flash-chat")?.model.id).toBe(
+        "gemini-3.7-flash",
       );
-      expect(personas.find((persona) => persona.id === "gemini-3.6-flash-coder")).toBeUndefined();
+      expect(personas.find((persona) => persona.id === "gemini-3.7-flash-coder")).toBeUndefined();
     } finally {
       fx.cleanup();
     }


### PR DESCRIPTION
## why

Gemini 3.7 Flash is available in the current pi-ai model catalog and should replace Gemini 3.6 Flash as Tau's built-in Gemini persona.

## what

Updates the built-in chat persona and its regression coverage to use `gemini-3.7-flash`. The persona retains the model's supported low, medium, and high reasoning efforts.

The repository was already pinned to the latest published pi-ai and pi-tui release, `0.84.2`, so no dependency version change was required.
