### PR TITLE
estimate image tokens without base64 inflation

### DIFF
--- a/src/core/agent/agent_runtime.ts
+++ b/src/core/agent/agent_runtime.ts
@@ -1,4 +1,3 @@
-import { Buffer } from "node:buffer";
 import { createHash, randomUUID } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
 import type {
@@ -44,7 +43,7 @@ import { buildCompactionUserMessage } from "../utils/compact.js";
 import { extractAssistantText } from "../utils/messages.js";
 import { prependModelNotice } from "../utils/model_notices.js";
 import type { TauStreamOptions } from "../utils/streaming_settings.js";
-import { bytesToTokens } from "../utils/token.js";
+import { estimateMessageTokens } from "../utils/token.js";
 import {
   formatTauUserText,
   getAutoCompactionMetadataFromMessage,
@@ -1366,8 +1365,7 @@ export class AgentRuntime {
       ) {
         return total;
       }
-      const contentBytes = Buffer.byteLength(JSON.stringify(message.content), "utf8");
-      return total + Math.max(1, bytesToTokens(contentBytes));
+      return total + estimateMessageTokens(message);
     }, checkpoint.tokens);
   }
 

--- a/src/core/session/compaction.ts
+++ b/src/core/session/compaction.ts
@@ -6,7 +6,7 @@ import {
   truncateToolRecoveryResults,
 } from "../utils/compact.js";
 import { extractAssistantText } from "../utils/messages.js";
-import { bytesToTokens } from "../utils/token.js";
+import { bytesToTokens, estimateMessageTokens } from "../utils/token.js";
 import { truncateForTokens } from "../utils/truncate.js";
 import {
   formatTauUserText,
@@ -810,10 +810,6 @@ function estimateEntriesTokens(entries: readonly CompactionHistoryEntry[]): numb
         : total + estimateMessageTokens(entry.message),
     0,
   );
-}
-
-function estimateMessageTokens(message: Message): number {
-  return Math.max(1, bytesToTokens(Buffer.byteLength(JSON.stringify(message), "utf8")));
 }
 
 function extractLastAssistantMessage(history: readonly Message[]): string | undefined {

--- a/src/core/utils/token.ts
+++ b/src/core/utils/token.ts
@@ -1,5 +1,6 @@
 import { Buffer } from "node:buffer";
 import type { Message } from "@earendil-works/pi-ai";
+import { assertNever } from "./never.js";
 
 // this is not accurate, but it's a good-enough estimate. OpenAI suggests 4 bytes per token as a
 // cheap heuristic, but in practice it seems to be slightly too low. we use 6 bytes per token, which
@@ -24,9 +25,17 @@ export function estimateMessageTokens(message: Message): number {
     typeof message.content === "string"
       ? message.content
       : message.content.map((block) => {
-          if (block.type !== "image") return block;
-          imageCount += 1;
-          return { ...block, data: "" };
+          switch (block.type) {
+            case "text":
+            case "thinking":
+            case "toolCall":
+              return block;
+            case "image":
+              imageCount += 1;
+              return { ...block, data: "" };
+            default:
+              return assertNever(block);
+          }
         });
   const bytes = Buffer.byteLength(JSON.stringify({ ...message, content }), "utf8");
   return Math.max(1, bytesToTokens(bytes) + imageCount * IMAGE_TOKEN_ESTIMATE);

--- a/src/core/utils/token.ts
+++ b/src/core/utils/token.ts
@@ -1,8 +1,14 @@
+import { Buffer } from "node:buffer";
+import type { Message } from "@earendil-works/pi-ai";
+
 // this is not accurate, but it's a good-enough estimate. OpenAI suggests 4 bytes per token as a
 // cheap heuristic, but in practice it seems to be slightly too low. we use 6 bytes per token, which
 // is a good enough safeguard.
 // see: https://cookbook.openai.com/examples/gpt-5/gpt-5-1-codex-max_prompting_guide
 export const BYTES_PER_TOKEN = 6;
+
+// Tau caps images at 2000x2000; this rounds up Anthropic's 4,784-token high-resolution cap.
+const IMAGE_TOKEN_ESTIMATE = 5_000;
 
 export function tokensToBytes(tokens: number): number {
   return tokens * BYTES_PER_TOKEN;
@@ -10,6 +16,20 @@ export function tokensToBytes(tokens: number): number {
 
 export function bytesToTokens(bytes: number): number {
   return Math.floor(bytes / BYTES_PER_TOKEN);
+}
+
+export function estimateMessageTokens(message: Message): number {
+  let imageCount = 0;
+  const content =
+    typeof message.content === "string"
+      ? message.content
+      : message.content.map((block) => {
+          if (block.type !== "image") return block;
+          imageCount += 1;
+          return { ...block, data: "" };
+        });
+  const bytes = Buffer.byteLength(JSON.stringify({ ...message, content }), "utf8");
+  return Math.max(1, bytesToTokens(bytes) + imageCount * IMAGE_TOKEN_ESTIMATE);
 }
 
 export function formatTokenEstimate(bytes: number): string {

--- a/test/agent_runtime.test.js
+++ b/test/agent_runtime.test.js
@@ -681,6 +681,75 @@ describe("AgentRuntime", () => {
     },
   );
 
+  it.each([
+    ["below", 1_000, false],
+    ["above", 6_000, true],
+  ])(
+    "handles a multi-megabyte image estimate %s the compaction threshold",
+    async (_position, checkpointTokens, shouldCompact) => {
+      const model = { ...personas[0].model, contextWindow: 11_000 };
+      const persona = createPersona({ model });
+      const call = fauxToolCall("image_tool", {}, { id: "image-call" });
+      const { runtime, events } = createRuntime({
+        persona,
+        config: {
+          autoCompact: { enabled: true, reserveTokens: 1_000, keepRecentTokens: 5_500 },
+        },
+        tools: [
+          createTool("image_tool", async () => ({
+            content: [{ type: "image", data: "a".repeat(2 * 1024 * 1024), mimeType: "image/png" }],
+            outcome: "succeeded",
+          })),
+        ],
+      });
+      const toolMessage = createAssistant(persona, [call], {
+        stopReason: "toolUse",
+        usage: {
+          input: checkpointTokens,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: checkpointTokens,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+      });
+      const finalText = shouldCompact ? "continued after compaction" : "image inspected";
+      const streams = [
+        createStream([], createAssistant(persona, "old response")),
+        createToolStream(toolMessage),
+      ];
+      if (shouldCompact) {
+        streams.push(
+          createStream(
+            [],
+            createAssistant(
+              persona,
+              "summary\n\n<preserved-user-message-ids>\n[]\n</preserved-user-message-ids>",
+            ),
+          ),
+        );
+      }
+      streams.push(createStream([], createAssistant(persona, finalText)));
+      const streamModel = setStreams(runtime, streams);
+
+      await runtime.submit(`old request ${"x".repeat(6_000)}`);
+      const result = await runtime.submit("inspect image");
+
+      expect(result.finalMessage.content[0].text).toBe(finalText);
+      expect(events.some((event) => event.type === "compaction_start")).toBe(shouldCompact);
+      if (shouldCompact) {
+        expect(events).toContainEqual(
+          expect.objectContaining({
+            type: "compaction_end",
+            reason: "threshold",
+            outcome: "compacted",
+          }),
+        );
+      }
+      expect(streamModel).toHaveBeenCalledTimes(shouldCompact ? 4 : 3);
+    },
+  );
+
   it("blocks a turn when required automatic compaction fails after input commit", async () => {
     const model = { ...personas[0].model, contextWindow: 100 };
     const persona = createPersona({ model });

--- a/test/core_runtime.test.js
+++ b/test/core_runtime.test.js
@@ -1074,6 +1074,27 @@ describe("compaction context message", () => {
     expect(cut).toEqual({ startIndex: 2, cutType: "turn-boundary" });
   });
 
+  it("does not let encoded image size distort the retained turn boundary", () => {
+    const entries = historyEntries([
+      userMessage(`old ${"x".repeat(9_000)}`),
+      assistantMessage("old answer"),
+      userMessage("current request"),
+      assistantMessage("image tool call"),
+      {
+        role: "toolResult",
+        toolCallId: "image-call",
+        toolName: "view_image",
+        content: [{ type: "image", data: "a".repeat(2 * 1024 * 1024), mimeType: "image/png" }],
+        isError: false,
+        timestamp: 0,
+      },
+    ]);
+
+    const cut = selectAutoCompactionCut(entries, { startIndex: 0, keepRecentTokens: 6_000 });
+
+    expect(cut).toEqual({ startIndex: 2, cutType: "turn-boundary" });
+  });
+
   it("splits only inside the oversized latest turn at assistant boundaries", () => {
     const entries = historyEntries([
       userMessage("latest request"),


### PR DESCRIPTION
## why

Tau's fallback context estimator serialized image blocks and treated their base64 payloads as text. A multi-megabyte `view_image` result could therefore add hundreds of thousands of estimated tokens and trigger auto-compaction even when actual context usage was low.

## what

- add one content-aware message token estimator that retains the existing UTF-8 heuristic for text and structured message fields
- exclude encoded image data from the text estimate and charge 5,000 tokens per image
- use the shared estimator for both the live auto-compaction gate and compaction retention boundaries
- cover image estimates below and above the auto-compaction threshold, plus retained-turn selection with a multi-megabyte payload

## details

The canonical image block has no dimensions, so the implementation uses a fixed provider-independent estimate rather than decoding every stored image in the synchronous compaction path or widening message and session contracts. The 5,000-token value rounds up Anthropic's documented 4,784-token high-resolution cap and is conservative for Tau's current 2000×2000 image limit. It is also in the same practical range as the official [OpenAI vision formulas](https://developers.openai.com/api/docs/guides/images-vision#calculating-costs) and [Gemini image token accounting](https://ai.google.dev/gemini-api/docs/tokens#image-tokens).

This assumes Tau-produced image content remains bounded by the existing image tool limit. Provider-reported usage still replaces the temporary estimate after the next successful model response. There are no remaining implementation questions.

fixes #452