### PR TITLE
refine tool result messages

### DIFF
--- a/src/code_mode/runtime.ts
+++ b/src/code_mode/runtime.ts
@@ -472,16 +472,17 @@ function appendTerminationNote(
   execution: TauCodeModeExecutionCapture,
   timeoutMs: number,
 ): string {
-  let note: string | undefined;
+  let notice: string | undefined;
   if (execution.timedOut) {
-    note = `(tau) timed out after ${timeoutMs}ms`;
+    notice = `Program timed out after ${timeoutMs}ms.`;
   } else if (execution.aborted) {
-    note = "(tau) aborted";
+    notice = "Program was cancelled.";
   } else if (execution.closeSignal) {
-    note = `(tau) terminated by signal ${execution.closeSignal}`;
+    notice = `Program was terminated by signal ${execution.closeSignal}.`;
   }
-  if (!note) return output;
-  return `${output}${output && !output.endsWith("\n") ? "\n" : ""}${note}\n`;
+  if (!notice) return output;
+  if (!output) return `${notice}\n`;
+  return `${output}${output.endsWith("\n") ? "\n" : "\n\n"}[${notice}]\n`;
 }
 
 function formatResultContent(args: {
@@ -494,8 +495,11 @@ function formatResultContent(args: {
   const output = projection.content.trimEnd();
   if (!output && status === "succeeded") {
     return persistedPath
-      ? `Program produced no output\n\n[Output saved to ${persistedPath}.]`
-      : "Program produced no output";
+      ? `Program produced no output.\n\n[Output saved to ${persistedPath}.]`
+      : "Program produced no output.";
+  }
+  if (!output && status === "failed" && execution.exitCode !== null && execution.exitCode !== 0) {
+    return `Program failed with exit code ${execution.exitCode} and produced no output.`;
   }
 
   const truncationNote =
@@ -504,9 +508,8 @@ function formatResultContent(args: {
       : persistedPath
         ? `\n\n[Output saved to ${persistedPath}.]`
         : "";
-  const exitNote =
-    status === "failed" && execution.exitCode !== null && execution.exitCode !== 0
-      ? `\n(exit ${execution.exitCode})`
-      : "";
-  return `${output || "(no output)"}${truncationNote}${exitNote}`;
+  const resultText = `${output || "Program failed without producing output."}${truncationNote}`;
+  return status === "failed" && execution.exitCode !== null && execution.exitCode !== 0
+    ? `${resultText.trimEnd()}\n\n[Program failed with exit code ${execution.exitCode}.]`
+    : resultText;
 }

--- a/src/core/session/direct_bash.ts
+++ b/src/core/session/direct_bash.ts
@@ -3,6 +3,7 @@ import {
   buildBashPresentation,
   formatBashUserMessageText,
   getBashOutputPolicy,
+  getBashTerminationNotice,
   prepareBashOutput,
 } from "../tools/bash.js";
 import type { ToolExecutionBackend } from "../tools/execution_backend.js";
@@ -35,11 +36,20 @@ export async function runDirectBashCommand(
     output,
     exitCode,
     truncated: captureTruncated,
+    aborted,
+    timedOut,
+    closeSignal,
   } = await options.backend.runBash(options.command, {
     signal: options.signal,
     timeoutMs: BASH_DEFAULT_TIMEOUT_MS,
   });
   const durationMs = Math.max(0, now() - startedAt);
+  const terminationNotice = getBashTerminationNotice({
+    aborted,
+    timedOut,
+    closeSignal,
+    timeoutMs: BASH_DEFAULT_TIMEOUT_MS,
+  });
   const truncationInfo = await prepareBashOutput(
     output,
     captureTruncated,
@@ -49,7 +59,8 @@ export async function runDirectBashCommand(
   const userMessageText = formatBashUserMessageText({
     command: options.command,
     truncationInfo,
-    exitCode,
+    exitCode: terminationNotice ? null : exitCode,
+    terminationNotice,
   });
   const presentation = buildBashPresentation({
     toolName: TOOL_NAME_BASH,
@@ -58,6 +69,8 @@ export async function runDirectBashCommand(
     exitCode,
     durationMs,
     workingDirectory: options.workingDirectory,
+    includeExitCode: !terminationNotice,
+    terminationNotice,
     actionLabel: options.actionLabel,
     detailTruncation: {
       maxLines: 33,

--- a/src/core/tools/bash.ts
+++ b/src/core/tools/bash.ts
@@ -11,6 +11,7 @@ import {
   type TruncationResult,
   truncateForTokens,
 } from "../utils/truncate.js";
+import { formatZodError } from "../utils/zod.js";
 import type { ToolActivity } from "./activity.js";
 import type { ToolExecutionBackend } from "./execution_backend.js";
 import {
@@ -218,8 +219,38 @@ export async function prepareBashOutput(
   };
 }
 
-function stripBashAbortNote(output: string): string {
-  return output.replace(/(?:\n?\(tau\) aborted)+\s*$/, "");
+function getBashTermination(args: {
+  aborted: boolean;
+  timedOut: boolean;
+  closeSignal: string | null;
+  timeoutMs: number;
+}): { backendNote: string; resultText: string } | undefined {
+  if (args.timedOut) {
+    return {
+      backendNote: `(tau) timed out after ${args.timeoutMs}ms`,
+      resultText: `Command timed out after ${args.timeoutMs}ms.`,
+    };
+  }
+  if (args.aborted) {
+    return { backendNote: "(tau) aborted", resultText: "Command was cancelled." };
+  }
+  if (args.closeSignal) {
+    return {
+      backendNote: `(tau) terminated by signal ${args.closeSignal}`,
+      resultText: `Command was terminated by signal ${args.closeSignal}.`,
+    };
+  }
+  return undefined;
+}
+
+function stripBashTerminationNote(output: string, note: string): string {
+  const trimmedOutput = output.trimEnd();
+  return trimmedOutput.endsWith(note) ? trimmedOutput.slice(0, -note.length).trimEnd() : output;
+}
+
+function appendBashNotice(output: string, notice: string): string {
+  const trimmedOutput = output.trimEnd();
+  return trimmedOutput ? `${trimmedOutput}\n\n[${notice}]` : notice;
 }
 
 export function formatBashToolResultText(args: {
@@ -234,12 +265,17 @@ export function formatBashToolResultText(args: {
     const preview = model.content;
     const totalTokenEstimate = bytesToTokens(model.totalBytes);
     const gateNote = `\n\n[Output gated: This command already ran and any side effects have persisted. Full output estimate: ~${totalTokenEstimate} tokens.${formatBashOutputFileHint({ path: fullOutputPath })} If you need more output from this truncated result, either read the saved file or re-run with maxOutputTokens set to ${BASH_MODEL_DEFAULT_MAX_TOKENS}-${BASH_MODEL_MAX_AUTONOMOUS_TOKENS}. Only exceed ${BASH_MODEL_MAX_AUTONOMOUS_TOKENS} when the user explicitly requests more output, up to ${BASH_MAX_OUTPUT_TOKENS}. User requests are checked by the system, so do not exceed ${BASH_MODEL_MAX_AUTONOMOUS_TOKENS} autonomously.]`;
-    const exitNote = exitCode !== null && exitCode !== 0 ? `\n(exit ${exitCode})` : "";
-    return `${preview}${gateNote}${exitNote}`;
+    const resultText = `${preview}${gateNote}`;
+    return exitCode !== null && exitCode !== 0
+      ? appendBashNotice(resultText, `Command failed with exit code ${exitCode}.`)
+      : resultText;
   }
 
   if (hasNoOutput && exitCode === 0) {
     return "Command produced no output (exit 0)";
+  }
+  if (hasNoOutput && exitCode !== null) {
+    return `Command failed with exit code ${exitCode} and produced no output.`;
   }
 
   const outputForContext = model.content;
@@ -247,8 +283,10 @@ export function formatBashToolResultText(args: {
     model.truncated || captureTruncated
       ? `\n\n[Output truncated for context: ${model.outputLines} lines / ${formatBytes(model.outputBytes)} shown of ${model.totalLines} lines / ${formatBytes(model.totalBytes)} (full output estimate: ~${bytesToTokens(model.totalBytes)} tokens).${formatBashOutputFileHint({ path: fullOutputPath })}]`
       : "";
-  const exitNote = exitCode !== null && exitCode !== 0 ? `\n(exit ${exitCode})` : "";
-  return `${outputForContext}${truncNote}${exitNote}`;
+  const resultText = `${outputForContext}${truncNote}`;
+  return exitCode !== null && exitCode !== 0
+    ? appendBashNotice(resultText, `Command failed with exit code ${exitCode}.`)
+    : resultText;
 }
 
 export function formatBashUserMessageText(args: {
@@ -340,15 +378,10 @@ function resolveBashWorkingDirectory(args: {
 
 const bashArgsSchema = z
   .object({
-    command: z.string().trim().min(1),
-    workingDirectory: z
-      .string()
-      .trim()
-      .min(1)
-      .refine((path) => !/[\r\n]/.test(path), "Working directory must be a single line.")
-      .optional(),
-    timeout: z.number().positive().optional(),
-    maxOutputTokens: z.number().int().positive().optional(),
+    command: z.string(),
+    workingDirectory: z.string().optional(),
+    timeout: z.number().optional(),
+    maxOutputTokens: z.number().int().optional(),
   })
   .strict();
 
@@ -377,7 +410,44 @@ function parseBashArgs(raw: unknown):
   if (!parsed.success) {
     return {
       ok: false,
-      error: parsed.error.issues.map((issue) => issue.message).join("; "),
+      error: formatZodError(parsed.error),
+      commandForDisplay,
+    };
+  }
+
+  const command = parsed.data.command.trim();
+  if (!command) {
+    return { ok: false, error: "command must not be empty.", commandForDisplay };
+  }
+
+  const workingDirectory = parsed.data.workingDirectory?.trim();
+  if (parsed.data.workingDirectory !== undefined && !workingDirectory) {
+    return { ok: false, error: "workingDirectory must not be empty.", commandForDisplay };
+  }
+  if (workingDirectory && /[\r\n]/.test(workingDirectory)) {
+    return {
+      ok: false,
+      error: "workingDirectory must be a single line.",
+      commandForDisplay,
+    };
+  }
+  if (parsed.data.timeout !== undefined && parsed.data.timeout <= 0) {
+    return { ok: false, error: "timeout must be greater than 0.", commandForDisplay };
+  }
+  if (parsed.data.maxOutputTokens !== undefined && parsed.data.maxOutputTokens <= 0) {
+    return {
+      ok: false,
+      error: "maxOutputTokens must be greater than 0.",
+      commandForDisplay,
+    };
+  }
+  if (
+    parsed.data.maxOutputTokens !== undefined &&
+    parsed.data.maxOutputTokens > BASH_MAX_OUTPUT_TOKENS
+  ) {
+    return {
+      ok: false,
+      error: `maxOutputTokens must not exceed ${BASH_MAX_OUTPUT_TOKENS}.`,
       commandForDisplay,
     };
   }
@@ -385,12 +455,12 @@ function parseBashArgs(raw: unknown):
   return {
     ok: true,
     data: {
-      command: parsed.data.command,
-      workingDirectory: parsed.data.workingDirectory,
+      command,
+      workingDirectory,
       timeout: parsed.data.timeout,
       maxOutputTokens: clampOutputTokens(parsed.data.maxOutputTokens),
       hasMaxOutputTokens,
-      commandForDisplay: parsed.data.command,
+      commandForDisplay: command,
     },
   };
 }
@@ -432,8 +502,11 @@ export function createBashToolDefinition(backend: ToolExecutionBackend, cwd: str
         workingDirectory: parsedArgs.ok ? parsedArgs.data.workingDirectory : undefined,
       });
 
-      const blocked = (reason: string): ToolImplementationOutcome => {
-        const outcome = createTextToolOutcome(reason, "blocked");
+      const blocked = (
+        reason: string,
+        semanticOutcome: ToolExecutionOutcome["outcome"] = "blocked",
+      ): ToolImplementationOutcome => {
+        const outcome = createTextToolOutcome(reason, semanticOutcome);
         const uiEvent: ToolActivity = {
           type: "bash_blocked",
           toolCallId: toolCall.id,
@@ -460,18 +533,26 @@ export function createBashToolDefinition(backend: ToolExecutionBackend, cwd: str
         async () => {
           try {
             const startedAt = Date.now();
+            const effectiveTimeoutMs = timeout ?? BASH_DEFAULT_TIMEOUT_MS;
             const {
               output,
               exitCode,
               truncated: captureTruncated,
               aborted,
               timedOut,
+              closeSignal,
             } = await backend.runBash(command, {
               signal,
-              timeoutMs: timeout ?? BASH_DEFAULT_TIMEOUT_MS,
+              timeoutMs: effectiveTimeoutMs,
               cwd: effectiveWorkingDirectory,
             });
             const durationMs = Math.max(0, Date.now() - startedAt);
+            const termination = getBashTermination({
+              aborted,
+              timedOut,
+              closeSignal,
+              timeoutMs: effectiveTimeoutMs,
+            });
 
             const outputPolicy = getBashOutputPolicy({
               mode: "model",
@@ -479,16 +560,19 @@ export function createBashToolDefinition(backend: ToolExecutionBackend, cwd: str
               hasMaxOutputTokens,
             });
             const truncationInfo = await prepareBashOutput(
-              aborted ? stripBashAbortNote(output) : output,
+              termination ? stripBashTerminationNote(output, termination.backendNote) : output,
               captureTruncated,
               outputPolicy,
               backend,
             );
-            const resultText = formatBashToolResultText({ truncationInfo, exitCode });
-            const toolText = aborted
-              ? [resultText.trimEnd(), "Command was cancelled."].filter(Boolean).join("\n\n")
+            const resultText = formatBashToolResultText({
+              truncationInfo,
+              exitCode: termination ? null : exitCode,
+            });
+            const toolText = termination
+              ? appendBashNotice(resultText, termination.resultText)
               : resultText;
-            const isError = exitCode === null || exitCode !== 0;
+            const isError = termination !== undefined || exitCode === null || exitCode !== 0;
             const presentation = buildBashPresentation({
               toolName: TOOL_NAME_BASH,
               subject: command,
@@ -496,7 +580,7 @@ export function createBashToolDefinition(backend: ToolExecutionBackend, cwd: str
               exitCode,
               durationMs,
               workingDirectory: effectiveWorkingDirectory,
-              includeExitCode: !aborted && !timedOut,
+              includeExitCode: !termination,
             });
 
             const outcome = createTextToolOutcome(
@@ -512,21 +596,8 @@ export function createBashToolDefinition(backend: ToolExecutionBackend, cwd: str
             };
             return { content: outcome.content, outcome: outcome.outcome, uiEvent };
           } catch (e) {
-            const msg = `Bash tool execution failed: ${e instanceof Error ? e.message : String(e)}`;
-            const outcome = createTextToolOutcome(msg, "failed");
-            const uiEvent: ToolActivity = {
-              type: "bash_blocked",
-              command: commandForDisplay,
-              presentation: buildToolRunPresentation({
-                toolName: TOOL_NAME_BASH,
-                subject: commandForDisplay,
-                details: [{ text: msg }],
-                metadata: [formatCwd(effectiveWorkingDirectory)],
-              }),
-              reason: msg,
-              toolCallId: toolCall.id,
-            };
-            return { content: outcome.content, outcome: outcome.outcome, uiEvent };
+            const errorMessage = e instanceof Error ? e.message : String(e);
+            return blocked(`Could not execute command: ${errorMessage}`, "failed");
           }
         },
         {

--- a/src/core/tools/bash.ts
+++ b/src/core/tools/bash.ts
@@ -219,33 +219,22 @@ export async function prepareBashOutput(
   };
 }
 
-function getBashTermination(args: {
+export function getBashTerminationNotice(args: {
   aborted: boolean;
   timedOut: boolean;
   closeSignal: string | null;
   timeoutMs: number;
-}): { backendNote: string; resultText: string } | undefined {
+}): string | undefined {
   if (args.timedOut) {
-    return {
-      backendNote: `(tau) timed out after ${args.timeoutMs}ms`,
-      resultText: `Command timed out after ${args.timeoutMs}ms.`,
-    };
+    return `Command timed out after ${args.timeoutMs}ms.`;
   }
   if (args.aborted) {
-    return { backendNote: "(tau) aborted", resultText: "Command was cancelled." };
+    return "Command was cancelled.";
   }
   if (args.closeSignal) {
-    return {
-      backendNote: `(tau) terminated by signal ${args.closeSignal}`,
-      resultText: `Command was terminated by signal ${args.closeSignal}.`,
-    };
+    return `Command was terminated by signal ${args.closeSignal}.`;
   }
   return undefined;
-}
-
-function stripBashTerminationNote(output: string, note: string): string {
-  const trimmedOutput = output.trimEnd();
-  return trimmedOutput.endsWith(note) ? trimmedOutput.slice(0, -note.length).trimEnd() : output;
 }
 
 function appendBashNotice(output: string, notice: string): string {
@@ -293,17 +282,21 @@ export function formatBashUserMessageText(args: {
   command: string;
   truncationInfo: BashTruncationInfo;
   exitCode: number | null;
+  terminationNotice?: string;
 }): string {
-  const { command, truncationInfo, exitCode } = args;
+  const { command, truncationInfo, exitCode, terminationNotice } = args;
   const { model, captureTruncated, fullOutputPath } = truncationInfo;
 
-  const outputForContext = model.content.trimEnd() || "(no output)";
+  const outputForContext = model.content.trimEnd() || (terminationNotice ? "" : "(no output)");
   const truncNote =
     model.truncated || captureTruncated
       ? `\n\n[Output truncated for context: ${model.outputLines} lines / ${formatBytes(model.outputBytes)} shown of ${model.totalLines} lines / ${formatBytes(model.totalBytes)} (full output estimate: ~${bytesToTokens(model.totalBytes)} tokens).${formatBashOutputFileHint({ path: fullOutputPath })}]`
       : "";
-  const exitNote = exitCode !== null && exitCode !== 0 ? `\n(exit ${exitCode})` : "";
-  const bashContextText = `$ ${command}\n${outputForContext}${truncNote}${exitNote}`;
+  const resultText = `${outputForContext}${truncNote}`;
+  const resultWithStatus = terminationNotice
+    ? appendBashNotice(resultText, terminationNotice)
+    : `${resultText}${exitCode !== null && exitCode !== 0 ? `\n(exit ${exitCode})` : ""}`;
+  const bashContextText = `$ ${command}\n${resultWithStatus}`;
   return `Bash command output:\n${bashContextText}`;
 }
 
@@ -316,6 +309,7 @@ export function buildBashPresentation(args: {
   durationMs: number;
   workingDirectory?: string;
   includeExitCode?: boolean;
+  terminationNotice?: string;
   actionLabel?: string;
   detailTruncation?: Exclude<ToolCardDetailTruncation, false>;
 }): ToolRunPresentation {
@@ -326,6 +320,9 @@ export function buildBashPresentation(args: {
   const details: ToolCardLine[] = detailText
     ? detailText.split("\n").map((text) => ({ text, wrap: "character" }))
     : [];
+  if (args.terminationNotice) {
+    details.push({ text: `[${args.terminationNotice}]`, wrap: "word" });
+  }
 
   const outputLines = model.outputLines;
   const outputBytes = model.outputBytes;
@@ -547,7 +544,7 @@ export function createBashToolDefinition(backend: ToolExecutionBackend, cwd: str
               cwd: effectiveWorkingDirectory,
             });
             const durationMs = Math.max(0, Date.now() - startedAt);
-            const termination = getBashTermination({
+            const terminationNotice = getBashTerminationNotice({
               aborted,
               timedOut,
               closeSignal,
@@ -560,19 +557,19 @@ export function createBashToolDefinition(backend: ToolExecutionBackend, cwd: str
               hasMaxOutputTokens,
             });
             const truncationInfo = await prepareBashOutput(
-              termination ? stripBashTerminationNote(output, termination.backendNote) : output,
+              output,
               captureTruncated,
               outputPolicy,
               backend,
             );
             const resultText = formatBashToolResultText({
               truncationInfo,
-              exitCode: termination ? null : exitCode,
+              exitCode: terminationNotice ? null : exitCode,
             });
-            const toolText = termination
-              ? appendBashNotice(resultText, termination.resultText)
+            const toolText = terminationNotice
+              ? appendBashNotice(resultText, terminationNotice)
               : resultText;
-            const isError = termination !== undefined || exitCode === null || exitCode !== 0;
+            const isError = terminationNotice !== undefined || exitCode === null || exitCode !== 0;
             const presentation = buildBashPresentation({
               toolName: TOOL_NAME_BASH,
               subject: command,
@@ -580,7 +577,8 @@ export function createBashToolDefinition(backend: ToolExecutionBackend, cwd: str
               exitCode,
               durationMs,
               workingDirectory: effectiveWorkingDirectory,
-              includeExitCode: !termination,
+              includeExitCode: !terminationNotice,
+              terminationNotice,
             });
 
             const outcome = createTextToolOutcome(

--- a/src/core/tools/code_mode.ts
+++ b/src/core/tools/code_mode.ts
@@ -94,11 +94,11 @@ function getCodeModeTerminationNote(
   timeoutMs: number | undefined,
 ): string | undefined {
   if (runtime.status === "timed-out") {
-    return `(tau) timed out${timeoutMs === undefined ? "" : ` after ${timeoutMs}ms`}`;
+    return `Program timed out${timeoutMs === undefined ? "" : ` after ${timeoutMs}ms`}.`;
   }
-  if (runtime.status === "cancelled") return "(tau) aborted";
+  if (runtime.status === "cancelled") return "Program was cancelled.";
   if (runtime.execution.closeSignal) {
-    return `(tau) terminated by signal ${runtime.execution.closeSignal}`;
+    return `Program was terminated by signal ${runtime.execution.closeSignal}.`;
   }
   return undefined;
 }
@@ -193,7 +193,9 @@ export function createCodeModeToolDefinition<TArgs>(
               ? {
                   ...outputPresentation,
                   details: outputPresentation.details.map((line) =>
-                    line.text === terminationNote ? { ...line, wrap: "word" as const } : line,
+                    line.text === terminationNote || line.text === `[${terminationNote}]`
+                      ? { ...line, wrap: "word" as const }
+                      : line,
                   ),
                 }
               : outputPresentation;
@@ -207,7 +209,8 @@ export function createCodeModeToolDefinition<TArgs>(
             };
             return { content: outcome.content, outcome: outcome.outcome, uiEvent };
           } catch (error) {
-            return blocked(error instanceof Error ? error.message : String(error), "failed");
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            return blocked(`Could not execute program: ${errorMessage}`, "failed");
           }
         },
         {

--- a/src/core/tools/edit.ts
+++ b/src/core/tools/edit.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { buildLineDiff } from "../utils/line_diff.js";
 import { formatZodError } from "../utils/zod.js";
 import type { ToolActivity } from "./activity.js";
-import type { ToolExecutionBackend } from "./execution_backend.js";
+import { isToolExecutionBackendError, type ToolExecutionBackend } from "./execution_backend.js";
 import { buildToolRunPresentation, type ToolCardLine } from "./presentation.js";
 import {
   type AgentTool,
@@ -173,7 +173,7 @@ export function createEditToolDefinition(backend: ToolExecutionBackend): AgentTo
           content = result.content;
         } catch (e) {
           const errorMessage = e instanceof Error ? e.message : String(e);
-          if ((e as NodeJS.ErrnoException).code === "ENOENT") {
+          if (isToolExecutionBackendError(e, "not-found")) {
             return blocked(`File not found at '${path}'. Verify the path is correct.`);
           }
           return blocked(`Could not read file: ${errorMessage}`, "failed");

--- a/src/core/tools/edit.ts
+++ b/src/core/tools/edit.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { buildLineDiff } from "../utils/line_diff.js";
 import { formatZodError } from "../utils/zod.js";
 import type { ToolActivity } from "./activity.js";
-import { isToolExecutionBackendError, type ToolExecutionBackend } from "./execution_backend.js";
+import type { ToolExecutionBackend } from "./execution_backend.js";
 import { buildToolRunPresentation, type ToolCardLine } from "./presentation.js";
 import {
   type AgentTool,
@@ -173,7 +173,7 @@ export function createEditToolDefinition(backend: ToolExecutionBackend): AgentTo
           content = result.content;
         } catch (e) {
           const errorMessage = e instanceof Error ? e.message : String(e);
-          if (isToolExecutionBackendError(e, "not-found")) {
+          if ((e as NodeJS.ErrnoException).code === "ENOENT") {
             return blocked(`File not found at '${path}'. Verify the path is correct.`);
           }
           return blocked(`Could not read file: ${errorMessage}`, "failed");

--- a/src/core/tools/execution_backend.ts
+++ b/src/core/tools/execution_backend.ts
@@ -214,12 +214,8 @@ export function createLocalToolExecutionBackend(
 
     async readFile(path) {
       const resolvedPath = resolvePath(path);
-      try {
-        const content = readFileSync(resolvedPath, "utf-8");
-        return { path: resolvedPath, content };
-      } catch (error) {
-        throw normalizeToolExecutionBackendError(error);
-      }
+      const content = readFileSync(resolvedPath, "utf-8");
+      return { path: resolvedPath, content };
     },
 
     async readFileBinary(path, options = {}) {

--- a/src/core/tools/execution_backend.ts
+++ b/src/core/tools/execution_backend.ts
@@ -65,6 +65,35 @@ export type ListDirResult = {
   entries: ListDirEntry[];
 };
 
+export class ToolExecutionBackendError extends Error {
+  constructor(
+    readonly code: "not-found",
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "ToolExecutionBackendError";
+  }
+}
+
+export function isToolExecutionBackendError(
+  error: unknown,
+  code: ToolExecutionBackendError["code"],
+): error is ToolExecutionBackendError {
+  return error instanceof ToolExecutionBackendError && error.code === code;
+}
+
+export function normalizeToolExecutionBackendError(error: unknown): unknown {
+  if (error instanceof ToolExecutionBackendError) {
+    return error;
+  }
+  if ((error as NodeJS.ErrnoException)?.code === "ENOENT") {
+    const message = error instanceof Error ? error.message : String(error);
+    return new ToolExecutionBackendError("not-found", message, { cause: error });
+  }
+  return error;
+}
+
 export const BASH_ENVIRONMENT_OVERRIDES = {
   NO_COLOR: "1",
   FORCE_COLOR: "0",
@@ -159,29 +188,10 @@ export function createLocalToolExecutionBackend(
       },
     );
 
-    let output = result.output ?? "";
-    const stdout = result.stdout;
-    let stderr = result.stderr;
-    let terminationNote: string | undefined;
-    if (result.timedOut && effectiveTimeoutMs !== undefined) {
-      terminationNote = `(tau) timed out after ${effectiveTimeoutMs}ms`;
-    } else if (result.aborted) {
-      terminationNote = "(tau) aborted";
-    } else if (result.closeSignal) {
-      terminationNote = `(tau) terminated by signal ${result.closeSignal}`;
-    }
-
-    const note = terminationNote?.trim();
-    if (note && !output.includes(note)) {
-      const noteText = `${output && !output.endsWith("\n") ? "\n" : ""}${note}\n`;
-      output += noteText;
-      stderr += noteText;
-    }
-
     return {
-      output,
-      stdout,
-      stderr,
+      output: result.output ?? "",
+      stdout: result.stdout,
+      stderr: result.stderr,
       exitCode: result.exitCode,
       truncated: result.captureLimitExceeded,
       timedOut: result.timedOut,
@@ -204,25 +214,33 @@ export function createLocalToolExecutionBackend(
 
     async readFile(path) {
       const resolvedPath = resolvePath(path);
-      const content = readFileSync(resolvedPath, "utf-8");
-      return { path: resolvedPath, content };
+      try {
+        const content = readFileSync(resolvedPath, "utf-8");
+        return { path: resolvedPath, content };
+      } catch (error) {
+        throw normalizeToolExecutionBackendError(error);
+      }
     },
 
     async readFileBinary(path, options = {}) {
       const resolvedPath = resolvePath(path);
-      const stats = statSync(resolvedPath);
-      if (!stats.isFile()) {
-        throw new Error("path is not a file.");
+      try {
+        const stats = statSync(resolvedPath);
+        if (!stats.isFile()) {
+          throw new Error("path is not a file.");
+        }
+        const bytes = stats.size;
+        const maxBytes = options.maxBytes;
+        if (maxBytes !== undefined && bytes > maxBytes) {
+          throw new Error(
+            `file exceeds maximum size of ${formatBytes(maxBytes)} (got ${formatBytes(bytes)}).`,
+          );
+        }
+        const content = readFileSync(resolvedPath);
+        return { path: resolvedPath, content, bytes };
+      } catch (error) {
+        throw normalizeToolExecutionBackendError(error);
       }
-      const bytes = stats.size;
-      const maxBytes = options.maxBytes;
-      if (maxBytes !== undefined && bytes > maxBytes) {
-        throw new Error(
-          `file exceeds maximum size of ${formatBytes(maxBytes)} (got ${formatBytes(bytes)}).`,
-        );
-      }
-      const content = readFileSync(resolvedPath);
-      return { path: resolvedPath, content, bytes };
     },
 
     async writeFile(path, content) {

--- a/src/core/tools/goal.ts
+++ b/src/core/tools/goal.ts
@@ -60,7 +60,15 @@ const UPDATE_GOAL_TOOL: Tool = {
 };
 
 const emptyArgsSchema = z.object({}).strict();
-const createArgsSchema = z.object({ objective: z.string().trim().min(1) }).strict();
+const createArgsSchema = z
+  .object({ objective: z.string().trim().min(1, "must not be empty.") })
+  .strict();
+const GOAL_FAILURE_ACTIONS: Record<string, string> = {
+  [TOOL_NAME_GET_GOAL]: "read session goal",
+  [TOOL_NAME_CREATE_GOAL]: "create session goal",
+  [TOOL_NAME_UPDATE_GOAL]: "update session goal",
+};
+
 const GOAL_ACTION_LABELS: Record<string, ToolRunActionLabels> = {
   [TOOL_NAME_GET_GOAL]: {
     preparing: "preparing check",
@@ -93,15 +101,15 @@ const GOAL_ACTION_LABELS: Record<string, ToolRunActionLabels> = {
 
 const updateArgsSchema = z
   .object({
-    objective: z.string().trim().min(1).optional(),
+    objective: z.string().trim().min(1, "must not be empty.").optional(),
     status: z.enum(["complete", "blocked"]).optional(),
   })
   .strict()
   .refine((args) => args.objective !== undefined || args.status !== undefined, {
-    message: "objective or status is required",
+    message: "objective or status is required.",
   })
   .refine((args) => !(args.objective !== undefined && args.status === "complete"), {
-    message: "objective cannot be combined with complete",
+    message: "objective cannot be combined with complete.",
   });
 
 export function createGoalToolDefinitions(manager: GoalManager): AgentTool[] {
@@ -150,8 +158,9 @@ function createGoalTool<T>(
   ) => string | GoalToolExecutionResult | Promise<string | GoalToolExecutionResult>,
 ): AgentTool {
   const actionOverrides = GOAL_ACTION_LABELS[schema.name];
-  if (!actionOverrides) {
-    throw new Error(`missing goal action labels for '${schema.name}'`);
+  const failureAction = GOAL_FAILURE_ACTIONS[schema.name];
+  if (!actionOverrides || !failureAction) {
+    throw new Error(`missing goal presentation configuration for '${schema.name}'`);
   }
   return {
     schema,
@@ -202,7 +211,8 @@ function createGoalTool<T>(
               ? finish(result, "succeeded")
               : finish(result.text, "succeeded", result.presentation);
           } catch (error) {
-            return finish(error instanceof Error ? error.message : String(error), "blocked");
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            return finish(`Could not ${failureAction}: ${errorMessage}`, "failed");
           }
         },
         {

--- a/src/core/tools/history.ts
+++ b/src/core/tools/history.ts
@@ -40,7 +40,9 @@ export const HISTORY_TOOL: Tool = {
   ),
 };
 
-const historyArgsSchema = z.object({ code: z.string().trim().min(1) }).strict();
+const historyArgsSchema = z
+  .object({ code: z.string().trim().min(1, "must not be empty.") })
+  .strict();
 type HistoryArgs = z.infer<typeof historyArgsSchema>;
 
 const attributeFilterSchema = z.union([

--- a/src/core/tools/interrupt_agent.ts
+++ b/src/core/tools/interrupt_agent.ts
@@ -39,13 +39,15 @@ export const INTERRUPT_AGENT_TOOL: Tool = {
   ),
 };
 
-const interruptArgsSchema = z.object({
-  id: z
-    .string()
-    .trim()
-    .min(1)
-    .refine((id) => !/[\r\n]/.test(id), "Subagent ID must be a single line."),
-});
+const interruptArgsSchema = z
+  .object({
+    id: z
+      .string()
+      .trim()
+      .min(1, "must not be empty.")
+      .refine((id) => !/[\r\n]/.test(id), "must be a single line."),
+  })
+  .strict();
 
 function getInterruptAgentSubject(raw: unknown): string {
   const parsedArgs = parseToolArgs(interruptArgsSchema, raw);
@@ -99,12 +101,12 @@ export function createInterruptAgentToolDefinition(supervisor: AgentSupervisor):
           try {
             const current = supervisor.getSnapshot(id);
             if (!current) {
-              return blocked(`Unknown subagent ID: ${id}`);
+              return blocked(`Unknown subagent ID '${id}'.`);
             }
             const wasRunning = current.availability === "running";
             const state = await supervisor.interrupt(id, signal);
             if (!state) {
-              return blocked(`Unknown subagent ID: ${id}`);
+              return blocked(`Unknown subagent ID '${id}'.`);
             }
 
             const resultText = formatInterruptAgentResult(
@@ -133,8 +135,10 @@ export function createInterruptAgentToolDefinition(supervisor: AgentSupervisor):
             const outcome = createTextToolOutcome(resultText, "succeeded");
             return { content: outcome.content, outcome: outcome.outcome, uiEvent };
           } catch (error) {
-            const message = error instanceof Error ? error.message : String(error);
-            const reason = message.trim() || "The interrupt_agent request failed.";
+            const errorMessage = (error instanceof Error ? error.message : String(error)).trim();
+            const reason = signal.aborted
+              ? "Subagent interruption was cancelled."
+              : `Could not interrupt subagent: ${errorMessage || "unknown error"}`;
             const presentation = signal.aborted
               ? buildToolRunPresentation({
                   toolName: TOOL_NAME_INTERRUPT_AGENT,

--- a/src/core/tools/list_agents.ts
+++ b/src/core/tools/list_agents.ts
@@ -43,8 +43,11 @@ export function createListAgentsToolDefinition(supervisor: AgentSupervisor): Age
       toolCall: ToolCall,
       context: ToolExecutionContext,
     ): Promise<ToolExecutionOutcome> {
-      const blocked = (reason: string): ToolImplementationOutcome => {
-        const outcome = createTextToolOutcome(reason, "blocked");
+      const blocked = (
+        reason: string,
+        semanticOutcome: ToolExecutionOutcome["outcome"] = "blocked",
+      ): ToolImplementationOutcome => {
+        const outcome = createTextToolOutcome(reason, semanticOutcome);
         const uiEvent: ToolActivity = {
           type: "tool_call_blocked",
           toolCallId: toolCall.id,
@@ -67,24 +70,29 @@ export function createListAgentsToolDefinition(supervisor: AgentSupervisor): Age
       return executeTool(
         context,
         (): ToolImplementationOutcome => {
-          const states = supervisor.listSnapshots();
-          const capacity = supervisor.getCapacity();
-          const resultText = formatListAgentsResult(states, capacity);
-          const outcome = createTextToolOutcome(resultText, "succeeded");
-          const presentation = buildSubagentPresentation({
-            toolName: TOOL_NAME_LIST_AGENTS,
-            subject: "subagents",
-            output: resultText,
-            detailTruncation: false,
-          });
-          const uiEvent: ToolActivity = {
-            type: "tool_call_finished",
-            toolCallId: toolCall.id,
-            toolName: TOOL_NAME_LIST_AGENTS,
-            presentation,
-            status: "success",
-          };
-          return { content: outcome.content, outcome: outcome.outcome, uiEvent };
+          try {
+            const states = supervisor.listSnapshots();
+            const capacity = supervisor.getCapacity();
+            const resultText = formatListAgentsResult(states, capacity);
+            const outcome = createTextToolOutcome(resultText, "succeeded");
+            const presentation = buildSubagentPresentation({
+              toolName: TOOL_NAME_LIST_AGENTS,
+              subject: "subagents",
+              output: resultText,
+              detailTruncation: false,
+            });
+            const uiEvent: ToolActivity = {
+              type: "tool_call_finished",
+              toolCallId: toolCall.id,
+              toolName: TOOL_NAME_LIST_AGENTS,
+              presentation,
+              status: "success",
+            };
+            return { content: outcome.content, outcome: outcome.outcome, uiEvent };
+          } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            return blocked(`Could not list subagents: ${errorMessage}`, "failed");
+          }
         },
         {
           type: "tool_call_started",

--- a/src/core/tools/nook.ts
+++ b/src/core/tools/nook.ts
@@ -53,7 +53,7 @@ export const NOOK_TOOL: Tool = {
 
 const nookArgsSchema = z
   .object({
-    code: z.string().trim().min(1),
+    code: z.string().trim().min(1, "must not be empty."),
   })
   .strict();
 

--- a/src/core/tools/send_input_to_agent.ts
+++ b/src/core/tools/send_input_to_agent.ts
@@ -46,14 +46,16 @@ export const SEND_INPUT_TO_AGENT_TOOL: Tool = {
   ),
 };
 
-const sendInputArgsSchema = z.object({
-  id: z
-    .string()
-    .trim()
-    .min(1)
-    .refine((id) => !/[\r\n]/.test(id), "Subagent ID must be a single line."),
-  prompt: z.string().trim().min(1),
-});
+const sendInputArgsSchema = z
+  .object({
+    id: z
+      .string()
+      .trim()
+      .min(1, "must not be empty.")
+      .refine((id) => !/[\r\n]/.test(id), "must be a single line."),
+    prompt: z.string().trim().min(1, "must not be empty."),
+  })
+  .strict();
 
 function resolveSnapshotTarget(snapshot: SubagentStateSnapshot) {
   return { name: snapshot.name, title: snapshot.title };
@@ -65,7 +67,11 @@ function getSendInputSubject(raw: unknown, supervisor: AgentSupervisor): string 
     return "(invalid arguments)";
   }
   const { id } = parsedArgs.data;
-  return supervisor.getSnapshot(id)?.title ?? id;
+  try {
+    return supervisor.getSnapshot(id)?.title ?? id;
+  } catch {
+    return id;
+  }
 }
 
 export function createSendInputToAgentToolDefinition(supervisor: AgentSupervisor): AgentTool {
@@ -89,8 +95,12 @@ export function createSendInputToAgentToolDefinition(supervisor: AgentSupervisor
       let prompt = "";
       const subject = getSendInputSubject(toolCall.arguments, supervisor);
 
-      const blocked = (reason: string, details?: { title?: string }) => {
-        const outcome = createTextToolOutcome(reason, "blocked");
+      const blocked = (
+        reason: string,
+        details?: { title?: string },
+        semanticOutcome: ToolExecutionOutcome["outcome"] = "blocked",
+      ) => {
+        const outcome = createTextToolOutcome(reason, semanticOutcome);
         const uiEvent: ToolActivity = {
           type: "tool_call_blocked",
           toolCallId: toolCall.id,
@@ -116,9 +126,17 @@ export function createSendInputToAgentToolDefinition(supervisor: AgentSupervisor
 
       ({ id, prompt } = parsedArgs.data);
 
-      const snapshot = supervisor.getSnapshot(id);
+      let snapshot: SubagentStateSnapshot | undefined;
+      try {
+        snapshot = supervisor.getSnapshot(id);
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        return executeTool(context, () =>
+          blocked(`Could not inspect subagent: ${errorMessage}`, { title: id }, "failed"),
+        );
+      }
       if (!snapshot) {
-        return executeTool(context, () => blocked(`Unknown subagent ID: ${id}`, { title: id }));
+        return executeTool(context, () => blocked(`Unknown subagent ID '${id}'.`, { title: id }));
       }
 
       const target = resolveSnapshotTarget(snapshot);
@@ -127,7 +145,7 @@ export function createSendInputToAgentToolDefinition(supervisor: AgentSupervisor
         context,
         async (): Promise<ToolImplementationOutcome> => {
           if (signal?.aborted) {
-            const reason = "Aborted.";
+            const reason = "Sending input to the subagent was cancelled.";
             const outcome = createTextToolOutcome(reason, "cancelled");
             const presentation = buildToolRunPresentation({
               toolName: TOOL_NAME_SEND_INPUT_TO_AGENT,
@@ -143,7 +161,17 @@ export function createSendInputToAgentToolDefinition(supervisor: AgentSupervisor
             return { content: outcome.content, outcome: outcome.outcome, uiEvent };
           }
 
-          const sendResult = supervisor.sendInput({ id, prompt });
+          let sendResult: ReturnType<AgentSupervisor["sendInput"]>;
+          try {
+            sendResult = supervisor.sendInput({ id, prompt });
+          } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            return blocked(
+              `Could not send input to subagent: ${errorMessage}`,
+              { title: target.title },
+              "failed",
+            );
+          }
 
           if (!sendResult.ok) {
             const outcome = createTextToolOutcome(sendResult.reason, "blocked");

--- a/src/core/tools/spawn_agent.ts
+++ b/src/core/tools/spawn_agent.ts
@@ -86,19 +86,19 @@ export const SPAWN_AGENT_TOOL: Tool = {
 
 const spawnArgsSchema = z
   .object({
-    name: z.string().trim().min(1),
+    name: z.string().trim().min(1, "must not be empty."),
     title: z
       .string()
       .trim()
-      .min(1)
-      .refine((title) => !/[\r\n]/.test(title), "Title must be a single line."),
-    prompt: z.string().trim().min(1),
-    model: z.string().trim().min(1).optional(),
+      .min(1, "must not be empty.")
+      .refine((title) => !/[\r\n]/.test(title), "must be a single line."),
+    prompt: z.string().trim().min(1, "must not be empty."),
+    model: z.string().trim().min(1, "must not be empty.").optional(),
     workingDirectory: z
       .string()
       .trim()
-      .min(1)
-      .refine((path) => !/[\r\n]/.test(path), "Working directory must be a single line.")
+      .min(1, "must not be empty.")
+      .refine((path) => !/[\r\n]/.test(path), "must be a single line.")
       .optional(),
   })
   .strict();
@@ -164,8 +164,12 @@ export function createSpawnAgentToolDefinition(options: {
         getSpawnAgentWorkingDirectory(toolCall.arguments, options.cwd),
       );
 
-      const blocked = (reason: string, details?: { title?: string }) => {
-        const outcome = createTextToolOutcome(reason, "blocked");
+      const blocked = (
+        reason: string,
+        details?: { title?: string },
+        semanticOutcome: ToolExecutionOutcome["outcome"] = "blocked",
+      ) => {
+        const outcome = createTextToolOutcome(reason, semanticOutcome);
         const uiEvent: ToolActivity = {
           type: "tool_call_blocked",
           toolCallId: toolCall.id,
@@ -255,12 +259,12 @@ export function createSpawnAgentToolDefinition(options: {
         try {
           effectiveSubagentPrompts = await options.resolveSubagentPrompts({ cwd, persona });
         } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : String(error);
           return executeTool(context, () =>
             blocked(
-              `Failed to build the subagent prompt for workingDirectory '${cwd}': ${(error as Error).message}`,
-              {
-                title,
-              },
+              `Could not build the subagent prompt for workingDirectory '${cwd}': ${errorMessage}`,
+              { title },
+              "failed",
             ),
           );
         }
@@ -296,7 +300,7 @@ export function createSpawnAgentToolDefinition(options: {
         context,
         async (): Promise<ToolImplementationOutcome> => {
           if (signal?.aborted) {
-            const reason = "Aborted.";
+            const reason = "Subagent creation was cancelled.";
             const outcome = createTextToolOutcome(reason, "cancelled");
             const presentation = buildToolRunPresentation({
               toolName: TOOL_NAME_SPAWN_AGENT,
@@ -313,16 +317,22 @@ export function createSpawnAgentToolDefinition(options: {
             return { content: outcome.content, outcome: outcome.outcome, uiEvent };
           }
 
-          const spawnResult = supervisor.spawn({
-            runtimeConfig,
-            prompt,
-            title,
-            originHistoryEntryId: context.assistantMessageId,
-            config: options.config,
-            backend,
-            history: options.history,
-            personaId: persona.id,
-          });
+          let spawnResult: ReturnType<AgentSupervisor["spawn"]>;
+          try {
+            spawnResult = supervisor.spawn({
+              runtimeConfig,
+              prompt,
+              title,
+              originHistoryEntryId: context.assistantMessageId,
+              config: options.config,
+              backend,
+              history: options.history,
+              personaId: persona.id,
+            });
+          } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            return blocked(`Could not create subagent: ${errorMessage}`, { title }, "failed");
+          }
 
           if (!spawnResult.ok) {
             const outcome = createTextToolOutcome(spawnResult.reason, "blocked");

--- a/src/core/tools/tau_docs.ts
+++ b/src/core/tools/tau_docs.ts
@@ -140,7 +140,7 @@ export function createTauDocsToolDefinition(): AgentTool {
           return { content: outcome.content, outcome: outcome.outcome, uiEvent };
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
-          return blocked(`Failed to read Tau documentation: ${message}`, "failed");
+          return blocked(`Could not read Tau documentation: ${message}`, "failed");
         }
       });
     },

--- a/src/core/tools/view_image.ts
+++ b/src/core/tools/view_image.ts
@@ -46,13 +46,7 @@ export const VIEW_IMAGE_TOOL: Tool = {
   ),
 };
 
-const viewImageArgsSchema = z.object({
-  path: z
-    .string()
-    .trim()
-    .min(1)
-    .refine((path) => !/[\r\n]/.test(path), "Path must be a single line."),
-});
+const viewImageArgsSchema = z.object({ path: z.string() }).strict();
 
 function parseViewImageArgs(
   raw: unknown,
@@ -61,7 +55,14 @@ function parseViewImageArgs(
   if (!parsed.success) {
     return { ok: false, error: formatZodError(parsed.error) };
   }
-  return { ok: true, data: parsed.data };
+  const path = parsed.data.path.trim();
+  if (!path) {
+    return { ok: false, error: "path must not be empty." };
+  }
+  if (/[\r\n]/.test(path)) {
+    return { ok: false, error: "path must be a single line." };
+  }
+  return { ok: true, data: { path } };
 }
 
 function getViewImageSubject(raw: unknown): string {
@@ -293,7 +294,7 @@ export function createViewImageToolDefinition(backend: ToolExecutionBackend): Ag
 
           const encodedImage = await prepareImageForModel(content, mimeType, sharp);
           const data = encodedImage.content.toString("base64");
-          const resultText = `Viewed ${resolvedPath} (${encodedImage.mimeType})`;
+          const resultText = `Successfully viewed ${resolvedPath}.`;
           const outcome: ToolExecutionOutcome = {
             content: [
               { type: "text", text: resultText },
@@ -316,7 +317,10 @@ export function createViewImageToolDefinition(backend: ToolExecutionBackend): Ag
           return { content: outcome.content, outcome: outcome.outcome, uiEvent };
         } catch (e) {
           const errorMessage = e instanceof Error ? e.message : String(e);
-          return blocked(`Tool view_image failed: ${errorMessage}`, "failed");
+          if ((e as NodeJS.ErrnoException).code === "ENOENT") {
+            return blocked(`File not found at '${path}'. Verify the path is correct.`);
+          }
+          return blocked(`Could not view image: ${errorMessage}`, "failed");
         }
       });
     },

--- a/src/core/tools/view_image.ts
+++ b/src/core/tools/view_image.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { formatBytes } from "../utils/truncate.js";
 import { formatZodError } from "../utils/zod.js";
 import type { ToolActivity } from "./activity.js";
-import type { ToolExecutionBackend } from "./execution_backend.js";
+import { isToolExecutionBackendError, type ToolExecutionBackend } from "./execution_backend.js";
 import { buildToolRunPresentation } from "./presentation.js";
 import {
   type AgentTool,
@@ -317,7 +317,7 @@ export function createViewImageToolDefinition(backend: ToolExecutionBackend): Ag
           return { content: outcome.content, outcome: outcome.outcome, uiEvent };
         } catch (e) {
           const errorMessage = e instanceof Error ? e.message : String(e);
-          if ((e as NodeJS.ErrnoException).code === "ENOENT") {
+          if (isToolExecutionBackendError(e, "not-found")) {
             return blocked(`File not found at '${path}'. Verify the path is correct.`);
           }
           return blocked(`Could not view image: ${errorMessage}`, "failed");

--- a/src/core/tools/wait_for_agents.ts
+++ b/src/core/tools/wait_for_agents.ts
@@ -44,17 +44,19 @@ export const WAIT_FOR_AGENTS_TOOL: Tool = {
   ),
 };
 
-const waitArgsSchema = z.object({
-  ids: z
-    .array(
-      z
-        .string()
-        .trim()
-        .min(1)
-        .refine((id) => !/[\r\n]/.test(id), "Subagent ID must be a single line."),
-    )
-    .min(1),
-});
+const waitArgsSchema = z
+  .object({
+    ids: z
+      .array(
+        z
+          .string()
+          .trim()
+          .min(1, "must not be empty.")
+          .refine((id) => !/[\r\n]/.test(id), "must be a single line."),
+      )
+      .min(1, "must contain at least one subagent ID."),
+  })
+  .strict();
 
 function getWaitDurationMs(states: SubagentStateSnapshot[]): number | undefined {
   const durations = states.flatMap((state) =>
@@ -181,8 +183,10 @@ export function createWaitForAgentsToolDefinition(supervisor: AgentSupervisor): 
             const outcome = createTextToolOutcome(resultText, "succeeded");
             return { content: outcome.content, outcome: outcome.outcome, uiEvent };
           } catch (error) {
-            const message = error instanceof Error ? error.message : String(error);
-            const reason = message.trim() || "The wait_for_agents request failed.";
+            const errorMessage = (error instanceof Error ? error.message : String(error)).trim();
+            const reason = signal.aborted
+              ? "Waiting for subagents was cancelled."
+              : `Could not wait for subagents: ${errorMessage || "unknown error"}`;
             const presentation = signal.aborted
               ? buildToolRunPresentation({
                   toolName: TOOL_NAME_WAIT_FOR_AGENTS,

--- a/src/core/tools/web.ts
+++ b/src/core/tools/web.ts
@@ -47,7 +47,7 @@ export const WEB_TOOL: Tool = {
 
 const webArgsSchema = z
   .object({
-    code: z.string().trim().min(1),
+    code: z.string().trim().min(1, "must not be empty."),
   })
   .strict();
 

--- a/src/core/tools/write.ts
+++ b/src/core/tools/write.ts
@@ -2,7 +2,6 @@ import type { Tool, ToolCall } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import { z } from "zod";
 import { formatTokenEstimate } from "../utils/token.js";
-import { formatBytes } from "../utils/truncate.js";
 import { formatZodError } from "../utils/zod.js";
 import type { ToolActivity } from "./activity.js";
 import type { ToolExecutionBackend } from "./execution_backend.js";
@@ -44,14 +43,12 @@ export const WRITE_TOOL: Tool = {
   ),
 };
 
-const writeArgsSchema = z.object({
-  path: z
-    .string()
-    .trim()
-    .min(1)
-    .refine((path) => !/[\r\n]/.test(path), "Path must be a single line."),
-  content: z.string(),
-});
+const writeArgsSchema = z
+  .object({
+    path: z.string(),
+    content: z.string(),
+  })
+  .strict();
 
 function parseWriteArgs(
   raw: unknown,
@@ -60,7 +57,14 @@ function parseWriteArgs(
   if (!parsed.success) {
     return { ok: false, error: formatZodError(parsed.error) };
   }
-  return { ok: true, data: parsed.data };
+  const path = parsed.data.path.trim();
+  if (!path) {
+    return { ok: false, error: "path must not be empty." };
+  }
+  if (/[\r\n]/.test(path)) {
+    return { ok: false, error: "path must be a single line." };
+  }
+  return { ok: true, data: { ...parsed.data, path } };
 }
 
 function getWriteSubject(raw: unknown): string {
@@ -136,7 +140,7 @@ export function createWriteToolDefinition(backend: ToolExecutionBackend): AgentT
 
         try {
           const { bytes, lines } = await backend.writeFile(path, content);
-          const resultText = `Successfully wrote ${formatBytes(bytes)} (${lines} lines) to ${path}`;
+          const resultText = `Successfully wrote ${path}.`;
 
           const outcome = createTextToolOutcome(resultText, "succeeded");
           const uiEvent: ToolActivity = {
@@ -153,7 +157,7 @@ export function createWriteToolDefinition(backend: ToolExecutionBackend): AgentT
           return { content: outcome.content, outcome: outcome.outcome, uiEvent };
         } catch (e) {
           const errorMessage = e instanceof Error ? e.message : String(e);
-          return blocked(`Write failed: ${errorMessage}`, "failed");
+          return blocked(`Could not write file: ${errorMessage}`, "failed");
         }
       });
     },

--- a/src/execution/cloudflare_sandbox_execution_environment.ts
+++ b/src/execution/cloudflare_sandbox_execution_environment.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_COMMAND_CAPTURE_BYTES,
   type ListDirEntry,
   type ToolExecutionBackend,
+  ToolExecutionBackendError,
 } from "../core/tools/execution_backend.js";
 import type {
   SessionProtocolCloudflareSandboxExecutionEnvironmentInput,
@@ -292,13 +293,10 @@ export function createCloudflareSandboxToolExecutionBackend(options: {
         scheduleCommandSessionReset(cwd);
       }
       if (timeoutSignal?.aborted) {
-        return terminatedExecutionResult(
-          `(tau) timed out after ${runOptions.timeoutMs}ms`,
-          "timeout",
-        );
+        return terminatedExecutionResult("timeout");
       }
       if (runOptions.signal?.aborted || disposeAbortController.signal.aborted) {
-        return terminatedExecutionResult("(tau) aborted", "abort");
+        return terminatedExecutionResult("abort");
       }
       throw error;
     } finally {
@@ -587,19 +585,20 @@ export class CloudflareSandboxBridgeClient {
     } catch {
       detail = await response.text().catch(() => "");
     }
-    return new Error(
-      `Cloudflare Sandbox bridge '${this.bridgeId}' request failed (${response.status})${
-        detail ? `: ${detail}` : ""
-      }`,
-    );
+    const message = `Cloudflare Sandbox bridge '${this.bridgeId}' request failed (${response.status})${
+      detail ? `: ${detail}` : ""
+    }`;
+    return response.status === 404
+      ? new ToolExecutionBackendError("not-found", message)
+      : new Error(message);
   }
 }
 
-function terminatedExecutionResult(note: string, reason: "timeout" | "abort"): BashExecutionResult {
+function terminatedExecutionResult(reason: "timeout" | "abort"): BashExecutionResult {
   return {
-    output: `${note}\n`,
+    output: "",
     stdout: "",
-    stderr: `${note}\n`,
+    stderr: "",
     exitCode: null,
     truncated: false,
     timedOut: reason === "timeout",

--- a/src/execution/fly_sprite_execution_environment.ts
+++ b/src/execution/fly_sprite_execution_environment.ts
@@ -163,15 +163,11 @@ export function createFlySpriteToolExecutionBackend(options: {
     runNodeScript,
 
     async readFile(path) {
-      try {
-        const result = await worker.request("readFile", {
-          path,
-          timeoutMs: HELPER_COMMAND_TIMEOUT_MS,
-        });
-        return { path, content: result.content };
-      } catch (error) {
-        throw normalizeToolExecutionBackendError(error);
-      }
+      const result = await worker.request("readFile", {
+        path,
+        timeoutMs: HELPER_COMMAND_TIMEOUT_MS,
+      });
+      return { path, content: result.content };
     },
 
     async readFileBinary(path, readOptions = {}) {

--- a/src/execution/fly_sprite_execution_environment.ts
+++ b/src/execution/fly_sprite_execution_environment.ts
@@ -6,6 +6,7 @@ import {
   type BashExecutionResult,
   DEFAULT_COMMAND_CAPTURE_BYTES,
   type ListDirEntry,
+  normalizeToolExecutionBackendError,
   type ToolExecutionBackend,
 } from "../core/tools/execution_backend.js";
 import type {
@@ -162,23 +163,31 @@ export function createFlySpriteToolExecutionBackend(options: {
     runNodeScript,
 
     async readFile(path) {
-      const result = await worker.request("readFile", {
-        path,
-        timeoutMs: HELPER_COMMAND_TIMEOUT_MS,
-      });
-      return { path, content: result.content };
+      try {
+        const result = await worker.request("readFile", {
+          path,
+          timeoutMs: HELPER_COMMAND_TIMEOUT_MS,
+        });
+        return { path, content: result.content };
+      } catch (error) {
+        throw normalizeToolExecutionBackendError(error);
+      }
     },
 
     async readFileBinary(path, readOptions = {}) {
-      const result = await worker.request("readFileBinary", {
-        path,
-        timeoutMs: HELPER_COMMAND_TIMEOUT_MS,
-        maxBytes: readOptions.maxBytes,
-      });
-      const content = Buffer.from(result.contentBase64, "base64");
-      const bytes = result.bytes;
-      assertFileWithinMaxBytes(bytes, readOptions.maxBytes);
-      return { path, content, bytes };
+      try {
+        const result = await worker.request("readFileBinary", {
+          path,
+          timeoutMs: HELPER_COMMAND_TIMEOUT_MS,
+          maxBytes: readOptions.maxBytes,
+        });
+        const content = Buffer.from(result.contentBase64, "base64");
+        const bytes = result.bytes;
+        assertFileWithinMaxBytes(bytes, readOptions.maxBytes);
+        return { path, content, bytes };
+      } catch (error) {
+        throw normalizeToolExecutionBackendError(error);
+      }
     },
 
     async writeFile(path, content) {
@@ -284,7 +293,10 @@ type FlySpriteWorkerResponse =
   | {
       id: number;
       ok: false;
-      error: string;
+      error: {
+        message: string;
+        code?: string;
+      };
     };
 
 type FlySpritePendingRequest = {
@@ -492,7 +504,11 @@ class FlySpriteWorker {
       return;
     }
 
-    pending.reject(new Error(message.error));
+    const error = new Error(message.error.message);
+    if (message.error.code) {
+      Object.assign(error, { code: message.error.code });
+    }
+    pending.reject(error);
   }
 
   private sendCancel(targetId: number): void {
@@ -685,9 +701,9 @@ async function handleLine(line) {
       return;
     }
 
-    fail(request.id, "unknown worker method");
+    fail(request.id, new Error("unknown worker method"));
   } catch (err) {
-    fail(request.id, err instanceof Error ? err.message : String(err));
+    fail(request.id, err);
   }
 }
 
@@ -766,18 +782,9 @@ function runCommand(id, command, args, options) {
       settled = true;
       cleanup();
       markStopped();
-      let output = Buffer.concat(chunks).toString("utf-8");
-      let stdout = Buffer.concat(stdoutChunks).toString("utf-8");
-      let stderr = Buffer.concat(stderrChunks).toString("utf-8");
-      const note = timedOut
-        ? "\\n(tau) timed out after " + options.timeoutMs + "ms\\n"
-        : aborted
-          ? "\\n(tau) aborted\\n"
-          : "";
-      if (note && !output.includes(note.trim())) {
-        output += note;
-        stderr += note;
-      }
+      const output = Buffer.concat(chunks).toString("utf-8");
+      const stdout = Buffer.concat(stdoutChunks).toString("utf-8");
+      const stderr = Buffer.concat(stderrChunks).toString("utf-8");
       resolve({
         output,
         stdout,
@@ -828,6 +835,10 @@ function respond(id, result) {
 }
 
 function fail(id, error) {
-  console.log(JSON.stringify({ id, ok: false, error }));
+  const message = error instanceof Error ? error.message : String(error);
+  const code = error && typeof error === "object" && typeof error.code === "string"
+    ? error.code
+    : undefined;
+  console.log(JSON.stringify({ id, ok: false, error: { message, ...(code ? { code } : {}) } }));
 }
 `;

--- a/test/bash_output.test.js
+++ b/test/bash_output.test.js
@@ -108,9 +108,9 @@ describe("bash output policy", () => {
       ...backend,
       async runBash() {
         return {
-          output: "partial output\n(tau) aborted\n",
+          output: "partial output\n",
           stdout: "partial output\n",
-          stderr: "(tau) aborted\n",
+          stderr: "",
           exitCode: null,
           truncated: false,
           timedOut: false,
@@ -132,6 +132,7 @@ describe("bash output policy", () => {
     ]);
     expect(result.uiEvent.presentation.details).toEqual([
       { text: "partial output", wrap: "character" },
+      { text: "[Command was cancelled.]", wrap: "word" },
     ]);
     expect(result.uiEvent.presentation.metadata).not.toContain("exit ?");
   });
@@ -141,9 +142,9 @@ describe("bash output policy", () => {
       ...backend,
       async runBash() {
         return {
-          output: "partial output\n(tau) timed out after 1500ms\n",
+          output: "partial output\n",
           stdout: "partial output\n",
-          stderr: "(tau) timed out after 1500ms\n",
+          stderr: "",
           exitCode: null,
           truncated: false,
           timedOut: true,
@@ -165,6 +166,7 @@ describe("bash output policy", () => {
     ]);
     expect(result.uiEvent.presentation.details).toEqual([
       { text: "partial output", wrap: "character" },
+      { text: "[Command timed out after 1500ms.]", wrap: "word" },
     ]);
     expect(result.uiEvent.presentation.metadata).not.toContain("exit ?");
   });
@@ -174,9 +176,9 @@ describe("bash output policy", () => {
       ...backend,
       async runBash() {
         return {
-          output: "partial output\n(tau) terminated by signal SIGKILL\n",
+          output: "partial output\n",
           stdout: "partial output\n",
-          stderr: "(tau) terminated by signal SIGKILL\n",
+          stderr: "",
           exitCode: null,
           truncated: false,
           timedOut: false,
@@ -198,6 +200,7 @@ describe("bash output policy", () => {
     ]);
     expect(result.uiEvent.presentation.details).toEqual([
       { text: "partial output", wrap: "character" },
+      { text: "[Command was terminated by signal SIGKILL.]", wrap: "word" },
     ]);
     expect(result.uiEvent.presentation.metadata).not.toContain("exit ?");
   });

--- a/test/bash_output.test.js
+++ b/test/bash_output.test.js
@@ -53,6 +53,23 @@ async function runTool(tool, toolCall, signal = new AbortController().signal) {
   };
 }
 
+function bashOutput(content) {
+  const bytes = Buffer.byteLength(content);
+  const lines = content ? content.split("\n").length - Number(content.endsWith("\n")) : 0;
+  return {
+    output: content,
+    model: {
+      content,
+      truncated: false,
+      totalLines: lines,
+      outputLines: lines,
+      totalBytes: bytes,
+      outputBytes: bytes,
+    },
+    captureTruncated: false,
+  };
+}
+
 describe("bash output policy", () => {
   it("rejects unknown execution arguments", async () => {
     const tool = createBashToolDefinition(backend, "/project");
@@ -81,129 +98,61 @@ describe("bash output policy", () => {
     expect(invalidPath.toolResult.content).toEqual([
       { type: "text", text: "Invalid arguments: workingDirectory must be a single line." },
     ]);
-
-    const emptyCommand = await runTool(tool, {
-      id: "bash-empty-command",
-      name: "bash",
-      arguments: { command: "  " },
-    });
-    expect(emptyCommand.toolResult.outcome).toBe("blocked");
-    expect(emptyCommand.toolResult.content).toEqual([
-      { type: "text", text: "Invalid arguments: command must not be empty." },
-    ]);
-
-    const invalidTimeout = await runTool(tool, {
-      id: "bash-invalid-timeout",
-      name: "bash",
-      arguments: { command: "pwd", timeout: 0 },
-    });
-    expect(invalidTimeout.toolResult.outcome).toBe("blocked");
-    expect(invalidTimeout.toolResult.content).toEqual([
-      { type: "text", text: "Invalid arguments: timeout must be greater than 0." },
-    ]);
   });
 
-  it("reports cancellation semantically without exposing the backend abort marker", async () => {
-    const cancelledBackend = {
-      ...backend,
-      async runBash() {
-        return {
-          output: "partial output\n",
-          stdout: "partial output\n",
-          stderr: "",
-          exitCode: null,
-          truncated: false,
-          timedOut: false,
-          aborted: true,
-          closeSignal: null,
-        };
-      },
-    };
-    const tool = createBashToolDefinition(cancelledBackend, "/project");
-    const result = await runTool(tool, {
-      id: "bash-cancelled",
-      name: "bash",
-      arguments: { command: "sleep 3" },
-    });
+  it.each([
+    ["cancellation", { aborted: true }, {}, "cancelled", "Command was cancelled."],
+    [
+      "timeout",
+      { timedOut: true, closeSignal: "SIGTERM" },
+      { timeout: 1500 },
+      "cancelled",
+      "Command timed out after 1500ms.",
+    ],
+    [
+      "signal termination",
+      { closeSignal: "SIGKILL" },
+      {},
+      "failed",
+      "Command was terminated by signal SIGKILL.",
+    ],
+  ])(
+    "reports %s from structured termination state",
+    async (_name, execution, args, outcome, notice) => {
+      const tool = createBashToolDefinition(
+        {
+          ...backend,
+          async runBash() {
+            return {
+              output: "partial output\n",
+              stdout: "partial output\n",
+              stderr: "",
+              exitCode: null,
+              truncated: false,
+              timedOut: false,
+              aborted: false,
+              closeSignal: null,
+              ...execution,
+            };
+          },
+        },
+        "/project",
+      );
+      const result = await runTool(tool, {
+        id: "bash-terminated",
+        name: "bash",
+        arguments: { command: "worker", ...args },
+      });
 
-    expect(result.toolResult.outcome).toBe("cancelled");
-    expect(result.toolResult.content).toEqual([
-      { type: "text", text: "partial output\n\n[Command was cancelled.]" },
-    ]);
-    expect(result.uiEvent.presentation.details).toEqual([
-      { text: "partial output", wrap: "character" },
-      { text: "[Command was cancelled.]", wrap: "word" },
-    ]);
-    expect(result.uiEvent.presentation.metadata).not.toContain("exit ?");
-  });
-
-  it("reports timeouts without exposing the backend termination marker", async () => {
-    const timedOutBackend = {
-      ...backend,
-      async runBash() {
-        return {
-          output: "partial output\n",
-          stdout: "partial output\n",
-          stderr: "",
-          exitCode: null,
-          truncated: false,
-          timedOut: true,
-          aborted: false,
-          closeSignal: "SIGTERM",
-        };
-      },
-    };
-    const tool = createBashToolDefinition(timedOutBackend, "/project");
-    const result = await runTool(tool, {
-      id: "bash-timed-out",
-      name: "bash",
-      arguments: { command: "sleep 3", timeout: 1500 },
-    });
-
-    expect(result.toolResult.outcome).toBe("cancelled");
-    expect(result.toolResult.content).toEqual([
-      { type: "text", text: "partial output\n\n[Command timed out after 1500ms.]" },
-    ]);
-    expect(result.uiEvent.presentation.details).toEqual([
-      { text: "partial output", wrap: "character" },
-      { text: "[Command timed out after 1500ms.]", wrap: "word" },
-    ]);
-    expect(result.uiEvent.presentation.metadata).not.toContain("exit ?");
-  });
-
-  it("reports signal termination without exposing the backend termination marker", async () => {
-    const terminatedBackend = {
-      ...backend,
-      async runBash() {
-        return {
-          output: "partial output\n",
-          stdout: "partial output\n",
-          stderr: "",
-          exitCode: null,
-          truncated: false,
-          timedOut: false,
-          aborted: false,
-          closeSignal: "SIGKILL",
-        };
-      },
-    };
-    const tool = createBashToolDefinition(terminatedBackend, "/project");
-    const result = await runTool(tool, {
-      id: "bash-terminated",
-      name: "bash",
-      arguments: { command: "worker" },
-    });
-
-    expect(result.toolResult.outcome).toBe("failed");
-    expect(result.toolResult.content).toEqual([
-      { type: "text", text: "partial output\n\n[Command was terminated by signal SIGKILL.]" },
-    ]);
-    expect(result.uiEvent.presentation.details).toEqual([
-      { text: "partial output", wrap: "character" },
-      { text: "[Command was terminated by signal SIGKILL.]", wrap: "word" },
-    ]);
-    expect(result.uiEvent.presentation.metadata).not.toContain("exit ?");
-  });
+      expect(result.toolResult.outcome).toBe(outcome);
+      expect(result.toolResult.content[0].text).toBe(`partial output\n\n[${notice}]`);
+      expect(result.uiEvent.presentation.details).toEqual([
+        { text: "partial output", wrap: "character" },
+        { text: `[${notice}]`, wrap: "word" },
+      ]);
+      expect(result.uiEvent.presentation.metadata).not.toContain("exit ?");
+    },
+  );
 
   it("returns a focused failure when the command cannot be executed", async () => {
     const failedBackend = {
@@ -219,12 +168,10 @@ describe("bash output policy", () => {
       arguments: { command: "pwd" },
     });
 
-    expect(result.toolResult.outcome).toBe("failed");
-    expect(result.toolResult.content).toEqual([
-      { type: "text", text: "Could not execute command: spawn bash ENOENT" },
+    expect([result.toolResult.outcome, result.toolResult.content[0].text]).toEqual([
+      "failed",
+      "Could not execute command: spawn bash ENOENT",
     ]);
-    expect(result.uiEvent.type).toBe("bash_blocked");
-    expect(result.uiEvent.reason).toBe("Could not execute command: spawn bash ENOENT");
   });
 
   it("shows the effective working directory throughout the tool lifecycle", async () => {
@@ -299,81 +246,21 @@ describe("bash output policy", () => {
     expect(truncationInfo.model.truncated).toBe(false);
   });
 
-  it("returns a default message for empty successful output", () => {
-    const toolText = formatBashToolResultText({
-      truncationInfo: {
-        output: "",
-        model: {
-          content: "",
-          truncated: false,
-          totalLines: 0,
-          outputLines: 0,
-          totalBytes: 0,
-          outputBytes: 0,
-        },
-        captureTruncated: false,
-      },
-      exitCode: 0,
-    });
-
-    expect(toolText).toBe("Command produced no output (exit 0)");
-  });
-
-  it("returns the exit status when a failed command produces no output", () => {
-    const toolText = formatBashToolResultText({
-      truncationInfo: {
-        output: "",
-        model: {
-          content: "",
-          truncated: false,
-          totalLines: 0,
-          outputLines: 0,
-          totalBytes: 0,
-          outputBytes: 0,
-        },
-        captureTruncated: false,
-      },
-      exitCode: 2,
-    });
-
-    expect(toolText).toBe("Command failed with exit code 2 and produced no output.");
-  });
-
-  it("adds a clear failure sentence after command output", () => {
-    const toolText = formatBashToolResultText({
-      truncationInfo: {
-        output: "permission denied\n",
-        model: {
-          content: "permission denied\n",
-          truncated: false,
-          totalLines: 1,
-          outputLines: 1,
-          totalBytes: 18,
-          outputBytes: 18,
-        },
-        captureTruncated: false,
-      },
-      exitCode: 126,
-    });
-
-    expect(toolText).toBe("permission denied\n\n[Command failed with exit code 126.]");
+  it.each([
+    ["", 0, "Command produced no output (exit 0)"],
+    ["", 2, "Command failed with exit code 2 and produced no output."],
+    ["permission denied\n", 126, "permission denied\n\n[Command failed with exit code 126.]"],
+  ])("formats command exit results", (output, exitCode, expected) => {
+    expect(formatBashToolResultText({ truncationInfo: bashOutput(output), exitCode })).toBe(
+      expected,
+    );
   });
 
   it("marks terminal output for character wrapping", () => {
     const presentation = buildBashPresentation({
       toolName: "bash",
       subject: "echo test",
-      truncationInfo: {
-        output: "alpha beta",
-        model: {
-          truncated: false,
-          totalLines: 1,
-          outputLines: 1,
-          totalBytes: 10,
-          outputBytes: 10,
-        },
-        captureTruncated: false,
-      },
+      truncationInfo: bashOutput("alpha beta"),
       exitCode: 0,
       durationMs: 0,
     });
@@ -385,17 +272,7 @@ describe("bash output policy", () => {
     const presentation = buildBashPresentation({
       toolName: "bash",
       subject: "echo test",
-      truncationInfo: {
-        output: "",
-        model: {
-          truncated: false,
-          totalLines: 0,
-          outputLines: 0,
-          totalBytes: 0,
-          outputBytes: 0,
-        },
-        captureTruncated: false,
-      },
+      truncationInfo: bashOutput(""),
       exitCode: 0,
       durationMs: 12,
     });
@@ -407,17 +284,7 @@ describe("bash output policy", () => {
     const presentation = buildBashPresentation({
       toolName: "bash",
       subject: "echo test",
-      truncationInfo: {
-        output: "",
-        model: {
-          truncated: false,
-          totalLines: 0,
-          outputLines: 0,
-          totalBytes: 0,
-          outputBytes: 0,
-        },
-        captureTruncated: false,
-      },
+      truncationInfo: bashOutput(""),
       exitCode: 0,
       workingDirectory: "/tmp/tau",
       durationMs: 12,

--- a/test/bash_output.test.js
+++ b/test/bash_output.test.js
@@ -15,6 +15,9 @@ const backend = {
       stdout: "command output\n",
       exitCode: 0,
       truncated: false,
+      timedOut: false,
+      aborted: false,
+      closeSignal: null,
     };
   },
   async runNodeScript() {
@@ -65,6 +68,9 @@ describe("bash output policy", () => {
     );
 
     expect(result.toolResult.outcome).toBe("blocked");
+    expect(result.toolResult.content).toEqual([
+      { type: "text", text: 'Invalid arguments: Unrecognized key: "unexpected"' },
+    ]);
 
     const invalidPath = await runTool(tool, {
       id: "bash-invalid-cwd",
@@ -72,7 +78,29 @@ describe("bash output policy", () => {
       arguments: { command: "pwd", workingDirectory: "one\ntwo" },
     });
     expect(invalidPath.toolResult.outcome).toBe("blocked");
-    expect(invalidPath.uiEvent.presentation.details[0].text).toContain("single line");
+    expect(invalidPath.toolResult.content).toEqual([
+      { type: "text", text: "Invalid arguments: workingDirectory must be a single line." },
+    ]);
+
+    const emptyCommand = await runTool(tool, {
+      id: "bash-empty-command",
+      name: "bash",
+      arguments: { command: "  " },
+    });
+    expect(emptyCommand.toolResult.outcome).toBe("blocked");
+    expect(emptyCommand.toolResult.content).toEqual([
+      { type: "text", text: "Invalid arguments: command must not be empty." },
+    ]);
+
+    const invalidTimeout = await runTool(tool, {
+      id: "bash-invalid-timeout",
+      name: "bash",
+      arguments: { command: "pwd", timeout: 0 },
+    });
+    expect(invalidTimeout.toolResult.outcome).toBe("blocked");
+    expect(invalidTimeout.toolResult.content).toEqual([
+      { type: "text", text: "Invalid arguments: timeout must be greater than 0." },
+    ]);
   });
 
   it("reports cancellation semantically without exposing the backend abort marker", async () => {
@@ -100,12 +128,100 @@ describe("bash output policy", () => {
 
     expect(result.toolResult.outcome).toBe("cancelled");
     expect(result.toolResult.content).toEqual([
-      { type: "text", text: "partial output\n\nCommand was cancelled." },
+      { type: "text", text: "partial output\n\n[Command was cancelled.]" },
     ]);
     expect(result.uiEvent.presentation.details).toEqual([
       { text: "partial output", wrap: "character" },
     ]);
     expect(result.uiEvent.presentation.metadata).not.toContain("exit ?");
+  });
+
+  it("reports timeouts without exposing the backend termination marker", async () => {
+    const timedOutBackend = {
+      ...backend,
+      async runBash() {
+        return {
+          output: "partial output\n(tau) timed out after 1500ms\n",
+          stdout: "partial output\n",
+          stderr: "(tau) timed out after 1500ms\n",
+          exitCode: null,
+          truncated: false,
+          timedOut: true,
+          aborted: false,
+          closeSignal: "SIGTERM",
+        };
+      },
+    };
+    const tool = createBashToolDefinition(timedOutBackend, "/project");
+    const result = await runTool(tool, {
+      id: "bash-timed-out",
+      name: "bash",
+      arguments: { command: "sleep 3", timeout: 1500 },
+    });
+
+    expect(result.toolResult.outcome).toBe("cancelled");
+    expect(result.toolResult.content).toEqual([
+      { type: "text", text: "partial output\n\n[Command timed out after 1500ms.]" },
+    ]);
+    expect(result.uiEvent.presentation.details).toEqual([
+      { text: "partial output", wrap: "character" },
+    ]);
+    expect(result.uiEvent.presentation.metadata).not.toContain("exit ?");
+  });
+
+  it("reports signal termination without exposing the backend termination marker", async () => {
+    const terminatedBackend = {
+      ...backend,
+      async runBash() {
+        return {
+          output: "partial output\n(tau) terminated by signal SIGKILL\n",
+          stdout: "partial output\n",
+          stderr: "(tau) terminated by signal SIGKILL\n",
+          exitCode: null,
+          truncated: false,
+          timedOut: false,
+          aborted: false,
+          closeSignal: "SIGKILL",
+        };
+      },
+    };
+    const tool = createBashToolDefinition(terminatedBackend, "/project");
+    const result = await runTool(tool, {
+      id: "bash-terminated",
+      name: "bash",
+      arguments: { command: "worker" },
+    });
+
+    expect(result.toolResult.outcome).toBe("failed");
+    expect(result.toolResult.content).toEqual([
+      { type: "text", text: "partial output\n\n[Command was terminated by signal SIGKILL.]" },
+    ]);
+    expect(result.uiEvent.presentation.details).toEqual([
+      { text: "partial output", wrap: "character" },
+    ]);
+    expect(result.uiEvent.presentation.metadata).not.toContain("exit ?");
+  });
+
+  it("returns a focused failure when the command cannot be executed", async () => {
+    const failedBackend = {
+      ...backend,
+      async runBash() {
+        throw new Error("spawn bash ENOENT");
+      },
+    };
+    const tool = createBashToolDefinition(failedBackend, "/project");
+    const result = await runTool(tool, {
+      id: "bash-execution-failed",
+      name: "bash",
+      arguments: { command: "pwd" },
+    });
+
+    expect(result.toolResult.outcome).toBe("failed");
+    expect(result.toolResult.content).toEqual([
+      { type: "text", text: "Could not execute command: spawn bash ENOENT" },
+    ]);
+    expect(result.uiEvent.type).toBe("bash_blocked");
+    expect(result.uiEvent.reason).toBe("Could not execute command: spawn bash ENOENT");
   });
 
   it("shows the effective working directory throughout the tool lifecycle", async () => {
@@ -198,6 +314,46 @@ describe("bash output policy", () => {
     });
 
     expect(toolText).toBe("Command produced no output (exit 0)");
+  });
+
+  it("returns the exit status when a failed command produces no output", () => {
+    const toolText = formatBashToolResultText({
+      truncationInfo: {
+        output: "",
+        model: {
+          content: "",
+          truncated: false,
+          totalLines: 0,
+          outputLines: 0,
+          totalBytes: 0,
+          outputBytes: 0,
+        },
+        captureTruncated: false,
+      },
+      exitCode: 2,
+    });
+
+    expect(toolText).toBe("Command failed with exit code 2 and produced no output.");
+  });
+
+  it("adds a clear failure sentence after command output", () => {
+    const toolText = formatBashToolResultText({
+      truncationInfo: {
+        output: "permission denied\n",
+        model: {
+          content: "permission denied\n",
+          truncated: false,
+          totalLines: 1,
+          outputLines: 1,
+          totalBytes: 18,
+          outputBytes: 18,
+        },
+        captureTruncated: false,
+      },
+      exitCode: 126,
+    });
+
+    expect(toolText).toBe("permission denied\n\n[Command failed with exit code 126.]");
   });
 
   it("marks terminal output for character wrapping", () => {

--- a/test/chat_runtime.test.js
+++ b/test/chat_runtime.test.js
@@ -140,7 +140,7 @@ Ship &lt;all&gt; requirements
     );
   });
 
-  it("returns focused goal validation and execution failures", async () => {
+  it("returns focused goal execution failures", async () => {
     const runtime = createRuntime({
       goalManager: {
         getGoal: () => null,
@@ -159,19 +159,14 @@ Ship &lt;all&gt; requirements
       emitActivity: async () => {},
     };
 
-    const invalid = await createGoal.execute(
-      fauxToolCall("create_goal", { objective: "  " }),
-      context,
-    );
-    expect(invalid.outcome).toBe("blocked");
-    expect(invalid.content[0].text).toBe("Invalid arguments: objective: must not be empty.");
-
     const failed = await createGoal.execute(
       fauxToolCall("create_goal", { objective: "Ship it" }),
       context,
     );
-    expect(failed.outcome).toBe("failed");
-    expect(failed.content[0].text).toBe("Could not create session goal: goal store unavailable");
+    expect([failed.outcome, failed.content[0].text]).toEqual([
+      "failed",
+      "Could not create session goal: goal store unavailable",
+    ]);
   });
 
   it("supplies the authoritative active goal to compaction continuations", () => {

--- a/test/chat_runtime.test.js
+++ b/test/chat_runtime.test.js
@@ -140,6 +140,40 @@ Ship &lt;all&gt; requirements
     );
   });
 
+  it("returns focused goal validation and execution failures", async () => {
+    const runtime = createRuntime({
+      goalManager: {
+        getGoal: () => null,
+        createGoal: async () => {
+          throw new Error("goal store unavailable");
+        },
+        updateGoal: async () => null,
+      },
+    });
+    const createGoal = runtime.agent.spec.tools.get("create_goal");
+    const context = {
+      agentId: "agent-1",
+      turnId: "turn-1",
+      assistantMessageId: "assistant-1",
+      signal: new AbortController().signal,
+      emitActivity: async () => {},
+    };
+
+    const invalid = await createGoal.execute(
+      fauxToolCall("create_goal", { objective: "  " }),
+      context,
+    );
+    expect(invalid.outcome).toBe("blocked");
+    expect(invalid.content[0].text).toBe("Invalid arguments: objective: must not be empty.");
+
+    const failed = await createGoal.execute(
+      fauxToolCall("create_goal", { objective: "Ship it" }),
+      context,
+    );
+    expect(failed.outcome).toBe("failed");
+    expect(failed.content[0].text).toBe("Could not create session goal: goal store unavailable");
+  });
+
   it("supplies the authoritative active goal to compaction continuations", () => {
     const runtime = createRuntime({
       goalManager: {

--- a/test/cloudflare_sandbox_execution_environment.test.js
+++ b/test/cloudflare_sandbox_execution_environment.test.js
@@ -332,6 +332,28 @@ describe("Cloudflare Sandbox execution environment", () => {
     expect(cancelled).toBe(true);
   });
 
+  it("normalizes missing files at the backend boundary", async () => {
+    const client = new CloudflareSandboxBridgeClient({
+      bridgeId: "default",
+      baseUrl: "https://bridge.example",
+      fetch: async () => jsonResponse({ error: "file not found" }, { status: 404 }),
+    });
+    const backend = createCloudflareSandboxToolExecutionBackend({
+      client,
+      sandboxId: "sandbox-1",
+      cwd: "/workspace/repo",
+    });
+
+    await expect(backend.readFile("/workspace/repo/missing.txt")).rejects.toMatchObject({
+      name: "ToolExecutionBackendError",
+      code: "not-found",
+    });
+    await expect(backend.readFileBinary("/workspace/repo/missing.png")).rejects.toMatchObject({
+      name: "ToolExecutionBackendError",
+      code: "not-found",
+    });
+  });
+
   it("serializes bridge exec calls that share a command session", async () => {
     const encoder = new TextEncoder();
     const requests = [];
@@ -651,9 +673,11 @@ describe("Cloudflare Sandbox execution environment", () => {
     });
 
     await expect(backend.runBash("pwd", { timeoutMs: 10 })).resolves.toMatchObject({
+      output: "",
+      stdout: "",
+      stderr: "",
       timedOut: true,
       exitCode: null,
-      stderr: expect.stringContaining("timed out after 10ms"),
     });
   });
 

--- a/test/cloudflare_sandbox_execution_environment.test.js
+++ b/test/cloudflare_sandbox_execution_environment.test.js
@@ -332,7 +332,7 @@ describe("Cloudflare Sandbox execution environment", () => {
     expect(cancelled).toBe(true);
   });
 
-  it("normalizes missing files at the backend boundary", async () => {
+  it("normalizes missing binary files at the backend boundary", async () => {
     const client = new CloudflareSandboxBridgeClient({
       bridgeId: "default",
       baseUrl: "https://bridge.example",
@@ -344,12 +344,7 @@ describe("Cloudflare Sandbox execution environment", () => {
       cwd: "/workspace/repo",
     });
 
-    await expect(backend.readFile("/workspace/repo/missing.txt")).rejects.toMatchObject({
-      name: "ToolExecutionBackendError",
-      code: "not-found",
-    });
     await expect(backend.readFileBinary("/workspace/repo/missing.png")).rejects.toMatchObject({
-      name: "ToolExecutionBackendError",
       code: "not-found",
     });
   });

--- a/test/code_mode.test.js
+++ b/test/code_mode.test.js
@@ -154,7 +154,7 @@ describe("public code-mode runtime", () => {
     await handlerStarted;
     controller.abort();
 
-    await expect(run).rejects.toThrow("(tau) aborted");
+    await expect(run).rejects.toThrow("Program was cancelled.");
   });
 
   it("passes SDK descriptions through unchanged", async () => {

--- a/test/edit_tool.test.js
+++ b/test/edit_tool.test.js
@@ -107,24 +107,6 @@ describe("edit tool", () => {
     expect(getToolText(emptyOldText)).toBe("Invalid arguments: oldText must not be empty.");
   });
 
-  it("reports missing files as a correctable request", async () => {
-    const editTool = createEditToolDefinition(createLocalToolExecutionBackend());
-    const result = await runTool(editTool, {
-      id: "tool-missing-file",
-      name: TOOL_NAME_EDIT,
-      arguments: {
-        path: "/missing/file.txt",
-        oldText: "one",
-        newText: "two",
-      },
-    });
-
-    expect(result.toolResult.outcome).toBe("blocked");
-    expect(getToolText(result)).toBe(
-      "File not found at '/missing/file.txt'. Verify the path is correct.",
-    );
-  });
-
   it("renders the complete dim line diff with net metadata", async () => {
     const fx = setupFixture();
 

--- a/test/edit_tool.test.js
+++ b/test/edit_tool.test.js
@@ -107,6 +107,24 @@ describe("edit tool", () => {
     expect(getToolText(emptyOldText)).toBe("Invalid arguments: oldText must not be empty.");
   });
 
+  it("reports missing files as a correctable request", async () => {
+    const editTool = createEditToolDefinition(createLocalToolExecutionBackend());
+    const result = await runTool(editTool, {
+      id: "tool-missing-file",
+      name: TOOL_NAME_EDIT,
+      arguments: {
+        path: "/missing/file.txt",
+        oldText: "one",
+        newText: "two",
+      },
+    });
+
+    expect(result.toolResult.outcome).toBe("blocked");
+    expect(getToolText(result)).toBe(
+      "File not found at '/missing/file.txt'. Verify the path is correct.",
+    );
+  });
+
   it("renders the complete dim line diff with net metadata", async () => {
     const fx = setupFixture();
 

--- a/test/fly_sprite_execution_environment.test.js
+++ b/test/fly_sprite_execution_environment.test.js
@@ -65,10 +65,13 @@ class FakeSpriteCommand extends EventEmitter {
       try {
         this.respond(request.id, handler(request));
       } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        const code =
+          err && typeof err === "object" && typeof err.code === "string" ? err.code : null;
         this.writeMessage({
           id: request.id,
           ok: false,
-          error: err instanceof Error ? err.message : String(err),
+          error: { message, ...(code ? { code } : {}) },
         });
       }
     }
@@ -380,9 +383,9 @@ describe("Fly Sprite execution environment", () => {
       requests.push(request);
       if (request.method === "exec") {
         return executionResult({
-          output: "(tau) aborted\n",
+          output: "",
           stdout: "",
-          stderr: "(tau) aborted\n",
+          stderr: "",
           exitCode: null,
           aborted: true,
         });
@@ -401,9 +404,9 @@ describe("Fly Sprite execution environment", () => {
 
     await expect(backend.runBash("sleep 10", { signal: controller.signal })).resolves.toEqual(
       executionResult({
-        output: "(tau) aborted\n",
+        output: "",
         stdout: "",
-        stderr: "(tau) aborted\n",
+        stderr: "",
         exitCode: null,
         aborted: true,
       }),
@@ -480,6 +483,25 @@ describe("Fly Sprite execution environment", () => {
     expect(requests[3].contentBase64).toBe(Buffer.from([0, 255]).toString("base64"));
   });
 
+  it("normalizes missing files at the backend boundary", async () => {
+    const sprite = createFakeSprite(() => {
+      throw Object.assign(new Error("ENOENT: no such file or directory"), { code: "ENOENT" });
+    });
+    const backend = createFlySpriteToolExecutionBackend({
+      sprite,
+      cwd: "/home/sprite/repo",
+    });
+
+    await expect(backend.readFile("/home/sprite/repo/missing.txt")).rejects.toMatchObject({
+      name: "ToolExecutionBackendError",
+      code: "not-found",
+    });
+    await expect(backend.readFileBinary("/home/sprite/repo/missing.png")).rejects.toMatchObject({
+      name: "ToolExecutionBackendError",
+      code: "not-found",
+    });
+  });
+
   it("escalates cancellation when a Sprite command ignores SIGTERM", async () => {
     const sprite = {
       spawn(command, args, options) {
@@ -500,7 +522,9 @@ describe("Fly Sprite execution environment", () => {
       const result = await execution;
       const pid = Number(result.stdout.trim().split("\n")[0]);
 
-      expect(result.stderr).toContain("(tau) aborted");
+      expect(result.stderr).toBe("");
+      expect(result.output).toBe(result.stdout);
+      expect(result.aborted).toBe(true);
       expect(() => process.kill(pid, 0)).toThrow();
     } finally {
       await backend.dispose();

--- a/test/fly_sprite_execution_environment.test.js
+++ b/test/fly_sprite_execution_environment.test.js
@@ -483,7 +483,7 @@ describe("Fly Sprite execution environment", () => {
     expect(requests[3].contentBase64).toBe(Buffer.from([0, 255]).toString("base64"));
   });
 
-  it("normalizes missing files at the backend boundary", async () => {
+  it("normalizes missing binary files at the backend boundary", async () => {
     const sprite = createFakeSprite(() => {
       throw Object.assign(new Error("ENOENT: no such file or directory"), { code: "ENOENT" });
     });
@@ -492,12 +492,7 @@ describe("Fly Sprite execution environment", () => {
       cwd: "/home/sprite/repo",
     });
 
-    await expect(backend.readFile("/home/sprite/repo/missing.txt")).rejects.toMatchObject({
-      name: "ToolExecutionBackendError",
-      code: "not-found",
-    });
     await expect(backend.readFileBinary("/home/sprite/repo/missing.png")).rejects.toMatchObject({
-      name: "ToolExecutionBackendError",
       code: "not-found",
     });
   });

--- a/test/local_execution_environment.test.js
+++ b/test/local_execution_environment.test.js
@@ -158,6 +158,52 @@ describe("LocalExecutionEnvironment", () => {
     });
   });
 
+  it("keeps termination state separate from captured output", async () => {
+    const backend = createLocalToolExecutionBackend({
+      spawn: async () => ({
+        stdout: "partial output\n",
+        stderr: "",
+        output: "partial output\n",
+        exitCode: null,
+        captureLimitExceeded: false,
+        timedOut: true,
+        aborted: false,
+        closeSignal: "SIGTERM",
+      }),
+    });
+
+    await expect(backend.runBash("sleep 10", { timeoutMs: 10 })).resolves.toEqual({
+      output: "partial output\n",
+      stdout: "partial output\n",
+      stderr: "",
+      exitCode: null,
+      truncated: false,
+      timedOut: true,
+      aborted: false,
+      closeSignal: "SIGTERM",
+    });
+  });
+
+  it("normalizes missing files at the backend boundary", async () => {
+    const root = await mkdtemp(join(tmpdir(), "tau-local-missing-file-"));
+    const backend = createLocalToolExecutionBackend({
+      env: { cwd: () => root },
+    });
+
+    try {
+      await expect(backend.readFile("missing.txt")).rejects.toMatchObject({
+        name: "ToolExecutionBackendError",
+        code: "not-found",
+      });
+      await expect(backend.readFileBinary("missing.png")).rejects.toMatchObject({
+        name: "ToolExecutionBackendError",
+        code: "not-found",
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("scopes explicit environment variables without filtering sensitive names", async () => {
     const cwd = process.cwd();
     const environment = new LocalExecutionEnvironment({

--- a/test/local_execution_environment.test.js
+++ b/test/local_execution_environment.test.js
@@ -172,36 +172,18 @@ describe("LocalExecutionEnvironment", () => {
       }),
     });
 
-    await expect(backend.runBash("sleep 10", { timeoutMs: 10 })).resolves.toEqual({
+    await expect(backend.runBash("sleep 10", { timeoutMs: 10 })).resolves.toMatchObject({
       output: "partial output\n",
-      stdout: "partial output\n",
       stderr: "",
-      exitCode: null,
-      truncated: false,
       timedOut: true,
-      aborted: false,
       closeSignal: "SIGTERM",
     });
   });
 
-  it("normalizes missing files at the backend boundary", async () => {
-    const root = await mkdtemp(join(tmpdir(), "tau-local-missing-file-"));
-    const backend = createLocalToolExecutionBackend({
-      env: { cwd: () => root },
-    });
-
-    try {
-      await expect(backend.readFile("missing.txt")).rejects.toMatchObject({
-        name: "ToolExecutionBackendError",
-        code: "not-found",
-      });
-      await expect(backend.readFileBinary("missing.png")).rejects.toMatchObject({
-        name: "ToolExecutionBackendError",
-        code: "not-found",
-      });
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
+  it("normalizes missing binary files at the backend boundary", async () => {
+    await expect(
+      createLocalToolExecutionBackend().readFileBinary("__tau_missing__.png"),
+    ).rejects.toMatchObject({ code: "not-found" });
   });
 
   it("scopes explicit environment variables without filtering sensitive names", async () => {

--- a/test/local_session_host.test.js
+++ b/test/local_session_host.test.js
@@ -1769,11 +1769,14 @@ describe("LocalSessionHost", () => {
             "abort",
             () =>
               resolve({
-                output: "(tau) aborted",
+                output: "",
                 stdout: "",
-                stderr: "(tau) aborted",
-                exitCode: 1,
+                stderr: "",
+                exitCode: null,
                 truncated: false,
+                timedOut: false,
+                aborted: true,
+                closeSignal: null,
               }),
             { once: true },
           );

--- a/test/nook.test.js
+++ b/test/nook.test.js
@@ -1287,6 +1287,6 @@ describe("nook code-mode tool", () => {
     expect(requestSettled).toBe(true);
     expect(createClient.mock.calls[0][0].signal.aborted).toBe(true);
     expect(result.toolResult.outcome).toBe("cancelled");
-    expect(getToolText(result)).toContain("(tau) aborted");
+    expect(getToolText(result)).toBe("Program was cancelled.");
   });
 });

--- a/test/session_runner.test.js
+++ b/test/session_runner.test.js
@@ -788,6 +788,9 @@ describe("session execution backend plumbing", () => {
           stderr: "",
           exitCode: 0,
           truncated: false,
+          timedOut: false,
+          aborted: false,
+          closeSignal: null,
         };
       },
     };
@@ -836,6 +839,9 @@ describe("session execution backend plumbing", () => {
           stderr: "",
           exitCode: 2,
           truncated: false,
+          timedOut: false,
+          aborted: false,
+          closeSignal: null,
         };
       },
     };
@@ -852,6 +858,42 @@ describe("session execution backend plumbing", () => {
     expect(addUserText).toHaveBeenCalledWith(
       "Bash command output:\n$ false\n(no output)\n(exit 2)",
     );
+  });
+
+  it("formats direct Bash termination from structured execution state", async () => {
+    const addUserText = vi.fn(async () => "history-1");
+    const backend = {
+      async runBash() {
+        return {
+          output: "partial output\n",
+          stdout: "partial output\n",
+          stderr: "",
+          exitCode: null,
+          truncated: false,
+          timedOut: true,
+          aborted: false,
+          closeSignal: "SIGTERM",
+        };
+      },
+    };
+
+    const result = await runDirectBashCommand({
+      command: "sleep 60",
+      backend,
+      workingDirectory: "/repo",
+      actionLabel: "ran",
+      addToContext: true,
+      addUserText,
+    });
+
+    expect(addUserText).toHaveBeenCalledWith(
+      `Bash command output:\n$ sleep 60\npartial output\n\n[Command timed out after ${BASH_DEFAULT_TIMEOUT_MS}ms.]`,
+    );
+    expect(result.presentation.details).toEqual([
+      { text: "partial output", wrap: "character" },
+      { text: `[Command timed out after ${BASH_DEFAULT_TIMEOUT_MS}ms.]`, wrap: "word" },
+    ]);
+    expect(result.presentation.metadata).not.toContain("exit ?");
   });
 });
 

--- a/test/session_runner.test.js
+++ b/test/session_runner.test.js
@@ -782,6 +782,18 @@ describe("session execution backend plumbing", () => {
     const backend = {
       async runBash(command, options = {}) {
         received.push({ command, options });
+        if (command === "sleep 60") {
+          return {
+            output: "partial output\n",
+            stdout: "partial output\n",
+            stderr: "",
+            exitCode: null,
+            truncated: false,
+            timedOut: true,
+            aborted: false,
+            closeSignal: "SIGTERM",
+          };
+        }
         return {
           output: "hello\n",
           stdout: "hello\n",
@@ -827,6 +839,23 @@ describe("session execution backend plumbing", () => {
     });
 
     expect(addUserText).toHaveBeenCalledTimes(1);
+
+    const terminated = await runDirectBashCommand({
+      command: "sleep 60",
+      backend,
+      workingDirectory: "/repo",
+      actionLabel: "ran",
+      addToContext: true,
+      addUserText,
+    });
+    expect(addUserText).toHaveBeenLastCalledWith(
+      `Bash command output:\n$ sleep 60\npartial output\n\n[Command timed out after ${BASH_DEFAULT_TIMEOUT_MS}ms.]`,
+    );
+    expect(terminated.presentation.details.at(-1)).toEqual({
+      text: `[Command timed out after ${BASH_DEFAULT_TIMEOUT_MS}ms.]`,
+      wrap: "word",
+    });
+    expect(terminated.presentation.metadata).not.toContain("exit ?");
   });
 
   it("records nonzero direct bash exit status in session history", async () => {
@@ -858,42 +887,6 @@ describe("session execution backend plumbing", () => {
     expect(addUserText).toHaveBeenCalledWith(
       "Bash command output:\n$ false\n(no output)\n(exit 2)",
     );
-  });
-
-  it("formats direct Bash termination from structured execution state", async () => {
-    const addUserText = vi.fn(async () => "history-1");
-    const backend = {
-      async runBash() {
-        return {
-          output: "partial output\n",
-          stdout: "partial output\n",
-          stderr: "",
-          exitCode: null,
-          truncated: false,
-          timedOut: true,
-          aborted: false,
-          closeSignal: "SIGTERM",
-        };
-      },
-    };
-
-    const result = await runDirectBashCommand({
-      command: "sleep 60",
-      backend,
-      workingDirectory: "/repo",
-      actionLabel: "ran",
-      addToContext: true,
-      addUserText,
-    });
-
-    expect(addUserText).toHaveBeenCalledWith(
-      `Bash command output:\n$ sleep 60\npartial output\n\n[Command timed out after ${BASH_DEFAULT_TIMEOUT_MS}ms.]`,
-    );
-    expect(result.presentation.details).toEqual([
-      { text: "partial output", wrap: "character" },
-      { text: `[Command timed out after ${BASH_DEFAULT_TIMEOUT_MS}ms.]`, wrap: "word" },
-    ]);
-    expect(result.presentation.metadata).not.toContain("exit ?");
   });
 });
 

--- a/test/spawn_agent_tool.test.js
+++ b/test/spawn_agent_tool.test.js
@@ -187,6 +187,18 @@ describe("list_agents tool", () => {
     expect(result.uiEvent.presentation.metadata).toEqual([]);
     expect(() => JSON.parse(text)).toThrow();
   });
+
+  it("returns a focused supervisor failure", async () => {
+    const tool = createListAgentsToolDefinition({
+      listSnapshots: vi.fn(() => {
+        throw new Error("supervisor unavailable");
+      }),
+    });
+    const { result } = await execute(tool, {}, TOOL_NAME_LIST_AGENTS);
+
+    expect(result.toolResult.outcome).toBe("failed");
+    expect(getText(result.toolResult)).toBe("Could not list subagents: supervisor unavailable");
+  });
 });
 
 describe("send_input_to_agent tool", () => {
@@ -233,6 +245,9 @@ describe("send_input_to_agent tool", () => {
       TOOL_NAME_SEND_INPUT_TO_AGENT,
     );
     expect(invalid.result.toolResult.outcome).toBe("blocked");
+    expect(getText(invalid.result.toolResult)).toBe(
+      "Invalid arguments: id: must be a single line.",
+    );
 
     const { result } = await execute(
       tool,
@@ -249,6 +264,26 @@ describe("send_input_to_agent tool", () => {
       ["Started run 2 for `agent-1` · child task", "capacity 1/8"].join("\n"),
     );
     expect(getText(result.toolResult)).not.toContain("previous response");
+  });
+
+  it("returns a focused supervisor failure", async () => {
+    const supervisor = {
+      getSnapshot: vi.fn(() => createSubagentState({ availability: "idle" })),
+      sendInput: vi.fn(() => {
+        throw new Error("supervisor unavailable");
+      }),
+    };
+    const tool = createSendInputToAgentToolDefinition(supervisor);
+    const { result } = await execute(
+      tool,
+      { id: "agent-1", prompt: "continue" },
+      TOOL_NAME_SEND_INPUT_TO_AGENT,
+    );
+
+    expect(result.toolResult.outcome).toBe("failed");
+    expect(getText(result.toolResult)).toBe(
+      "Could not send input to subagent: supervisor unavailable",
+    );
   });
 
   it("does not duplicate cancellation in details or metadata", async () => {
@@ -268,6 +303,7 @@ describe("send_input_to_agent tool", () => {
     );
 
     expect(result.toolResult.outcome).toBe("cancelled");
+    expect(getText(result.toolResult)).toBe("Sending input to the subagent was cancelled.");
     expect(result.uiEvent.presentation.details).toEqual([]);
     expect(result.uiEvent.presentation.metadata).toEqual([]);
   });
@@ -326,6 +362,9 @@ describe("wait_for_agents tool", () => {
 
     const invalid = await execute(tool, { ids: ["agent-1\nagent-2"] }, TOOL_NAME_WAIT_FOR_AGENTS);
     expect(invalid.result.toolResult.outcome).toBe("blocked");
+    expect(getText(invalid.result.toolResult)).toBe(
+      "Invalid arguments: ids.0: must be a single line.",
+    );
 
     const { result } = await execute(
       tool,
@@ -356,6 +395,19 @@ describe("wait_for_agents tool", () => {
     expect(result.uiEvent.presentation.metadata).toEqual(["cost $0.02", "duration 30s"]);
   });
 
+  it("returns a focused supervisor failure", async () => {
+    const supervisor = {
+      waitForAgents: vi.fn(async () => {
+        throw new Error("supervisor unavailable");
+      }),
+    };
+    const tool = createWaitForAgentsToolDefinition(supervisor);
+    const { result } = await execute(tool, { ids: ["agent-1"] }, TOOL_NAME_WAIT_FOR_AGENTS);
+
+    expect(result.toolResult.outcome).toBe("failed");
+    expect(getText(result.toolResult)).toBe("Could not wait for subagents: supervisor unavailable");
+  });
+
   it("does not duplicate cancellation as a detail", async () => {
     const supervisor = {
       waitForAgents: vi.fn(async () => {
@@ -375,6 +427,7 @@ describe("wait_for_agents tool", () => {
     );
 
     expect(result.toolResult.outcome).toBe("cancelled");
+    expect(getText(result.toolResult)).toBe("Waiting for subagents was cancelled.");
     expect(result.uiEvent.presentation.details).toEqual([]);
   });
 });
@@ -403,6 +456,9 @@ describe("interrupt_agent tool", () => {
 
     const invalid = await execute(tool, { id: "agent-1\nagent-2" }, TOOL_NAME_INTERRUPT_AGENT);
     expect(invalid.result.toolResult.outcome).toBe("blocked");
+    expect(getText(invalid.result.toolResult)).toBe(
+      "Invalid arguments: id: must be a single line.",
+    );
 
     const { result } = await execute(tool, { id: "agent-1" }, TOOL_NAME_INTERRUPT_AGENT);
 
@@ -483,6 +539,20 @@ describe("interrupt_agent tool", () => {
     expect(result.uiEvent.presentation.details.at(-1).text).toBe(`failure: ${failureMessage}`);
   });
 
+  it("returns a focused supervisor failure", async () => {
+    const supervisor = {
+      getSnapshot: vi.fn(() => createSubagentState()),
+      interrupt: vi.fn(async () => {
+        throw new Error("supervisor unavailable");
+      }),
+    };
+    const tool = createInterruptAgentToolDefinition(supervisor);
+    const { result } = await execute(tool, { id: "agent-1" }, TOOL_NAME_INTERRUPT_AGENT);
+
+    expect(result.toolResult.outcome).toBe("failed");
+    expect(getText(result.toolResult)).toBe("Could not interrupt subagent: supervisor unavailable");
+  });
+
   it("does not duplicate cancellation as a detail", async () => {
     const supervisor = {
       getSnapshot: vi.fn(() => createSubagentState()),
@@ -502,6 +572,7 @@ describe("interrupt_agent tool", () => {
     );
 
     expect(result.toolResult.outcome).toBe("cancelled");
+    expect(getText(result.toolResult)).toBe("Subagent interruption was cancelled.");
     expect(result.uiEvent.presentation.details).toEqual([]);
   });
 });
@@ -518,14 +589,18 @@ describe("spawn_agent tool", () => {
       workingDirectory: "one\ntwo",
     });
     expect(invalidDirectory.result.toolResult.outcome).toBe("blocked");
-    expect(invalidDirectory.result.uiEvent.presentation.details[0].text).toContain("single line");
+    expect(getText(invalidDirectory.result.toolResult)).toBe(
+      "Invalid arguments: workingDirectory: must be a single line.",
+    );
 
     const invalidTitle = await execute(tool, {
       ...baseArguments,
       title: "one\ntwo",
     });
     expect(invalidTitle.result.toolResult.outcome).toBe("blocked");
-    expect(invalidTitle.result.uiEvent.presentation.details[0].text).toContain("single line");
+    expect(getText(invalidTitle.result.toolResult)).toBe(
+      "Invalid arguments: title: must be a single line.",
+    );
   });
 
   it("binds dependencies before execution and admits an allowed launch model", async () => {
@@ -589,6 +664,7 @@ describe("spawn_agent tool", () => {
     const { result } = await execute(tool, baseArguments, TOOL_NAME_SPAWN_AGENT, controller.signal);
 
     expect(result.toolResult.outcome).toBe("cancelled");
+    expect(getText(result.toolResult)).toBe("Subagent creation was cancelled.");
     expect(result.uiEvent.presentation.details).toEqual([]);
     expect(result.uiEvent.presentation.metadata).not.toContain("Aborted.");
   });
@@ -709,9 +785,23 @@ describe("spawn_agent tool", () => {
       workingDirectory: "/tmp/project",
     });
 
-    expect(result.toolResult.outcome).toBe("blocked");
-    expect(getText(result.toolResult)).toContain("target context failed");
+    expect(result.toolResult.outcome).toBe("failed");
+    expect(getText(result.toolResult)).toBe(
+      "Could not build the subagent prompt for workingDirectory '/tmp/project': target context failed",
+    );
     expect(supervisor.spawn).not.toHaveBeenCalled();
+  });
+
+  it("returns a focused supervisor failure", async () => {
+    const supervisor = {
+      spawn: vi.fn(() => {
+        throw new Error("supervisor unavailable");
+      }),
+    };
+    const { result } = await execute(createFixture({ supervisor }).tool, baseArguments);
+
+    expect(result.toolResult.outcome).toBe("failed");
+    expect(getText(result.toolResult)).toBe("Could not create subagent: supervisor unavailable");
   });
 
   it("reports supervisor admission failures as blocked", async () => {

--- a/test/spawn_agent_tool.test.js
+++ b/test/spawn_agent_tool.test.js
@@ -187,18 +187,6 @@ describe("list_agents tool", () => {
     expect(result.uiEvent.presentation.metadata).toEqual([]);
     expect(() => JSON.parse(text)).toThrow();
   });
-
-  it("returns a focused supervisor failure", async () => {
-    const tool = createListAgentsToolDefinition({
-      listSnapshots: vi.fn(() => {
-        throw new Error("supervisor unavailable");
-      }),
-    });
-    const { result } = await execute(tool, {}, TOOL_NAME_LIST_AGENTS);
-
-    expect(result.toolResult.outcome).toBe("failed");
-    expect(getText(result.toolResult)).toBe("Could not list subagents: supervisor unavailable");
-  });
 });
 
 describe("send_input_to_agent tool", () => {
@@ -264,26 +252,6 @@ describe("send_input_to_agent tool", () => {
       ["Started run 2 for `agent-1` · child task", "capacity 1/8"].join("\n"),
     );
     expect(getText(result.toolResult)).not.toContain("previous response");
-  });
-
-  it("returns a focused supervisor failure", async () => {
-    const supervisor = {
-      getSnapshot: vi.fn(() => createSubagentState({ availability: "idle" })),
-      sendInput: vi.fn(() => {
-        throw new Error("supervisor unavailable");
-      }),
-    };
-    const tool = createSendInputToAgentToolDefinition(supervisor);
-    const { result } = await execute(
-      tool,
-      { id: "agent-1", prompt: "continue" },
-      TOOL_NAME_SEND_INPUT_TO_AGENT,
-    );
-
-    expect(result.toolResult.outcome).toBe("failed");
-    expect(getText(result.toolResult)).toBe(
-      "Could not send input to subagent: supervisor unavailable",
-    );
   });
 
   it("does not duplicate cancellation in details or metadata", async () => {
@@ -393,19 +361,6 @@ describe("wait_for_agents tool", () => {
       "agent-3",
     );
     expect(result.uiEvent.presentation.metadata).toEqual(["cost $0.02", "duration 30s"]);
-  });
-
-  it("returns a focused supervisor failure", async () => {
-    const supervisor = {
-      waitForAgents: vi.fn(async () => {
-        throw new Error("supervisor unavailable");
-      }),
-    };
-    const tool = createWaitForAgentsToolDefinition(supervisor);
-    const { result } = await execute(tool, { ids: ["agent-1"] }, TOOL_NAME_WAIT_FOR_AGENTS);
-
-    expect(result.toolResult.outcome).toBe("failed");
-    expect(getText(result.toolResult)).toBe("Could not wait for subagents: supervisor unavailable");
   });
 
   it("does not duplicate cancellation as a detail", async () => {
@@ -537,20 +492,6 @@ describe("interrupt_agent tool", () => {
 
     expect(result.uiEvent.presentation.details.map((line) => line.text).join("\n")).toBe(modelText);
     expect(result.uiEvent.presentation.details.at(-1).text).toBe(`failure: ${failureMessage}`);
-  });
-
-  it("returns a focused supervisor failure", async () => {
-    const supervisor = {
-      getSnapshot: vi.fn(() => createSubagentState()),
-      interrupt: vi.fn(async () => {
-        throw new Error("supervisor unavailable");
-      }),
-    };
-    const tool = createInterruptAgentToolDefinition(supervisor);
-    const { result } = await execute(tool, { id: "agent-1" }, TOOL_NAME_INTERRUPT_AGENT);
-
-    expect(result.toolResult.outcome).toBe("failed");
-    expect(getText(result.toolResult)).toBe("Could not interrupt subagent: supervisor unavailable");
   });
 
   it("does not duplicate cancellation as a detail", async () => {
@@ -792,18 +733,6 @@ describe("spawn_agent tool", () => {
     expect(supervisor.spawn).not.toHaveBeenCalled();
   });
 
-  it("returns a focused supervisor failure", async () => {
-    const supervisor = {
-      spawn: vi.fn(() => {
-        throw new Error("supervisor unavailable");
-      }),
-    };
-    const { result } = await execute(createFixture({ supervisor }).tool, baseArguments);
-
-    expect(result.toolResult.outcome).toBe("failed");
-    expect(getText(result.toolResult)).toBe("Could not create subagent: supervisor unavailable");
-  });
-
   it("reports supervisor admission failures as blocked", async () => {
     const supervisor = { spawn: vi.fn(() => ({ ok: false, reason: "active limit reached" })) };
     const { result } = await execute(createFixture({ supervisor }).tool, baseArguments);
@@ -816,3 +745,31 @@ describe("spawn_agent tool", () => {
     });
   });
 });
+
+it.each([
+  [
+    "list_agents",
+    () => createListAgentsToolDefinition({ listSnapshots: failSupervisorCall }),
+    {},
+    TOOL_NAME_LIST_AGENTS,
+    "Could not list subagents: supervisor unavailable",
+  ],
+  [
+    "send_input_to_agent",
+    () =>
+      createSendInputToAgentToolDefinition({
+        getSnapshot: () => createSubagentState({ availability: "idle" }),
+        sendInput: failSupervisorCall,
+      }),
+    { id: "agent-1", prompt: "continue" },
+    TOOL_NAME_SEND_INPUT_TO_AGENT,
+    "Could not send input to subagent: supervisor unavailable",
+  ],
+])("reports %s supervisor failures", async (_toolName, createTool, args, name, message) => {
+  const { result } = await execute(createTool(), args, name);
+  expect([result.toolResult.outcome, getText(result.toolResult)]).toEqual(["failed", message]);
+});
+
+function failSupervisorCall() {
+  throw new Error("supervisor unavailable");
+}

--- a/test/tool_card.test.js
+++ b/test/tool_card.test.js
@@ -292,16 +292,6 @@ describe("tool cards", () => {
       { type: "text", text: "Invalid arguments: path must be a single line." },
     ]);
 
-    const unknownArgument = await execute({
-      id: "write-unknown-argument",
-      name: "write",
-      arguments: { path: "file.txt", content, unexpected: true },
-    });
-    expect(unknownArgument.result.outcome).toBe("blocked");
-    expect(unknownArgument.result.content).toEqual([
-      { type: "text", text: 'Invalid arguments: Unrecognized key: "unexpected"' },
-    ]);
-
     const succeeded = await execute({
       id: "write-valid",
       name: "write",

--- a/test/tool_card.test.js
+++ b/test/tool_card.test.js
@@ -264,6 +264,7 @@ describe("tool cards", () => {
     const bytes = Buffer.byteLength(content, "utf8");
     const tool = createWriteToolDefinition({
       async writeFile(path, writtenContent) {
+        if (path === "failed.txt") throw new Error("disk is full");
         return { path, bytes: Buffer.byteLength(writtenContent, "utf8"), lines: 17 };
       },
     });
@@ -287,7 +288,19 @@ describe("tool cards", () => {
       arguments: { path: "one\ntwo", content },
     });
     expect(invalid.result.outcome).toBe("blocked");
-    expect(invalid.uiEvent.presentation.details[0].text).toContain("single line");
+    expect(invalid.result.content).toEqual([
+      { type: "text", text: "Invalid arguments: path must be a single line." },
+    ]);
+
+    const unknownArgument = await execute({
+      id: "write-unknown-argument",
+      name: "write",
+      arguments: { path: "file.txt", content, unexpected: true },
+    });
+    expect(unknownArgument.result.outcome).toBe("blocked");
+    expect(unknownArgument.result.content).toEqual([
+      { type: "text", text: 'Invalid arguments: Unrecognized key: "unexpected"' },
+    ]);
 
     const succeeded = await execute({
       id: "write-valid",
@@ -295,6 +308,9 @@ describe("tool cards", () => {
       arguments: { path: "file.txt", content },
     });
     expect(succeeded.result.outcome).toBe("succeeded");
+    expect(succeeded.result.content).toEqual([
+      { type: "text", text: "Successfully wrote file.txt." },
+    ]);
     expect(succeeded.uiEvent.presentation.details.map((line) => line.text)).toEqual([
       ...Array.from({ length: 15 }, (_, index) => `line ${index + 1}`),
       "…2 more lines…",
@@ -306,6 +322,16 @@ describe("tool cards", () => {
     expect(succeeded.uiEvent.presentation.metadata).toEqual([
       `~${Math.floor(bytes / 6)} tokens`,
       "17 lines",
+    ]);
+
+    const failed = await execute({
+      id: "write-failed",
+      name: "write",
+      arguments: { path: "failed.txt", content },
+    });
+    expect(failed.result.outcome).toBe("failed");
+    expect(failed.result.content).toEqual([
+      { type: "text", text: "Could not write file: disk is full" },
     ]);
   });
 

--- a/test/view_image_tool.test.js
+++ b/test/view_image_tool.test.js
@@ -100,16 +100,6 @@ describe("view_image tool", () => {
       "Invalid arguments: path must be a single line.",
     );
     expect(result.uiEvent.presentation.details[0].tone).toBeUndefined();
-
-    const unknownArgument = await runTool(tool, {
-      id: "tool-unknown-argument",
-      name: TOOL_NAME_VIEW_IMAGE,
-      arguments: { path: "image.png", unexpected: true },
-    });
-    expect(unknownArgument.toolResult.outcome).toBe("blocked");
-    expect(getTextBlock(unknownArgument.toolResult.content)).toBe(
-      'Invalid arguments: Unrecognized key: "unexpected"',
-    );
   });
 
   it("downscales images to fit inside a 2000x2000 square", async () => {
@@ -217,7 +207,7 @@ describe("view_image tool", () => {
     }
   }, 10_000);
 
-  it("returns focused file read failures", async () => {
+  it("returns a focused missing-file result", async () => {
     const tool = createViewImageToolDefinition(createLocalToolExecutionBackend());
     const missing = await runTool(tool, {
       id: "tool-missing",
@@ -225,26 +215,10 @@ describe("view_image tool", () => {
       arguments: { path: "/missing/image.png" },
     });
 
-    expect(missing.toolResult.outcome).toBe("blocked");
-    expect(getTextBlock(missing.toolResult.content)).toBe(
+    expect([missing.toolResult.outcome, getTextBlock(missing.toolResult.content)]).toEqual([
+      "blocked",
       "File not found at '/missing/image.png'. Verify the path is correct.",
-    );
-
-    const failedTool = createViewImageToolDefinition({
-      async readFileBinary() {
-        throw new Error("storage unavailable");
-      },
-    });
-    const failed = await runTool(failedTool, {
-      id: "tool-read-failed",
-      name: TOOL_NAME_VIEW_IMAGE,
-      arguments: { path: "image.png" },
-    });
-
-    expect(failed.toolResult.outcome).toBe("failed");
-    expect(getTextBlock(failed.toolResult.content)).toBe(
-      "Could not view image: storage unavailable",
-    );
+    ]);
   });
 
   it("blocks unsupported image formats", async () => {

--- a/test/view_image_tool.test.js
+++ b/test/view_image_tool.test.js
@@ -96,8 +96,20 @@ describe("view_image tool", () => {
       arguments: { path: "one\ntwo" },
     });
     expect(result.toolResult.outcome).toBe("blocked");
-    expect(result.uiEvent.presentation.details[0].text).toContain("single line");
+    expect(getTextBlock(result.toolResult.content)).toBe(
+      "Invalid arguments: path must be a single line.",
+    );
     expect(result.uiEvent.presentation.details[0].tone).toBeUndefined();
+
+    const unknownArgument = await runTool(tool, {
+      id: "tool-unknown-argument",
+      name: TOOL_NAME_VIEW_IMAGE,
+      arguments: { path: "image.png", unexpected: true },
+    });
+    expect(unknownArgument.toolResult.outcome).toBe("blocked");
+    expect(getTextBlock(unknownArgument.toolResult.content)).toBe(
+      'Invalid arguments: Unrecognized key: "unexpected"',
+    );
   });
 
   it("downscales images to fit inside a 2000x2000 square", async () => {
@@ -121,7 +133,7 @@ describe("view_image tool", () => {
       }
 
       expect(result.uiEvent.presentation.metadata).toEqual(["image/png", "2000×1500"]);
-      expect(getTextBlock(result.toolResult.content)).toBe(`Viewed ${filePath} (image/png)`);
+      expect(getTextBlock(result.toolResult.content)).toBe(`Successfully viewed ${filePath}.`);
 
       const imageBlock = getImageBlock(result.toolResult.content);
       const outputBuffer = Buffer.from(imageBlock.data, "base64");
@@ -199,13 +211,41 @@ describe("view_image tool", () => {
       expect(Math.max(outputMetadata.width ?? 0, outputMetadata.height ?? 0)).toBeLessThanOrEqual(
         2000,
       );
-      expect(getTextBlock(result.toolResult.content)).toBe(
-        `Viewed ${filePath} (${imageBlock.mimeType})`,
-      );
+      expect(getTextBlock(result.toolResult.content)).toBe(`Successfully viewed ${filePath}.`);
     } finally {
       fx.cleanup();
     }
   }, 10_000);
+
+  it("returns focused file read failures", async () => {
+    const tool = createViewImageToolDefinition(createLocalToolExecutionBackend());
+    const missing = await runTool(tool, {
+      id: "tool-missing",
+      name: TOOL_NAME_VIEW_IMAGE,
+      arguments: { path: "/missing/image.png" },
+    });
+
+    expect(missing.toolResult.outcome).toBe("blocked");
+    expect(getTextBlock(missing.toolResult.content)).toBe(
+      "File not found at '/missing/image.png'. Verify the path is correct.",
+    );
+
+    const failedTool = createViewImageToolDefinition({
+      async readFileBinary() {
+        throw new Error("storage unavailable");
+      },
+    });
+    const failed = await runTool(failedTool, {
+      id: "tool-read-failed",
+      name: TOOL_NAME_VIEW_IMAGE,
+      arguments: { path: "image.png" },
+    });
+
+    expect(failed.toolResult.outcome).toBe("failed");
+    expect(getTextBlock(failed.toolResult.content)).toBe(
+      "Could not view image: storage unavailable",
+    );
+  });
 
   it("blocks unsupported image formats", async () => {
     const fx = setupFixture();

--- a/test/web_tool.test.js
+++ b/test/web_tool.test.js
@@ -490,6 +490,18 @@ describe("Exa web code-mode tool", () => {
     expect(deps.createExaClient).not.toHaveBeenCalled();
   });
 
+  it("separates failed-program status from program output", async () => {
+    const backend = createBackend();
+    const tool = createWebTool(backend, createDeps({}));
+    const { result } = await runTool(tool, { code: 'throw new Error("program failure")' });
+    const text = getToolText(result);
+
+    expect(result.toolResult.outcome).toBe("failed");
+    expect(text).toContain("program failure");
+    expect(text).toMatch(/\n\n\[Program failed with exit code 1\.\]$/);
+    expect(text).not.toContain("\n(exit 1)");
+  });
+
   it("forwards cancellation to a running sandbox", async () => {
     const backend = createBackend();
     const tool = createWebTool(backend, createDeps({}));
@@ -499,9 +511,9 @@ describe("Exa web code-mode tool", () => {
 
     const { result } = await run;
     expect(result.toolResult.outcome).toBe("cancelled");
-    expect(getToolText(result)).toContain("(tau) aborted");
+    expect(getToolText(result)).toBe("Program was cancelled.");
     expect(result.uiEvent.presentation.details).toContainEqual({
-      text: "(tau) aborted",
+      text: "Program was cancelled.",
       wrap: "word",
     });
   });
@@ -539,7 +551,7 @@ describe("Exa web code-mode tool", () => {
 
     expect(providerSettled).toBe(true);
     expect(client.search.mock.calls[0][2].aborted).toBe(true);
-    expect(getToolText(result)).toContain("(tau) aborted");
+    expect(getToolText(result)).toBe("Program was cancelled.");
   });
 
   it("cancels provider requests and reports sandbox timeouts explicitly", async () => {
@@ -562,13 +574,15 @@ describe("Exa web code-mode tool", () => {
     const backend = createBackend();
     const deps = { ...createDeps(client), timeoutMs: 1_000 };
     const tool = createWebTool(backend, deps);
-    const { result } = await runTool(tool, { code: "await web.search('tau')" });
+    const { result } = await runTool(tool, {
+      code: "console.log('partial output'); await web.search('tau')",
+    });
 
     expect(providerSettled).toBe(true);
     expect(result.toolResult.outcome).toBe("cancelled");
-    expect(getToolText(result)).toContain("(tau) timed out after 1000ms");
+    expect(getToolText(result)).toBe("partial output\n\n[Program timed out after 1000ms.]");
     expect(result.uiEvent.presentation.details).toContainEqual({
-      text: "(tau) timed out after 1000ms",
+      text: "[Program timed out after 1000ms.]",
       wrap: "word",
     });
   });


### PR DESCRIPTION
## why

Built-in tools returned inconsistent validation, failure, cancellation, and execution-status text. Some responses exposed internal `(tau)` markers or made appended status indistinguishable from command and program output, while similar file and subagent operations used different wording and outcome classifications.

## what

Align built-in tool responses around focused argument guidance, concise success text, contextual `Could not ...` failures, and operation-specific cancellation messages. Bash and code-mode execution now separate Tau-authored notices from captured output with bracketed status text, and file, goal, documentation, and subagent tools use stricter argument boundaries and consistent semantic outcomes.

## details

Adds focused regression coverage for exact model-facing text, unknown arguments, filesystem and supervisor failures, termination behavior, and code-mode output separation.
