### PR TITLE
ignore unknown preserved user message ids

### DIFF
--- a/src/core/session/compaction.ts
+++ b/src/core/session/compaction.ts
@@ -289,17 +289,18 @@ export function parseCompactionSummaryResponse(args: {
     args.userMessageCandidates.map((message) => [message.id, message] as const),
   );
   const seenIds = new Set<string>();
-  const selectedCandidates = selectedIds.map((id) => {
+  const selectedCandidates: PreservedUserMessage[] = [];
+  for (const id of selectedIds) {
+    const candidate = candidatesById.get(id);
+    if (!candidate) {
+      continue;
+    }
     if (seenIds.has(id)) {
       throw new Error(`compaction summary selected duplicate preserved user message id '${id}'`);
     }
-    const candidate = candidatesById.get(id);
-    if (!candidate) {
-      throw new Error(`compaction summary selected unknown preserved user message id '${id}'`);
-    }
     seenIds.add(id);
-    return candidate;
-  });
+    selectedCandidates.push(candidate);
+  }
 
   return {
     summary,

--- a/test/core_runtime.test.js
+++ b/test/core_runtime.test.js
@@ -987,6 +987,30 @@ describe("compaction context message", () => {
     });
   });
 
+  it("ignores unknown selected preserved user message ids", () => {
+    const parsed = parseCompactionSummaryResponse({
+      response: compactionSummary("## Goal\nContinue", ["unknown", "valid"]),
+      userMessageCandidates: [{ id: "valid", text: "keep this standing constraint" }],
+    });
+
+    expect(parsed).toEqual({
+      summary: "## Goal\nContinue",
+      preservedUserMessages: [{ id: "valid", text: "keep this standing constraint" }],
+    });
+  });
+
+  it("accepts an all-unknown preserved user message selection", () => {
+    const parsed = parseCompactionSummaryResponse({
+      response: compactionSummary("## Goal\nContinue", ["unknown"]),
+      userMessageCandidates: [{ id: "valid", text: "keep this standing constraint" }],
+    });
+
+    expect(parsed).toEqual({
+      summary: "## Goal\nContinue",
+      preservedUserMessages: [],
+    });
+  });
+
   it("middle-truncates selected preserved user messages by size", () => {
     const first = `first start ${"a".repeat(60000)} first end`;
     const second = `second start ${"b".repeat(120000)} second end`;


### PR DESCRIPTION
## why

A compaction summary can contain a preserved user message ID that was not among the advertised candidates. Treating that model-side selection mistake as fatal discards an otherwise usable summary and fails both manual and automatic compaction.

## what

The shared compaction response parser now ignores IDs that are absent from `userMessageCandidates`, while preserving valid selected candidates in their original selection order. Regression coverage includes mixed valid and unknown selections and an all-unknown selection.

## details

Unknown means an ID with no exact match in the current candidate set. Malformed or missing selection blocks and duplicate valid IDs remain validation errors. There are no remaining implementation questions.

fixes #457
