### PR TITLE
make session snapshots projection-owned

### DIFF
--- a/src/host/local_session_host.ts
+++ b/src/host/local_session_host.ts
@@ -261,9 +261,7 @@ export class LocalSessionHost implements TauSessionHost {
           ? { usageCheckpoint: { ...recovered.snapshot.agentState.usageCheckpoint } }
           : {}),
       });
-      if (recovered.changed || agentRecovery.recoveredToolResults.length > 0) {
-        await hostedSession.persistRecoveredAgentState(agentRecovery);
-      }
+      await hostedSession.reconcileRecoveredState(agentRecovery);
       return hostedSession;
     } catch (error) {
       if (hostedSession) {
@@ -670,7 +668,7 @@ function normalizeDeltaCause(cause: LocalDeltaCause): SessionProtocolDeltaCause 
 
 class LocalHostedSessionHandle implements LocalHostedSession {
   readonly session: ChatRuntime;
-  private committedSnapshot?: SessionProtocolSnapshot;
+  private committedSnapshot: SessionProtocolSnapshot;
   private persistedSnapshot?: SessionProtocolSnapshot;
   private draftAssistantMessage?: SessionProtocolMessage;
   private readonly messageStates = new Map<string, SessionProtocolMessage["state"]>();
@@ -734,15 +732,15 @@ class LocalHostedSessionHandle implements LocalHostedSession {
     private readonly removeFromHost: (session: LocalHostedSessionHandle) => void = () => {},
   ) {
     this.session = runtime;
-    this.committedSnapshot = committedSnapshot
-      ? cloneSessionProtocolSnapshot(committedSnapshot)
-      : undefined;
     this.persistedSnapshot = committedSnapshot
       ? cloneSessionProtocolSnapshot(committedSnapshot)
       : undefined;
     this.goal = structuredClone(committedSnapshot?.goal ?? null);
     this.forceNextSnapshotRevision = forceNextSnapshotRevision;
     this.restoreProtocolState(committedSnapshot);
+    this.committedSnapshot = committedSnapshot
+      ? cloneSessionProtocolSnapshot(committedSnapshot)
+      : { ...this.buildSnapshotDraft(), revision: 1 };
   }
 
   getRemoteModelCatalog(): RemoteModelCatalogSnapshot {
@@ -1258,13 +1256,11 @@ class LocalHostedSessionHandle implements LocalHostedSession {
   async setReasoning(reasoning: ReasoningEffort): Promise<SessionProtocolSettingsUpdateResult> {
     this.assertActive();
     return await this.enqueueMutation(async () => {
-      const fromRevision = this.committedSnapshot?.revision;
+      const fromRevision = this.committedSnapshot.revision;
       this.runtime.setReasoning(reasoning);
       this.bootstrap.persona.settings.reasoning = reasoning;
       const snapshot = await this.commitSnapshot();
-      if (fromRevision === undefined) {
-        this.emitSnapshotReset("configuration", snapshot);
-      } else if (snapshot.revision !== fromRevision) {
+      if (snapshot.revision !== fromRevision) {
         this.emitDelta(
           createSessionProtocolDeltaMessage({
             sessionId: snapshot.sessionId,
@@ -1599,14 +1595,10 @@ class LocalHostedSessionHandle implements LocalHostedSession {
 
   async snapshot(): Promise<SessionProtocolSnapshot> {
     this.assertActive();
-    return await this.enqueueMutation(async () =>
-      this.runtime.isTurnRunning && this.committedSnapshot
-        ? await this.commitProjectedSnapshot()
-        : await this.commitSnapshot(),
-    );
+    return await this.enqueueMutation(() => this.commitProjectedSnapshot());
   }
 
-  async persistRecoveredAgentState(recovery: AgentStateRecovery): Promise<void> {
+  async reconcileRecoveredState(recovery: AgentStateRecovery): Promise<void> {
     this.assertActive();
     await this.enqueueMutation(async () => {
       const recoveredTools: Array<{
@@ -1849,7 +1841,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
       if (options.removeMissingAgents) {
         this.removeMissingSubagentActivities();
       }
-      return cloneSessionProtocolSnapshot(this.committedSnapshot ?? snapshot);
+      return cloneSessionProtocolSnapshot(this.committedSnapshot);
     }
 
     await this.store.commitSessionSnapshot(snapshot, {
@@ -1865,11 +1857,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
 
   private async commitProjectedSnapshot(): Promise<SessionProtocolSnapshot> {
     this.assertNotDisposed();
-    const current = this.committedSnapshot;
-    if (!current) {
-      return await this.commitSnapshot();
-    }
-    const snapshot = cloneSessionProtocolSnapshot(current);
+    const snapshot = cloneSessionProtocolSnapshot(this.committedSnapshot);
     if (this.persistedSnapshot && isDeepStrictEqual(this.persistedSnapshot, snapshot)) {
       return snapshot;
     }
@@ -1887,10 +1875,6 @@ class LocalHostedSessionHandle implements LocalHostedSession {
   ): Promise<SessionProtocolDeltaMessage> {
     this.assertNotDisposed();
     const current = this.committedSnapshot;
-    if (!current) {
-      throw new Error("cannot persist a session patch without a committed snapshot");
-    }
-
     const delta = createSessionProtocolDeltaMessage({
       sessionId: current.sessionId,
       fromRevision: current.revision,
@@ -2212,10 +2196,6 @@ class LocalHostedSessionHandle implements LocalHostedSession {
   private nextSnapshotRevision(
     next: Omit<SessionProtocolSnapshot, "revision">,
   ): SessionProtocolSnapshot["revision"] {
-    if (!this.committedSnapshot) {
-      return 1;
-    }
-
     if (this.forceNextSnapshotRevision) {
       this.forceNextSnapshotRevision = false;
       return this.committedSnapshot.revision + 1;
@@ -2272,7 +2252,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
     resultHistoryEntryId: string,
     result: Extract<AgentEvent, { type: "tool_result" }>["message"],
   ): Promise<void> {
-    const callMessage = this.committedSnapshot?.messages.find(
+    const callMessage = this.committedSnapshot.messages.find(
       (message) => message.id === tool.call.messageId,
     );
     const call =
@@ -2566,7 +2546,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
               message: event.message,
             },
           },
-          ...(this.committedSnapshot?.lifecycle !== lifecycle
+          ...(this.committedSnapshot.lifecycle !== lifecycle
             ? [{ type: "lifecycle.set" as const, lifecycle }]
             : []),
           ...toolChanges,
@@ -2993,17 +2973,6 @@ class LocalHostedSessionHandle implements LocalHostedSession {
     if (changes.length === 0) {
       return;
     }
-    if (!this.committedSnapshot) {
-      if (options.persist === false) {
-        const snapshot = { ...this.buildSnapshotDraft(), revision: 1 };
-        this.committedSnapshot = snapshot;
-        this.emitSnapshotReset(cause, snapshot);
-        return;
-      }
-      const snapshot = await this.commitSnapshot();
-      this.emitSnapshotReset(cause, snapshot);
-      return;
-    }
     if (options.persist !== false) {
       this.emitDelta(await this.commitSnapshotPatch(cause, changes));
       return;
@@ -3037,7 +3006,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
   }
 
   private async emitSnapshotResetIfChanged(cause: LocalDeltaCause): Promise<void> {
-    const previousRevision = this.committedSnapshot?.revision;
+    const previousRevision = this.committedSnapshot.revision;
     const snapshot = await this.commitSnapshot();
     if (snapshot.revision !== previousRevision) {
       this.emitSnapshotReset(cause, snapshot);

--- a/src/host/local_session_host.ts
+++ b/src/host/local_session_host.ts
@@ -710,6 +710,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
   private goal: SessionProtocolGoal | null;
   private pendingGoalCommit?: SessionProtocolGoal;
   private forceNextSnapshotRevision: boolean;
+  private projectionFailure?: Error;
   private disposed = false;
 
   constructor(
@@ -1255,7 +1256,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
 
   async setReasoning(reasoning: ReasoningEffort): Promise<SessionProtocolSettingsUpdateResult> {
     this.assertActive();
-    return await this.enqueueMutation(async () => {
+    return await this.enqueueConfigurationMutation(async () => {
       const fromRevision = this.committedSnapshot.revision;
       this.runtime.setReasoning(reasoning);
       this.bootstrap.persona.settings.reasoning = reasoning;
@@ -1302,7 +1303,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
       includeAgentContext: this.includeAgentContext,
       agentContextFiles: runtimeConfig.config.agentContextFiles ?? [],
     });
-    return await this.enqueueMutation(async () => {
+    return await this.enqueueConfigurationMutation(async () => {
       this.runtime.setRuntimeConfig(
         runtimeConfig.config,
         runtimeConfig.bootstrap.modelResolver.resolveModel,
@@ -1352,7 +1353,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
       agentContextFiles: runtimeConfig.config.agentContextFiles ?? [],
     });
 
-    return await this.enqueueMutation(async () => {
+    return await this.enqueueConfigurationMutation(async () => {
       this.runtime.setRuntimeConfig(
         runtimeConfig.config,
         runtimeConfig.bootstrap.modelResolver.resolveModel,
@@ -1449,20 +1450,22 @@ class LocalHostedSessionHandle implements LocalHostedSession {
   async compact(
     options: Omit<SessionProtocolCompactParams, "sessionId">,
   ): Promise<SessionProtocolCompactResult> {
-    return await this.runMaintenance(async (signal) => {
-      const result = await this.session.compact({
-        mode: options.mode === "summary-only" ? "only-summary" : "with-last-assistant",
-        ...(options.guidance !== undefined ? { guidance: options.guidance } : {}),
-        signal,
-      });
+    return await this.runAgentStateMutation(() =>
+      this.runMaintenance(async (signal) => {
+        const result = await this.session.compact({
+          mode: options.mode === "summary-only" ? "only-summary" : "with-last-assistant",
+          ...(options.guidance !== undefined ? { guidance: options.guidance } : {}),
+          signal,
+        });
 
-      signal.throwIfAborted();
-      return {
-        snapshot: await this.snapshot(),
-        compactionMessage: result.compactionMessage,
-        includedLastAssistant: result.includedLastAssistant,
-      };
-    });
+        signal.throwIfAborted();
+        return {
+          snapshot: await this.snapshot(),
+          compactionMessage: result.compactionMessage,
+          includedLastAssistant: result.includedLastAssistant,
+        };
+      }),
+    );
   }
 
   private async runMaintenance<T>(operation: (signal: AbortSignal) => Promise<T>): Promise<T> {
@@ -1521,15 +1524,17 @@ class LocalHostedSessionHandle implements LocalHostedSession {
     ) {
       throw new Error("rewind failed");
     }
-    const result = await this.session.rewindToHistoryEntryId(historyEntryId);
-    if (!result) {
-      throw new Error("rewind failed");
-    }
+    return await this.runAgentStateMutation(async () => {
+      const result = await this.session.rewindToHistoryEntryId(historyEntryId);
+      if (!result) {
+        throw new Error("rewind failed");
+      }
 
-    return {
-      snapshot: await this.snapshot(),
-      ...result,
-    };
+      return {
+        snapshot: await this.snapshot(),
+        ...result,
+      };
+    });
   }
 
   async interruptSubagent(subagentId: string): Promise<SessionProtocolInterruptSubagentResult> {
@@ -2160,17 +2165,37 @@ class LocalHostedSessionHandle implements LocalHostedSession {
     }
   }
 
+  private async enqueueConfigurationMutation<T>(mutation: () => Promise<T>): Promise<T> {
+    try {
+      return await this.enqueueMutation(mutation);
+    } catch (error) {
+      this.invalidateProjection(error);
+      throw error;
+    }
+  }
+
+  private async runAgentStateMutation<T>(mutation: () => Promise<T>): Promise<T> {
+    const runtimeState = this.runtime.snapshot();
+    try {
+      return await mutation();
+    } catch (error) {
+      if (!isDeepStrictEqual(this.runtime.snapshot(), runtimeState)) {
+        this.invalidateProjection(error);
+      }
+      throw error;
+    }
+  }
+
   private enqueueMutation<T>(mutation: () => Promise<T> | T): Promise<T> {
     const result = this.mutationQueue
       .catch(() => undefined)
       .then(async () => {
+        this.assertProjectionValid();
         try {
           return await mutation();
         } catch (error) {
-          if (this.committedSnapshot) {
-            this.goal = structuredClone(this.committedSnapshot.goal);
-            this.restoreProtocolState(this.committedSnapshot);
-          }
+          this.goal = structuredClone(this.committedSnapshot.goal);
+          this.restoreProtocolState(this.committedSnapshot);
           throw error;
         }
       });
@@ -2181,16 +2206,30 @@ class LocalHostedSessionHandle implements LocalHostedSession {
     return result;
   }
 
+  private invalidateProjection(error: unknown): void {
+    this.projectionFailure ??= new Error("session state is inconsistent after a failed mutation", {
+      cause: error,
+    });
+  }
+
+  private assertProjectionValid(): void {
+    if (this.projectionFailure) {
+      throw this.projectionFailure;
+    }
+  }
+
   private assertActive(): void {
     if (this.disposing || this.disposed) {
       throw new Error(`session is shut down: ${this.sessionId}`);
     }
+    this.assertProjectionValid();
   }
 
   private assertNotDisposed(): void {
     if (this.disposed) {
       throw new Error(`session is shut down: ${this.sessionId}`);
     }
+    this.assertProjectionValid();
   }
 
   private nextSnapshotRevision(
@@ -3085,7 +3124,9 @@ class LocalHostedSessionHandle implements LocalHostedSession {
     }
 
     const interruptedMessage = createInterruptedAssistantMessage(draft, this.runtime.persona.model);
-    await this.session.commitInterruptedAssistant(interruptedMessage, draft.id);
+    await this.runAgentStateMutation(() =>
+      this.session.commitInterruptedAssistant(interruptedMessage, draft.id),
+    );
   }
 
   private async cleanupFailedTurn(

--- a/test/local_session_host.test.js
+++ b/test/local_session_host.test.js
@@ -655,6 +655,43 @@ describe("LocalSessionHost", () => {
     await host.shutdown();
   });
 
+  it("does not rebuild a snapshot from a user message awaiting event projection", async () => {
+    const store = new BlockingCommitStore();
+    const host = createHost(store);
+    const session = await host.createSession(localCreateInput);
+
+    const gate = store.blockNextCommit();
+    const settings = session.setReasoning("high");
+    await gate.started;
+
+    const concurrentSnapshot = session.snapshot();
+    const acceptance = session.acceptTurn({
+      text: "queue after the previous turn",
+      historyEntryId: "queued-turn",
+    });
+
+    gate.release();
+    await settings;
+
+    await expect(concurrentSnapshot).resolves.toMatchObject({
+      messages: [expect.objectContaining({ id: "system" })],
+      turns: {},
+    });
+    await expect(acceptance).resolves.toMatchObject({
+      userHistoryEntryId: "queued-turn",
+      snapshot: {
+        messages: expect.arrayContaining([expect.objectContaining({ id: "queued-turn" })]),
+        turns: {
+          "queued-turn": {
+            userHistoryEntryId: "queued-turn",
+            state: "running",
+          },
+        },
+      },
+    });
+    await host.shutdown();
+  });
+
   it.each([
     {
       label: "failed",
@@ -1057,7 +1094,7 @@ describe("LocalSessionHost", () => {
     await expect(hostedSession.snapshot()).resolves.toEqual(
       expect.objectContaining({
         sessionId: hostedSession.session.sessionId,
-        revision: 1,
+        revision: 2,
         lifecycle: "idle",
         settings: expectedSettings(),
         bootstrap: {
@@ -1093,18 +1130,18 @@ describe("LocalSessionHost", () => {
       }),
     );
     await expect(hostedSession.snapshot()).resolves.toEqual(
-      expect.objectContaining({ revision: 1 }),
+      expect.objectContaining({ revision: 2 }),
     );
     await hostedSession.session.commitUserText("next");
     await expect(hostedSession.snapshot()).resolves.toEqual(
-      expect.objectContaining({ revision: 2 }),
+      expect.objectContaining({ revision: 3 }),
     );
 
     const returnedSnapshot = await hostedSession.snapshot();
     returnedSnapshot.messages[1].message.content[0].text = "mutated outside";
     await expect(hostedSession.snapshot()).resolves.toEqual(
       expect.objectContaining({
-        revision: 2,
+        revision: 3,
         messages: expect.arrayContaining([
           expect.objectContaining({
             id: "system",
@@ -3032,10 +3069,10 @@ describe("LocalSessionHost", () => {
     await hostedSession.session.commitUserText("hello");
 
     await expect(hostedSession.snapshot()).resolves.toEqual(
-      expect.objectContaining({ revision: 1 }),
+      expect.objectContaining({ revision: 2 }),
     );
     await expect(hostedSession.snapshot()).resolves.toEqual(
-      expect.objectContaining({ revision: 1 }),
+      expect.objectContaining({ revision: 2 }),
     );
     await expect(host.observeSession(hostedSession.session.sessionId)).resolves.toBe(hostedSession);
     await expect(host.listSessions()).resolves.toEqual([
@@ -3045,7 +3082,7 @@ describe("LocalSessionHost", () => {
 
     await hostedSession.session.commitUserText("next");
     await expect(hostedSession.snapshot()).resolves.toEqual(
-      expect.objectContaining({ revision: 2 }),
+      expect.objectContaining({ revision: 3 }),
     );
     expect(store.commitSessionSnapshot).toHaveBeenCalledTimes(2);
   });
@@ -3235,13 +3272,13 @@ describe("LocalSessionHost", () => {
     await expect(
       Promise.all([hostedSession.snapshot(), hostedSession.snapshot(), hostedSession.snapshot()]),
     ).resolves.toEqual([
-      expect.objectContaining({ revision: 1 }),
-      expect.objectContaining({ revision: 1 }),
-      expect.objectContaining({ revision: 1 }),
+      expect.objectContaining({ revision: 2 }),
+      expect.objectContaining({ revision: 2 }),
+      expect.objectContaining({ revision: 2 }),
     ]);
 
     await expect(store.loadSession(hostedSession.session.sessionId)).resolves.toEqual(
-      expect.objectContaining({ revision: 1 }),
+      expect.objectContaining({ revision: 2 }),
     );
   });
 

--- a/test/local_session_host.test.js
+++ b/test/local_session_host.test.js
@@ -2356,6 +2356,31 @@ describe("LocalSessionHost", () => {
     await host.shutdown();
   });
 
+  it("invalidates the session when rewind persistence fails after runtime mutation", async () => {
+    const store = new MemorySessionStore();
+    const host = createHost(store);
+    const hostedSession = await host.createSession(localCreateInput);
+    const historyEntryId = await hostedSession.session.commitUserText("rewind me");
+    const persisted = await hostedSession.snapshot();
+    const commitSessionSnapshot = vi.spyOn(store, "commitSessionSnapshot");
+
+    commitSessionSnapshot.mockRejectedValueOnce(new Error("rewind persistence failed"));
+    await expect(hostedSession.rewindToHistoryEntryId(historyEntryId)).rejects.toThrow(
+      "rewind persistence failed",
+    );
+
+    expect(hostedSession.runtime.rawHistoryEntries).toEqual([]);
+    await expect(hostedSession.snapshot()).rejects.toThrow(
+      "session state is inconsistent after a failed mutation",
+    );
+    await expect(hostedSession.record({ text: "must not persist" })).rejects.toThrow(
+      "session state is inconsistent after a failed mutation",
+    );
+    await expect(store.loadSession(hostedSession.sessionId)).resolves.toEqual(persisted);
+    await hostedSession.dispose();
+    await host.shutdown();
+  });
+
   it("truncates timeline notices after the rewound message", async () => {
     const host = createHost(new MemorySessionStore());
     const hostedSession = await host.createSession(localCreateInput);
@@ -3737,6 +3762,27 @@ describe("LocalSessionHost", () => {
     );
     expect(hostedSession.subagentActivities()).toEqual(activityState);
     expect(activityMessages).toEqual([]);
+  });
+
+  it("invalidates the session when configuration persistence fails after runtime mutation", async () => {
+    const store = new MemorySessionStore();
+    const host = createHost(store);
+    const hostedSession = await host.createSession(localCreateInput);
+    const persisted = await hostedSession.snapshot();
+    const commitSessionSnapshot = vi.spyOn(store, "commitSessionSnapshot");
+
+    commitSessionSnapshot.mockRejectedValueOnce(new Error("configuration persistence failed"));
+    await expect(hostedSession.setReasoning("high")).rejects.toThrow(
+      "configuration persistence failed",
+    );
+
+    expect(hostedSession.runtime.persona.settings.reasoning).toBe("high");
+    await expect(hostedSession.snapshot()).rejects.toThrow(
+      "session state is inconsistent after a failed mutation",
+    );
+    await expect(store.loadSession(hostedSession.sessionId)).resolves.toEqual(persisted);
+    await hostedSession.dispose();
+    await host.shutdown();
   });
 
   it("does not let a reasoning write replace streamed state at the same revision", async () => {


### PR DESCRIPTION
## why

Queued user-message acceptance mutates agent history before its awaited semantic event is projected by the host. Ordinary snapshot refreshes rebuilt from that live history whenever the runtime appeared idle, so a refresh could commit the message without its turn and timeline state, then reject the event's canonical `message.append` as a duplicate.

Persistence failures could also roll protocol state back while runtime-owned rewind, compaction, interrupted-message, or configuration mutations remained applied. Serving snapshots after that divergence could combine stale transcript state with newer runtime revisions.

## what

- Make the host's committed protocol projection authoritative for every ordinary snapshot refresh.
- Initialize new hosted sessions with a canonical in-memory projection instead of treating projection state as optional.
- Keep full runtime reconciliation at explicit host-owned transitions, and reconcile restored runtime state eagerly at the recovery boundary.
- Fail closed when a failed runtime-owning transition leaves runtime state ahead of the committed projection.
- Add deterministic regressions for queued event projection and failed rewind/configuration persistence.

## details

New sessions now begin with a revision 1 system-only projection, so the first user-message event advances the snapshot to revision 2. Protocol revisions are opaque ordering values, and this gives snapshots a valid source of truth before any runtime event can race with them.

Runtime-owning operations now guard their failure boundaries. Configuration mutations invalidate the live handle when their queued commit fails. Rewind, compaction, and interrupted-assistant mutations compare agent state before and after failure and invalidate only when runtime state changed. Invalidated handles reject later snapshots and mutations, preserving the last committed store state for explicit disposal and recovery.

There are no remaining questions.

fixes #460
