### PR TITLE
refine Telegram composite project config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,8 @@ Treat the client, host, and execution environment as separate logical machines e
 - The execution environment is the agent's machine. It owns every agent-visible path, `cwd`, home, repository, project configuration and content, `AGENTS.md`, skills, model overlays, platform, Node version, `PATH`, filesystem operation, and command.
 - The Telegram runner owns Telegram polling, routing, attachments, prepared workspaces, outbound messages, and runner-specific persisted state. It is a client of local in-process sessions.
 
+Repository and composite managed workspaces are prepared once per Telegram session. Normal runner recovery reconnects through the preserved workspace without rerunning preparation or provisioning and without rewriting generated composite metadata. Reconstruct the workspace only when it is missing. Telegram project configuration changes apply to future workspace preparations, not preserved workspaces.
+
 Temporary storage follows the same ownership boundary. Client, host, and runner code derives process-local temporary paths from `node:os` `tmpdir()` instead of hard-coding `/tmp`. Target-owned temporary paths come from target capabilities or a documented adapter contract, never from the caller's local temporary directory.
 
 Outside narrow pre-creation metadata obtained by a client from an environment it directly manages, client and host filesystem APIs must not inspect execution-environment paths. Session creation attributes are complete, authoritative client input. The host and stores do not infer or normalize them. All agent-visible access must cross `ExecutionEnvironment` and `ToolExecutionBackend`, even for a local session. Physical co-location must not create a second runtime path.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -191,7 +191,7 @@ For `tau serve`, make the changes on the host machine and restart the server. Re
 
 Some settings are choices rather than live mutations. `defaultPersona` and startup persona flags select a new session. Execution-environment kind, identity, `cwd`, and home are fixed when the session is created or recovered.
 
-The Telegram runner loads its speech provider and separate runner config at startup. Restart it for speech, project, routing, or workspace-preparation changes. Command client tools are selected when a Telegram session client is created, so configuration changes apply to new sessions; restarting the runner also rebuilds clients while recovering its sessions. Existing sessions retain their recorded execution environment unless the documented recovery behavior reconstructs a managed workspace.
+The Telegram runner loads its speech provider and separate runner config at startup. Restart it for speech, project, routing, or workspace-preparation changes. Workspace-preparation changes apply when a managed workspace is created or reconstructed; restarting does not retrofit a preserved workspace. Command client tools are selected when a Telegram session client is created, so configuration changes apply to new sessions; restarting the runner also rebuilds clients while recovering its sessions. Existing sessions retain their recorded execution environment unless the documented recovery behavior reconstructs a managed workspace.
 
 ## Common precedence mistakes
 

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -140,7 +140,7 @@ Tau keeps a persistent bare cache at:
 
 The first preparation uses `gh repo clone <owner/repo> <cache> -- --bare`. Later preparations fetch and prune the cache, then create the session workspace with a shared local clone. If the repository configured for the same project ID changes, Tau discards and recreates that cache.
 
-Caches are not session workspaces. Tau does not commit, push, or preserve uncommitted changes automatically. Managed workspaces survive a normal restart, but `/new` removes the active session's workspace.
+Caches are shared preparation inputs, not session workspaces.
 
 ## Persistent-directory projects
 
@@ -188,35 +188,31 @@ A composite project creates a root containing multiple repositories:
 
 `projectIds` requires at least two unique repository projects; directories and composites are invalid members. Order controls workspace context and history `repository`.
 
-Members live at `<composite-root>/<member-project-id>` and use each repository's cache, ref, and working directory. The root is the session `cwd`. Its generated `AGENTS.md` lists members and optional `instructions`, and requires reading relevant member root instructions before work.
+Members live at `<composite-root>/<member-project-id>` and use each repository's cache, ref, and working directory. The root is the session `cwd`. At creation, Tau writes a root `AGENTS.md` listing the members and optional `instructions`, plus root `.tau/config.json` containing `subagents` or `{}`. These are workspace files, not synchronized mirrors of Telegram configuration, and are not regenerated when a preserved session reconnects.
 
-`subagents.defaultLaunchModels` sets the built-in `default` launch override allowlist. Tau writes it to root `.tau/config.json`; without `subagents`, the file is `{}`. Runtime config resolves and enforces entries. See [subagents](subagents.md) for model syntax and custom policy.
+`subagents.defaultLaunchModels` sets the built-in `default` launch override allowlist. Runtime config resolves and enforces entries. See [subagents](subagents.md) for model syntax and custom policy.
 
 The composite owns the parent persona, subagents, model catalog, config, settings, and tools. Child `.tau/config.json` files are not merged. A subagent in a member directory rebuilds only target context: environment and repository metadata, applicable `AGENTS.md` and `agentContextFiles`, and skills filtered by the parent persona.
 
 Composite preparation is all-or-nothing. If one member cannot be prepared, Tau removes the generated composite workspace. The composite's optional `workspaceRoot` controls the generated root; member repository caches continue to use each member's configured root or the top-level default.
 
+## Managed workspace lifecycle
+
+Repository and composite projects follow the same lifecycle. Tau prepares one workspace per session, then the session continues working there. A normal runner restart reconnects without fetching or checking out repositories, rerunning provision hooks, or rewriting generated files. Workspace-preparation changes in Telegram configuration affect later preparations, not a preserved workspace.
+
+If the expected workspace is missing, recovery reconstructs it from the caches and current project configuration. `/new` and session close remove a managed workspace; normal shutdown preserves it. Tau does not commit, push, or save uncommitted changes elsewhere.
+
 ## Managed workspace safety
 
-**Important:** runner startup removes entries under configured managed workspace roots when they are not referenced by persisted sessions. Dedicate these roots to Tau Telegram workspaces. Do not point `workspaceRoot` at a home directory, repository collection, or any directory containing unrelated files.
+**Important:** startup removes entries under managed workspace roots that no persisted session references. Dedicate these roots to Tau; never use a home directory, repository collection, or unrelated tree.
 
-Tau preserves managed workspaces referenced by active or failed persisted records and always preserves configured persistent directories. It also preserves repository caches, which live beside the workspace root under the `-repo-cache` suffix rather than inside the pruned root.
-
-`/new` closes the chat's current active session before creating its replacement. For repository and composite projects, closing interrupts work and recursively removes that session's managed workspace. Uncommitted changes are lost unless the agent or operator saved them elsewhere. For persistent-directory projects, the shared directory remains untouched.
+Tau preserves referenced managed workspaces, configured persistent directories, and repository caches. `/new` closes the active session before replacing it. Closing a repository or composite session interrupts work and removes its workspace; persistent directories remain untouched.
 
 ## Provision hooks
 
-A repository may provide an optional setup script at its repository root:
+A repository may provide `.tau/scripts/provision` at its root. It must be a regular executable file, not a symlink, and start with a shebang. Tau runs it through `session.exec` from the configured working directory after the session becomes available, without blocking chat input.
 
-```text
-.tau/scripts/provision
-```
-
-Tau runs it through `session.exec` with the project's configured working directory as `cwd`. The path must be a regular executable file, not a symlink, and must begin with a shebang. A missing hook is a successful no-op.
-
-Provisioning starts after the session becomes available and does not block chat input. A failure is reported to linked chats, but the session remains usable. Composite sessions run each member hook in member order and continue after a member failure. Persistent-directory projects are never provisioned.
-
-A newly created workspace runs its hook. A preserved workspace skips it during normal restart recovery. If recovery must reconstruct a missing repository or composite workspace from cache, the reconstructed repositories run provisioning again. Keep hooks repeatable and non-interactive.
+New and reconstructed workspaces run their hooks; preserved workspaces and persistent-directory projects do not. Composite sessions run member hooks in order and continue after failures. A failure is reported to linked chats but leaves the session usable. Keep hooks repeatable and non-interactive.
 
 ## Normal Tau configuration inside workspaces
 
@@ -304,9 +300,7 @@ Tool selection occurs when the session client is created or reconnected. `/reloa
 
 ## Persistence and restart behavior
 
-Normal shutdown interrupts live work, waits for active work to settle, disconnects sessions, and preserves repository and composite workspaces rather than deleting them. Sessions that finished creation reconnect on restart and retain their conversation. A session interrupted while its workspace or Tau session was still being prepared starts preparation again.
-
-If a referenced repository workspace is missing, Tau reconstructs it from the cache and reconnects the same session. A persistent-directory workspace is never reconstructed; its configured directory must still exist at the original path.
+Normal shutdown interrupts live work, waits for it to settle, and disconnects sessions. Finished sessions reconnect with their conversation on restart. A session interrupted during workspace or Tau session creation starts preparation again. A persistent-directory workspace is never reconstructed and must remain at its original path.
 
 If the connection is lost after Telegram submits a message, startup checks whether Tau accepted and completed it. Running work remains interruptible until it settles. A confirmed unaccepted message prompts the user to resend it; failed or blocked outcomes remain queued until delivery succeeds.
 

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -167,7 +167,7 @@ Persistent-directory sessions omit the conventional history `repository` attribu
 
 ## Composite projects
 
-A composite project creates one generated root with multiple repository projects as children:
+A composite project creates a root containing multiple repositories:
 
 ```json
 {
@@ -177,17 +177,22 @@ A composite project creates one generated root with multiple repository projects
     "platform": {
       "projectIds": ["web", "api"],
       "persona": "gpt-5.6-sol-coder:high",
-      "instructions": "Keep shared contracts synchronized."
+      "instructions": "Keep shared contracts synchronized.",
+      "subagents": {
+        "defaultLaunchModels": ["openai/gpt-5.6-sol:high"]
+      }
     }
   }
 }
 ```
 
-`projectIds` must contain at least two unique repository project IDs. A composite cannot contain persistent-directory projects or another composite. Member order is retained for workspace context and the comma-delimited history `repository` attribute.
+`projectIds` requires at least two unique repository projects; directories and composites are invalid members. Order controls workspace context and history `repository`.
 
-Tau creates each member under `<composite-root>/<member-project-id>`, using that member's repository cache, ref, and working directory. The session `cwd` is the generated composite root. Tau writes a root `AGENTS.md` describing the members and optional `instructions`, plus a root `.tau/config.json` that adds discovered member `AGENTS.md` files along the configured working-directory paths.
+Members live at `<composite-root>/<member-project-id>` and use each repository's cache, ref, and working directory. The root is the session `cwd`. Its generated `AGENTS.md` lists members and optional `instructions`, and requires reading relevant member root instructions before work.
 
-The parent composite session remains authoritative for the persona, subagent definition, model catalog, runtime config, settings, and tools. Child `.tau/config.json` files are not merged into the main composite session. A subagent launched in a member directory rebuilds only target-dependent prompt context there: environment and repository metadata, applicable `AGENTS.md` and target `agentContextFiles`, and target-discovered skills filtered by the parent persona.
+`subagents.defaultLaunchModels` sets the built-in `default` launch override allowlist. Tau writes it to root `.tau/config.json`; without `subagents`, the file is `{}`. Runtime config resolves and enforces entries. See [subagents](subagents.md) for model syntax and custom policy.
+
+The composite owns the parent persona, subagents, model catalog, config, settings, and tools. Child `.tau/config.json` files are not merged. A subagent in a member directory rebuilds only target context: environment and repository metadata, applicable `AGENTS.md` and `agentContextFiles`, and skills filtered by the parent persona.
 
 Composite preparation is all-or-nothing. If one member cannot be prepared, Tau removes the generated composite workspace. The composite's optional `workspaceRoot` controls the generated root; member repository caches continue to use each member's configured root or the top-level default.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -267,7 +267,7 @@ Repository projects need runner-side `gh`, Git, network access, and noninteracti
 
 Persistent-directory projects require the configured directory to exist and intentionally share it across sessions. Recovery rejects a stored `cwd` that differs from current configuration. Restore the mapping or create a new session in the new directory, rather than editing state.
 
-Tau reconstructs missing managed workspaces. New and reconstructed repositories may run executable `.tau/scripts/provision` asynchronously after the session is available; preserved workspaces skip it. Failure notifies chats but leaves the session usable. Fix the script or dependencies, then run it manually only when its contract allows, or create a fresh session to provision again.
+Tau reconstructs missing managed workspaces. A preserved repository or composite workspace is reused as-is: recovery does not reprovision it or rewrite generated composite metadata from the current Telegram project configuration. New and reconstructed repositories may run executable `.tau/scripts/provision` asynchronously after the session is available. Failure notifies chats but leaves the session usable. Fix the script or dependencies, then run it manually only when its contract allows, or create a fresh session to provision again.
 
 Recovery needs the same `workspaceRoot`, project definitions, host home, and Tau sessions. Inspect runner logs and `/status`. Do not edit runner state, project preferences, snapshots, or managed workspaces to force a match.
 

--- a/src/core/config/schema.ts
+++ b/src/core/config/schema.ts
@@ -152,6 +152,9 @@ export type TelegramCompositeProjectConfig = TelegramManagedProjectBaseConfig & 
   projectIds: string[];
   persona: string;
   instructions?: string;
+  subagents?: {
+    defaultLaunchModels?: string[];
+  };
 };
 
 export type TelegramProjectConfig =

--- a/src/core/telegram/config.ts
+++ b/src/core/telegram/config.ts
@@ -121,6 +121,16 @@ function createCompositeProjectSchema(configDir: string) {
       projectIds: stringListSchema.min(2, "must contain at least two project ids."),
       persona: z.string(),
       instructions: nonEmptyStringSchema.optional(),
+      subagents: z
+        .object({
+          defaultLaunchModels: z
+            .array(z.string(), {
+              message: "must be an array of strings.",
+            })
+            .optional(),
+        })
+        .strip()
+        .optional(),
     })
     .strip();
 }
@@ -298,9 +308,17 @@ function parseProject(
   }
 
   const incompatibleFields = hasRepo
-    ? ["directory", "projectIds", "instructions"]
+    ? ["directory", "projectIds", "instructions", "subagents"]
     : hasDirectory
-      ? ["repo", "ref", "workingDirectory", "workspaceRoot", "projectIds", "instructions"]
+      ? [
+          "repo",
+          "ref",
+          "workingDirectory",
+          "workspaceRoot",
+          "projectIds",
+          "instructions",
+          "subagents",
+        ]
       : ["repo", "directory", "ref", "workingDirectory", "noAgentContextFiles"];
   const configuredIncompatibleFields = incompatibleFields.filter((field) =>
     Object.hasOwn(rawObject.data, field),

--- a/src/core/telegram/workspace.ts
+++ b/src/core/telegram/workspace.ts
@@ -610,39 +610,6 @@ async function prepareRepositoryWorkspace(options: {
   return projectCwd;
 }
 
-async function pathIsFile(path: string): Promise<boolean> {
-  const stats = await stat(path).catch((error) => {
-    if (getErrorCode(error) === "ENOENT") {
-      return undefined;
-    }
-    throw error;
-  });
-  return stats?.isFile() ?? false;
-}
-
-async function collectMemberAgentContextFiles(options: {
-  workspacePath: string;
-  memberProjectId: string;
-  project: TelegramRepositoryProjectConfig;
-}): Promise<string[]> {
-  const memberPath = join(options.workspacePath, options.memberProjectId);
-  const candidates = [join(memberPath, "AGENTS.md")];
-  let currentPath = memberPath;
-
-  for (const segment of options.project.workingDirectory?.split(/[\\/]/).filter(Boolean) ?? []) {
-    currentPath = join(currentPath, segment);
-    candidates.push(join(currentPath, "AGENTS.md"));
-  }
-
-  const contextFiles: string[] = [];
-  for (const candidate of candidates) {
-    if (await pathIsFile(candidate)) {
-      contextFiles.push(relative(options.workspacePath, candidate));
-    }
-  }
-  return contextFiles;
-}
-
 function formatCompositeAgentsFile(options: {
   project: Extract<TelegramProjectConfig, { projectIds: string[] }>;
   projects: Record<string, TelegramProjectConfig>;
@@ -673,7 +640,7 @@ function formatCompositeAgentsFile(options: {
 
   lines.push(
     "",
-    "Each child directory is an independent Git repository. Instructions from AGENTS.md files inside each repository apply to work in that repository's subtree.",
+    "Each child directory is an independent Git repository. When asked to work in one or more repositories, read each relevant repository's root AGENTS.md file, if present, before making changes.",
   );
 
   if (options.project.instructions) {
@@ -688,27 +655,13 @@ async function writeCompositeWorkspaceFiles(options: {
   project: Extract<TelegramProjectConfig, { projectIds: string[] }>;
   projects: Record<string, TelegramProjectConfig>;
 }): Promise<void> {
-  const agentContextFiles: string[] = [];
-  for (const memberProjectId of options.project.projectIds) {
-    const memberProject = options.projects[memberProjectId];
-    if (!memberProject || !isRepositoryProject(memberProject)) {
-      throw new Error(`composite project references invalid member '${memberProjectId}'`);
-    }
-    agentContextFiles.push(
-      ...(await collectMemberAgentContextFiles({
-        workspacePath: options.workspacePath,
-        memberProjectId,
-        project: memberProject,
-      })),
-    );
-  }
-
+  const config = options.project.subagents ? { subagents: options.project.subagents } : {};
   await mkdir(join(options.workspacePath, ".tau"), { recursive: true });
   await Promise.all([
     writeFile(join(options.workspacePath, "AGENTS.md"), formatCompositeAgentsFile(options), "utf8"),
     writeFile(
       join(options.workspacePath, ".tau", "config.json"),
-      `${JSON.stringify({ agentContextFiles }, null, 2)}\n`,
+      `${JSON.stringify(config, null, 2)}\n`,
       "utf8",
     ),
   ]);

--- a/test/telegram_cli.test.js
+++ b/test/telegram_cli.test.js
@@ -126,6 +126,9 @@ describe("telegram cli", () => {
           projectIds: ["tau", "cowork"],
           persona: "gpt-5.6-sol-coder:high",
           instructions: "Keep changes coordinated.",
+          subagents: {
+            defaultLaunchModels: ["openai/gpt-5.6-sol:high"],
+          },
         },
       },
     });
@@ -134,7 +137,24 @@ describe("telegram cli", () => {
       projectIds: ["tau", "cowork"],
       persona: "gpt-5.6-sol-coder:high",
       instructions: "Keep changes coordinated.",
+      subagents: {
+        defaultLaunchModels: ["openai/gpt-5.6-sol:high"],
+      },
     });
+  });
+
+  it("rejects subagent launch models on repository projects", () => {
+    const { path } = writeConfig({
+      bots: { ops: { botToken: "token" } },
+      projects: {
+        me: {
+          repo: "owner/repo",
+          subagents: { defaultLaunchModels: ["openai/gpt-5.6-sol:high"] },
+        },
+      },
+    });
+
+    expect(() => loadTelegramConfig(path)).toThrow("projects.me does not support subagents");
   });
 
   it("rejects project ids that cannot be Telegram command suffixes", () => {

--- a/test/telegram_workspace.test.js
+++ b/test/telegram_workspace.test.js
@@ -228,11 +228,8 @@ describe("telegram workspace", () => {
           const cachePath = commandArgs[2];
           const memberPath = commandArgs[3];
           await mkdir(memberPath, { recursive: true });
-          await writeFile(join(memberPath, "AGENTS.md"), "member instructions");
           if (cachePath.endsWith("cowork.git")) {
             await mkdir(join(memberPath, "packages", "core"), { recursive: true });
-            await writeFile(join(memberPath, "packages", "AGENTS.md"), "package instructions");
-            await writeFile(join(memberPath, "packages", "core", "AGENTS.md"), "core instructions");
           }
           return { exitCode: 0, output: "cloned from cache" };
         }
@@ -282,21 +279,42 @@ describe("telegram workspace", () => {
 
     expect(
       JSON.parse(await readFile(join(result.workspacePath, ".tau", "config.json"), "utf8")),
-    ).toEqual({
-      agentContextFiles: [
-        "tau/AGENTS.md",
-        "cowork/AGENTS.md",
-        "cowork/packages/AGENTS.md",
-        "cowork/packages/core/AGENTS.md",
-      ],
-    });
+    ).toEqual({});
     const agents = await readFile(join(result.workspacePath, "AGENTS.md"), "utf8");
     expect(agents).toContain("This workspace contains multiple independent Git repositories:");
     expect(agents).not.toContain("Telegram");
     expect(agents).toContain("`tau/`: repository `owner/tau`");
     expect(agents).toContain("`cowork/`: repository `owner/cowork`, ref `main`");
+    expect(agents).toContain(
+      "When asked to work in one or more repositories, read each relevant repository's root AGENTS.md file, if present, before making changes.",
+    );
     expect(agents).toContain("Coordinate changes across both repositories.");
     expect(agents).not.toContain("report verification");
+
+    const configuredProject = {
+      ...projects.platform,
+      subagents: {
+        defaultLaunchModels: ["openai/gpt-5.6-sol:high", "anthropic/claude-haiku-4-5:low"],
+      },
+    };
+    const configuredResult = await prepareWorkspace({
+      sessionId: "def67890",
+      projectId: "platform",
+      project: configuredProject,
+      projects: { ...projects, platform: configuredProject },
+      workspaceRoot,
+      defaultWorkspaceRoot: workspaceRoot,
+    });
+
+    expect(
+      JSON.parse(
+        await readFile(join(configuredResult.workspacePath, ".tau", "config.json"), "utf8"),
+      ),
+    ).toEqual({
+      subagents: {
+        defaultLaunchModels: ["openai/gpt-5.6-sol:high", "anthropic/claude-haiku-4-5:low"],
+      },
+    });
   });
 
   it("removes a composite workspace when member preparation fails", async () => {


### PR DESCRIPTION
## why

Composite workspaces currently inject every discovered member `AGENTS.md` into the parent session, even before work targets that repository. Composite projects also need a project-scoped way to allow model overrides for the built-in default subagent.

## what

Generate an empty composite root config by default and instruct the agent to read each relevant repository's root `AGENTS.md` before making changes. Add composite-only `subagents.defaultLaunchModels` configuration and write it through to the generated root config so the normal Tau runtime owns model resolution and enforcement.

Update Telegram configuration validation, workspace coverage, and public documentation for the new contract.
