### PR TITLE
allow ephemeral reasoning overrides

### DIFF
--- a/docs/node-sdk.md
+++ b/docs/node-sdk.md
@@ -203,6 +203,8 @@ Each subscription returns an unsubscribe function.
 
 `submit`, `queue`, and `record` accept `{ historyEntryId?: string }`. When omitted, Tau generates the user history id. Use `getTauSdkSessionTurnRecord(snapshot, id)` to distinguish unknown, running, and settled accepted turns, or `getTauSdkSessionTurnOutcome(snapshot, id)` when only a settled outcome matters.
 
+`createEphemeralContext` and `submitEphemeralThread` accept an optional `reasoning` effort. A context inherits the parent session agent's current effort when creation omits it. A submission override becomes that thread's current effort before its turn; forks inherit the source thread's effort before applying an override.
+
 ### Execute a command
 
 `exec` generates a unique wire-level execution id and supports exact positional arguments, environment overrides other than `HOME`, binary stdin, a command `cwd`, timeout, capture limit, and cancellation signal:

--- a/docs/session-protocol-methods.md
+++ b/docs/session-protocol-methods.md
@@ -504,13 +504,14 @@ params: {
   sessionId: string;
   instructions: string;
   tools: Array<"bash" | "write" | "edit" | "view_image" | "web">;
+  reasoning?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 }
 result: {
   contextId: string;
 }
 ```
 
-The context uses the hosted session's persona and execution environment plus the supplied instructions and exact tool set. It is not recoverable after host restart.
+The context uses the hosted session's persona and execution environment plus the supplied instructions and exact tool set. `reasoning` sets the initial effort for new threads. When omitted, the context captures the parent session agent's current effective effort. Later parent setting changes do not affect the context. It is not recoverable after host restart.
 
 ### `session.ephemeral.submit`
 
@@ -523,11 +524,12 @@ params: {
   threadId: string;
   forkFromThreadId?: string;
   message: string;
+  reasoning?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 }
 result: { threadId: string; response: string }
 ```
 
-`forkFromThreadId` creates a new thread from an idle thread in the same context. Overlapping submissions to the same thread return `busy`; independent threads can run concurrently.
+`reasoning` updates the target thread before running the submitted message and remains active for later submissions. When omitted, the thread retains its current effort. `forkFromThreadId` creates a new thread from an idle thread in the same context, including its current reasoning effort; a submit-time `reasoning` value overrides only the new fork. Overlapping submissions to the same thread return `busy`; independent threads can run concurrently.
 
 ### `session.ephemeral.close`
 

--- a/src/host/hosted_ephemeral_agent_session.ts
+++ b/src/host/hosted_ephemeral_agent_session.ts
@@ -14,7 +14,7 @@ import { composeSessionPrompts } from "../core/runtime/session_prompt_composer.j
 import { createAutoCompactionArchiver } from "../core/session/auto_compaction_archive.js";
 import type { SubagentToolName } from "../core/subagents/types.js";
 import { ToolCatalog } from "../core/tools/catalog.js";
-import type { Persona, Skill } from "../core/types.js";
+import type { Persona, ReasoningEffort, Skill } from "../core/types.js";
 import {
   appendUsageLogEntry,
   getUsageCostTotal,
@@ -67,6 +67,7 @@ export type HostedEphemeralAgentSessionOptions = {
   executionEnvironment: ExecutionEnvironment;
   instructions: string;
   tools: SubagentToolName[];
+  reasoning: ReasoningEffort;
   emitUpdate: (
     threadId: string,
     update: SessionProtocolEphemeralAgentThreadUpdateEvent["update"],
@@ -104,6 +105,7 @@ export class HostedEphemeralAgentSession {
     this.activeThreadIds.add(options.threadId);
     try {
       const thread = await this.getOrCreateThread(options.threadId, options.forkFromThreadId);
+      if (options.reasoning !== undefined) thread.setReasoning(options.reasoning);
       return { threadId: options.threadId, response: await thread.submitMessage(options.message) };
     } finally {
       this.activeThreadIds.delete(options.threadId);
@@ -162,6 +164,7 @@ export class HostedEphemeralAgentSession {
       persona: this.options.persona,
       systemPrompt: [composition.baseSystemPrompt, this.options.instructions].join("\n\n"),
       config: this.options.config,
+      reasoning: this.options.reasoning,
       deps,
       backend: this.options.executionEnvironment.getToolExecutionBackend(),
       tools: this.options.tools,
@@ -182,6 +185,7 @@ type EphemeralAgentThreadOptions = {
   persona: Persona;
   systemPrompt: string;
   config: Config;
+  reasoning: ReasoningEffort;
   deps: ReturnType<typeof createDefaultCoreDeps>;
   backend: ReturnType<ExecutionEnvironment["getToolExecutionBackend"]>;
   tools: SubagentToolName[];
@@ -204,7 +208,12 @@ class EphemeralAgentThread {
       options.forkFrom?.spec ??
       createAgentSpec({
         ...resolveAgentModel(
-          createEphemeralPersona(options.persona, options.systemPrompt, options.tools),
+          createEphemeralPersona(
+            options.persona,
+            options.systemPrompt,
+            options.tools,
+            options.reasoning,
+          ),
           options.config,
           { includeModelNotice: false, deps: options.deps },
         ),
@@ -242,6 +251,15 @@ class EphemeralAgentThread {
     if (options.forkFrom) {
       this.onUpdate?.({ costTotal: this.costTotal, usage: { ...this.usage } });
     }
+  }
+
+  setReasoning(reasoning: ReasoningEffort): void {
+    const spec = this.runtime.spec;
+    this.runtime.updateSpec({
+      ...spec,
+      attribution: { ...spec.attribution, reasoningEffort: reasoning },
+      streamOptions: { ...spec.streamOptions, reasoning },
+    });
   }
 
   async submitMessage(message: string): Promise<string> {
@@ -337,6 +355,7 @@ function createEphemeralPersona(
   persona: Persona,
   systemPrompt: string,
   tools: SubagentToolName[],
+  reasoning: ReasoningEffort,
 ): Persona {
   return {
     ...structuredClone(persona),
@@ -344,6 +363,7 @@ function createEphemeralPersona(
     label: `${persona.label} ephemeral`,
     description: "Ephemeral assistant",
     systemPrompt,
+    settings: { ...persona.settings, reasoning },
     subagents: undefined,
     tools,
   };

--- a/src/host/local_session_host.ts
+++ b/src/host/local_session_host.ts
@@ -1558,6 +1558,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
       executionEnvironment: this.executionEnvironment,
       instructions: options.instructions,
       tools: options.tools,
+      reasoning: options.reasoning ?? this.runtime.agent.spec.attribution.reasoningEffort,
       recordUsage: this.recordUsage,
       emitUpdate: (threadId, update) => {
         this.emitEphemeral(

--- a/src/host/session_protocol_handler.ts
+++ b/src/host/session_protocol_handler.ts
@@ -1427,6 +1427,7 @@ export class SessionProtocolHandler {
     const result = await state.session.createEphemeralContext({
       instructions: request.params.instructions,
       tools: request.params.tools,
+      ...(request.params.reasoning !== undefined ? { reasoning: request.params.reasoning } : {}),
     });
     this.sendMessage(
       createSessionProtocolSuccessResponse(request.id, "session.ephemeral.create", result),
@@ -1450,6 +1451,7 @@ export class SessionProtocolHandler {
           ? { forkFromThreadId: request.params.forkFromThreadId }
           : {}),
         message: request.params.message,
+        ...(request.params.reasoning !== undefined ? { reasoning: request.params.reasoning } : {}),
       });
       this.sendMessage(
         createSessionProtocolSuccessResponse(request.id, "session.ephemeral.submit", result),

--- a/src/protocol/session_protocol.ts
+++ b/src/protocol/session_protocol.ts
@@ -236,12 +236,14 @@ export type SessionProtocolEphemeralAgentTool = "bash" | "write" | "edit" | "vie
 export type SessionProtocolEphemeralCreateParams = SessionProtocolSessionIdParams & {
   instructions: string;
   tools: SessionProtocolEphemeralAgentTool[];
+  reasoning?: SessionProtocolReasoningEffort;
 };
 export type SessionProtocolEphemeralSubmitParams = SessionProtocolSessionIdParams & {
   contextId: string;
   threadId: string;
   forkFromThreadId?: string;
   message: string;
+  reasoning?: SessionProtocolReasoningEffort;
 };
 export type SessionProtocolEphemeralCloseParams = SessionProtocolSessionIdParams & {
   contextId: string;
@@ -1910,6 +1912,7 @@ const sessionProtocolEphemeralCreateParamsSchema = z
     sessionId: nonEmptyStringSchema,
     instructions: nonEmptyStringSchema,
     tools: z.array(sessionProtocolEphemeralAgentToolSchema),
+    reasoning: sessionProtocolReasoningEffortSchema.optional(),
   })
   .strip();
 
@@ -1920,6 +1923,7 @@ const sessionProtocolEphemeralSubmitParamsSchema = z
     threadId: nonEmptyStringSchema,
     forkFromThreadId: nonEmptyStringSchema.optional(),
     message: nonEmptyStringSchema,
+    reasoning: sessionProtocolReasoningEffortSchema.optional(),
   })
   .strip();
 
@@ -5134,7 +5138,9 @@ function validateEphemeralCreateParams(
           ? "session.ephemeral.create params.instructions must be a non-empty string"
           : hasIssue(parsed.error, ["tools"])
             ? "session.ephemeral.create params.tools are invalid"
-            : `session.ephemeral.create params are invalid: ${formatZodError(parsed.error)}`;
+            : hasIssue(parsed.error, ["reasoning"])
+              ? "session.ephemeral.create params.reasoning must be one of none, minimal, low, medium, high, xhigh, or max when provided"
+              : `session.ephemeral.create params are invalid: ${formatZodError(parsed.error)}`;
     return invalidParams(message);
   }
 
@@ -5158,7 +5164,9 @@ function validateEphemeralSubmitParams(
               ? "session.ephemeral.submit params.forkFromThreadId must be a non-empty string when provided"
               : hasIssue(parsed.error, ["message"])
                 ? "session.ephemeral.submit params.message must be a non-empty string"
-                : `session.ephemeral.submit params are invalid: ${formatZodError(parsed.error)}`;
+                : hasIssue(parsed.error, ["reasoning"])
+                  ? "session.ephemeral.submit params.reasoning must be one of none, minimal, low, medium, high, xhigh, or max when provided"
+                  : `session.ephemeral.submit params are invalid: ${formatZodError(parsed.error)}`;
     return invalidParams(message);
   }
 
@@ -5172,6 +5180,7 @@ function validateEphemeralSubmitParams(
         ? { forkFromThreadId: parsed.data.forkFromThreadId }
         : {}),
       message: parsed.data.message,
+      ...(parsed.data.reasoning !== undefined ? { reasoning: parsed.data.reasoning } : {}),
     },
   };
 }

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -104,6 +104,7 @@ export type {
   TauSdkPendingUserMessagesMessage,
   TauSdkPendingUserMessagesState,
   TauSdkReadyMessage,
+  TauSdkReasoningEffort,
   TauSdkRequestId,
   TauSdkResolvePromptResult,
   TauSdkSession,

--- a/src/sdk/session.ts
+++ b/src/sdk/session.ts
@@ -5,6 +5,7 @@ import type {
   SessionProtocolCreateParams,
   SessionProtocolEphemeralAgentTool,
   SessionProtocolInitializeParams,
+  SessionProtocolReasoningEffort,
   SessionProtocolResultByMethod,
   SessionProtocolSampleParams,
 } from "../protocol/session_protocol.js";
@@ -511,12 +512,14 @@ class TauSdkClientImpl implements TauSdkClient {
     options: {
       instructions: string;
       tools: SessionProtocolEphemeralAgentTool[];
+      reasoning?: SessionProtocolReasoningEffort;
     },
   ): Promise<SessionProtocolResultByMethod["session.ephemeral.create"]> {
     return this.transport.request("session.ephemeral.create", {
       sessionId,
       instructions: options.instructions,
       tools: options.tools,
+      ...(options.reasoning !== undefined ? { reasoning: options.reasoning } : {}),
     });
   }
 
@@ -527,6 +530,7 @@ class TauSdkClientImpl implements TauSdkClient {
       threadId: string;
       forkFromThreadId?: string;
       message: string;
+      reasoning?: SessionProtocolReasoningEffort;
     },
   ): Promise<SessionProtocolResultByMethod["session.ephemeral.submit"]> {
     return this.transport.request("session.ephemeral.submit", {
@@ -537,6 +541,7 @@ class TauSdkClientImpl implements TauSdkClient {
         ? { forkFromThreadId: options.forkFromThreadId }
         : {}),
       message: options.message,
+      ...(options.reasoning !== undefined ? { reasoning: options.reasoning } : {}),
     });
   }
 
@@ -803,7 +808,7 @@ class TauSdkSessionImpl implements TauSdkSession {
   }
 
   async setReasoning(
-    reasoning: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max",
+    reasoning: SessionProtocolReasoningEffort,
   ): Promise<SessionProtocolResultByMethod["session.setReasoning"]> {
     const snapshot = await this.client.sendSetReasoning(this.activeSessionId(), reasoning);
     this.discardBufferedDeltasThrough(snapshot.revision);
@@ -863,6 +868,7 @@ class TauSdkSessionImpl implements TauSdkSession {
   async createEphemeralContext(options: {
     instructions: string;
     tools: SessionProtocolEphemeralAgentTool[];
+    reasoning?: SessionProtocolReasoningEffort;
   }): Promise<SessionProtocolResultByMethod["session.ephemeral.create"]> {
     return await this.client.sendEphemeralCreate(this.activeSessionId(), options);
   }
@@ -872,6 +878,7 @@ class TauSdkSessionImpl implements TauSdkSession {
     threadId: string;
     forkFromThreadId?: string;
     message: string;
+    reasoning?: SessionProtocolReasoningEffort;
   }): Promise<SessionProtocolResultByMethod["session.ephemeral.submit"]> {
     return await this.client.sendEphemeralSubmit(this.activeSessionId(), options);
   }

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -19,6 +19,7 @@ import type {
   SessionProtocolPendingUserMessagesState,
   SessionProtocolQueueResult,
   SessionProtocolReadyMessage,
+  SessionProtocolReasoningEffort,
   SessionProtocolRecordResult,
   SessionProtocolReloadResult,
   SessionProtocolRequestId,
@@ -81,6 +82,7 @@ export type TauSdkSessionSampleResult = SessionProtocolSampleResult;
 export type TauSdkSessionInterruptSubagentResult = SessionProtocolInterruptSubagentResult;
 export type TauSdkSessionUnobserveResult = SessionProtocolUnobserveResult;
 export type TauSdkEphemeralAgentTool = SessionProtocolEphemeralAgentTool;
+export type TauSdkReasoningEffort = SessionProtocolReasoningEffort;
 export type TauSdkEphemeralCreateResult = SessionProtocolEphemeralCreateResult;
 export type TauSdkEphemeralSubmitResult = SessionProtocolEphemeralSubmitResult;
 export type TauSdkEphemeralCloseResult = SessionProtocolEphemeralCloseResult;
@@ -202,9 +204,7 @@ export type TauSdkSession = {
   startGoal(objective: string): Promise<TauSdkSessionStartGoalResult>;
   resumeGoal(): Promise<TauSdkSessionResumeGoalResult>;
   clearGoal(): Promise<TauSdkSessionClearGoalResult>;
-  setReasoning(
-    reasoning: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max",
-  ): Promise<TauSdkSessionSetReasoningResult>;
+  setReasoning(reasoning: TauSdkReasoningEffort): Promise<TauSdkSessionSetReasoningResult>;
   setPersona(personaId: string): Promise<TauSdkSessionSetPersonaResult>;
   resolvePrompt(promptId: string): Promise<TauSdkResolvePromptResult>;
   autocompletePaths(options: {
@@ -221,12 +221,14 @@ export type TauSdkSession = {
   createEphemeralContext(options: {
     instructions: string;
     tools: TauSdkEphemeralAgentTool[];
+    reasoning?: TauSdkReasoningEffort;
   }): Promise<TauSdkEphemeralCreateResult>;
   submitEphemeralThread(options: {
     contextId: string;
     threadId: string;
     forkFromThreadId?: string;
     message: string;
+    reasoning?: TauSdkReasoningEffort;
   }): Promise<TauSdkEphemeralSubmitResult>;
   closeEphemeralContext(contextId: string): Promise<TauSdkEphemeralCloseResult>;
   unobserve(): Promise<TauSdkSessionUnobserveResult>;

--- a/test/hosted_ephemeral_agent_session.test.js
+++ b/test/hosted_ephemeral_agent_session.test.js
@@ -47,7 +47,11 @@ function createFailingStream(partialText, error) {
   };
 }
 
-function createSession(recordUsage = vi.fn(), config = { autoCompact: { enabled: false } }) {
+function createSession(
+  recordUsage = vi.fn(),
+  config = { autoCompact: { enabled: false } },
+  reasoning = "medium",
+) {
   const backend = createLocalToolExecutionBackend();
   const executionEnvironment = {
     snapshot: () => ({ kind: "local", cwd: "/repo", home: "/home/user" }),
@@ -82,6 +86,7 @@ function createSession(recordUsage = vi.fn(), config = { autoCompact: { enabled:
       executionEnvironment,
       instructions: "review the diff",
       tools: [],
+      reasoning,
       emitUpdate,
       recordUsage,
     }),
@@ -90,9 +95,14 @@ function createSession(recordUsage = vi.fn(), config = { autoCompact: { enabled:
 
 describe("HostedEphemeralAgentSession", () => {
   it("continues and forks thread state", async () => {
-    const { session, recordUsage, emitUpdate } = createSession();
+    const { session, recordUsage, emitUpdate } = createSession(
+      vi.fn(),
+      { autoCompact: { enabled: false } },
+      "low",
+    );
     const source = await session.getOrCreateThread("source");
     expect(source.runtime).toBeInstanceOf(AgentRuntime);
+    expect(source.runtime.spec.attribution.reasoningEffort).toBe("low");
     const sourceResponses = [createAssistant("first"), createAssistant("continued")];
     source.runtime.spec.model.stream = vi.fn(() => createStream(sourceResponses.shift()));
 
@@ -101,8 +111,10 @@ describe("HostedEphemeralAgentSession", () => {
         contextId: "ephemeral-1",
         threadId: "source",
         message: "first request",
+        reasoning: "high",
       }),
     ).resolves.toEqual({ threadId: "source", response: "first" });
+    expect(source.runtime.spec.attribution.reasoningEffort).toBe("high");
     await expect(
       session.submitThreadMessage({
         contextId: "ephemeral-1",
@@ -110,8 +122,23 @@ describe("HostedEphemeralAgentSession", () => {
         message: "continue",
       }),
     ).resolves.toEqual({ threadId: "source", response: "continued" });
+    expect(source.runtime.spec.attribution.reasoningEffort).toBe("high");
 
-    const fork = await session.getOrCreateThread("fork", "source");
+    const inheritedFork = await session.getOrCreateThread("inherited-fork", "source");
+    expect(inheritedFork.runtime.spec.attribution.reasoningEffort).toBe("high");
+
+    source.runtime.spec.model.stream = vi.fn(() => createStream(createAssistant("forked")));
+    await expect(
+      session.submitThreadMessage({
+        contextId: "ephemeral-1",
+        threadId: "fork",
+        forkFromThreadId: "source",
+        message: "alternate path",
+        reasoning: "minimal",
+      }),
+    ).resolves.toEqual({ threadId: "fork", response: "forked" });
+
+    const fork = await session.getOrCreateThread("fork");
     expect(emitUpdate).toHaveBeenCalledWith(
       "fork",
       expect.objectContaining({
@@ -121,20 +148,21 @@ describe("HostedEphemeralAgentSession", () => {
     );
     expect(fork.runtime).toBeInstanceOf(AgentRuntime);
     expect(fork.runtime.agentIdValue).not.toBe(source.runtime.agentIdValue);
-    expect(fork.runtime.rawHistory).toEqual(source.runtime.rawHistory);
-    fork.runtime.spec.model.stream = vi.fn(() => createStream(createAssistant("forked")));
-    await expect(
-      session.submitThreadMessage({
-        contextId: "ephemeral-1",
-        threadId: "fork",
-        message: "alternate path",
-      }),
-    ).resolves.toEqual({ threadId: "fork", response: "forked" });
+    expect(fork.runtime.rawHistory.slice(0, source.runtime.rawHistory.length)).toEqual(
+      source.runtime.rawHistory,
+    );
+    expect(fork.runtime.spec.attribution.reasoningEffort).toBe("minimal");
+    expect(source.runtime.spec.attribution.reasoningEffort).toBe("high");
 
     expect(recordUsage).toHaveBeenCalledTimes(3);
     for (const [entry] of recordUsage.mock.calls) {
       expect(entry.agent).toEqual({ type: "ephemeral" });
     }
+    expect(recordUsage.mock.calls.map(([entry]) => entry.reasoningEffort)).toEqual([
+      "high",
+      "high",
+      "minimal",
+    ]);
   });
 
   it("rejects a partial provider failure", async () => {

--- a/test/local_session_host.test.js
+++ b/test/local_session_host.test.js
@@ -397,6 +397,7 @@ describe("HostedEphemeralAgentSession", () => {
       executionEnvironment: createTestExecutionEnvironment(),
       instructions: "review",
       tools: [],
+      reasoning: "medium",
       emitUpdate: vi.fn(),
     });
     session.createThread = vi.fn(async () => {
@@ -4162,6 +4163,7 @@ describe("LocalSessionHost", () => {
     };
     const host = createHostForEnvironment(store, executionEnvironment);
     const session = await host.createSession(localCreateInput);
+    await session.setReasoning("high");
     const { contextId } = await session.createEphemeralContext({
       instructions: "review instructions",
       tools: ["bash"],
@@ -4171,6 +4173,7 @@ describe("LocalSessionHost", () => {
     const thread = await hostedContext.createThread("thread-1");
     const systemPrompt = thread.runtime.spec.systemPrompt;
 
+    expect(thread.runtime.spec.attribution.reasoningEffort).toBe("high");
     expect(systemPrompt).toContain("target AGENTS instructions");
     expect(systemPrompt).toContain("target skill");
     expect(systemPrompt).toContain("- Current working directory: `/repo`");

--- a/test/sdk_client.test.js
+++ b/test/sdk_client.test.js
@@ -116,6 +116,12 @@ class FakeSessionProtocolTransport {
           };
         case "session.resolvePrompt":
           return { promptId: params.promptId, text: `prompt body for ${params.promptId}` };
+        case "session.ephemeral.create":
+          return { contextId: "ephemeral-1" };
+        case "session.ephemeral.submit":
+          return { threadId: params.threadId, response: "reviewed" };
+        case "session.ephemeral.close":
+          return { closed: true };
         case "session.reload":
           return {
             snapshot: {
@@ -676,6 +682,44 @@ describe("sdk_client", () => {
     expect(transport.requests.at(-1)).toEqual({
       method: "session.interruptSubagent",
       params: { sessionId: "session-1", subagentId: "subagent-1" },
+    });
+
+    await expect(
+      readySession.createEphemeralContext({
+        instructions: "review this",
+        tools: ["bash"],
+        reasoning: "high",
+      }),
+    ).resolves.toEqual({ contextId: "ephemeral-1" });
+    expect(transport.requests.at(-1)).toEqual({
+      method: "session.ephemeral.create",
+      params: {
+        sessionId: "session-1",
+        instructions: "review this",
+        tools: ["bash"],
+        reasoning: "high",
+      },
+    });
+
+    await expect(
+      readySession.submitEphemeralThread({
+        contextId: "ephemeral-1",
+        threadId: "fork-1",
+        forkFromThreadId: "source-1",
+        message: "review this",
+        reasoning: "minimal",
+      }),
+    ).resolves.toEqual({ threadId: "fork-1", response: "reviewed" });
+    expect(transport.requests.at(-1)).toEqual({
+      method: "session.ephemeral.submit",
+      params: {
+        sessionId: "session-1",
+        contextId: "ephemeral-1",
+        threadId: "fork-1",
+        forkFromThreadId: "source-1",
+        message: "review this",
+        reasoning: "minimal",
+      },
     });
 
     const unobservedSession = await client.sessions.observe("session-1");

--- a/test/sdk_pack_types.test.js
+++ b/test/sdk_pack_types.test.js
@@ -87,7 +87,7 @@ describe("sdk npm pack types", () => {
       writeFileSync(
         validFixturePath,
         [
-          'import type { SessionProtocolFeedbackEvent, SessionProtocolFeedbackTone, SessionProtocolSnapshot, SessionProtocolTransport, TauSdkClient, TauSdkClientToolContext, TauSdkClientToolDescribeContext, TauSdkCreateSessionInput, TauSdkDelta, TauSdkInitializeParams, TauSdkRequestId, TauSdkSessionExecResult, TauSdkSessionSampleInput, TauSdkSessionSampleResult, TauSdkSessionSetReasoningResult, TauSdkSessionTurnOutcome, TauSdkSessionTurnRecord, TauSdkReadyMessage, TauSdkTransportClientOptions, TauSdkUserTextProjection } from "@markusylisiurunen/tau/sdk";',
+          'import type { SessionProtocolFeedbackEvent, SessionProtocolFeedbackTone, SessionProtocolSnapshot, SessionProtocolTransport, TauSdkClient, TauSdkClientToolContext, TauSdkClientToolDescribeContext, TauSdkCreateSessionInput, TauSdkDelta, TauSdkInitializeParams, TauSdkReasoningEffort, TauSdkRequestId, TauSdkSessionExecResult, TauSdkSessionSampleInput, TauSdkSessionSampleResult, TauSdkSessionSetReasoningResult, TauSdkSessionTurnOutcome, TauSdkSessionTurnRecord, TauSdkReadyMessage, TauSdkTransportClientOptions, TauSdkUserTextProjection } from "@markusylisiurunen/tau/sdk";',
           'import { applySessionProtocolDelta, createTauSdkClient, createTauSdkClientFromTransport, createTauSdkWebSocketClient, getTauSdkSessionTurnOutcome, getTauSdkSessionTurnRecord, getTauUserDisplayText, getTauUserModelText, projectTauUserText, runTauClientToolCommand, truncateTauClientToolText } from "@markusylisiurunen/tau/sdk";',
           "",
           "const sdkDelta: TauSdkDelta = {",
@@ -116,6 +116,7 @@ describe("sdk npm pack types", () => {
           "const createInput: TauSdkCreateSessionInput = { executionEnvironment: { kind: 'local', cwd: '/repo' }, attributes: { source: 'fixture' } };",
           "const initializeParams: TauSdkInitializeParams = { client: { name: 'fixture', version: '1' } };",
           "const requestId: TauSdkRequestId = 'req-1';",
+          "const reasoning: TauSdkReasoningEffort = 'high';",
           "const feedbackTone: SessionProtocolFeedbackTone = 'default';",
           "const feedbackEvent: SessionProtocolFeedbackEvent = { type: 'feedback.notice', title: 'retrying', tone: feedbackTone, presentation: 'footer', durationMs: 3000 };",
           "declare const execResult: TauSdkSessionExecResult;",
@@ -143,6 +144,8 @@ describe("sdk npm pack types", () => {
           "client.subscribe((delta) => { void delta.sessionId; });",
           "client.subscribeEphemeral((message) => { void message.sessionId; });",
           "transport.onFailure((error) => { void error.message; });",
+          "void client.sessions.observe('session-1').then((session) => session.createEphemeralContext({ instructions: 'review', tools: ['bash'], reasoning }));",
+          "void client.sessions.observe('session-1').then((session) => session.submitEphemeralThread({ contextId: 'context-1', threadId: 'thread-1', message: 'review', reasoning }));",
           "void client.sessions.observe('session-1').then((session) => session.sample(sampleInput));",
           "void createTauSdkClient({ cwd: '/repo', refreshModelCatalog: false });",
           "void createTauSdkClientFromTransport(transport, transportOptions);",
@@ -151,6 +154,7 @@ describe("sdk npm pack types", () => {
           "void createInput;",
           "void initializeParams;",
           "void requestId;",
+          "void reasoning;",
           "void feedbackEvent;",
           "void execResult;",
           "void sampleInput;",

--- a/test/session_protocol.test.js
+++ b/test/session_protocol.test.js
@@ -308,6 +308,7 @@ describe("session_protocol", () => {
           sessionId: "session-1",
           instructions: "review this",
           tools: ["bash", "view_image"],
+          reasoning: "high",
         },
       }),
     );
@@ -322,6 +323,7 @@ describe("session_protocol", () => {
           sessionId: "session-1",
           instructions: "review this",
           tools: ["bash", "view_image"],
+          reasoning: "high",
         },
       },
     });
@@ -338,6 +340,7 @@ describe("session_protocol", () => {
           threadId: "thread-1",
           forkFromThreadId: "thread-0",
           message: "review this",
+          reasoning: "minimal",
         },
       }),
     );
@@ -354,6 +357,7 @@ describe("session_protocol", () => {
           threadId: "thread-1",
           forkFromThreadId: "thread-0",
           message: "review this",
+          reasoning: "minimal",
         },
       },
     });
@@ -1086,6 +1090,7 @@ describe("session_protocol", () => {
         sessionId: "session-1",
         instructions: "review this",
         tools: ["bash", "view_image"],
+        reasoning: "xhigh",
       }),
     ).toEqual({
       ok: true,
@@ -1093,6 +1098,7 @@ describe("session_protocol", () => {
         sessionId: "session-1",
         instructions: "review this",
         tools: ["bash", "view_image"],
+        reasoning: "xhigh",
       },
     });
     expect(
@@ -1101,6 +1107,7 @@ describe("session_protocol", () => {
         contextId: "ephemeral-1",
         threadId: "thread-1",
         message: "review this",
+        reasoning: "low",
       }),
     ).toEqual({
       ok: true,
@@ -1109,6 +1116,7 @@ describe("session_protocol", () => {
         contextId: "ephemeral-1",
         threadId: "thread-1",
         message: "review this",
+        reasoning: "low",
       },
     });
     expect(
@@ -1147,6 +1155,22 @@ describe("session_protocol", () => {
     });
 
     expect(
+      validateSessionProtocolParams("session.ephemeral.create", {
+        sessionId: "session-1",
+        instructions: "review this",
+        tools: [],
+        reasoning: "extreme",
+      }),
+    ).toEqual({
+      ok: false,
+      error: expect.objectContaining({
+        code: SESSION_PROTOCOL_ERROR_CODES.invalidParams,
+        message:
+          "session.ephemeral.create params.reasoning must be one of none, minimal, low, medium, high, xhigh, or max when provided",
+      }),
+    });
+
+    expect(
       validateSessionProtocolParams("session.ephemeral.submit", {
         sessionId: "session-1",
         contextId: "ephemeral-1",
@@ -1160,6 +1184,23 @@ describe("session_protocol", () => {
         code: SESSION_PROTOCOL_ERROR_CODES.invalidParams,
         message:
           "session.ephemeral.submit params.forkFromThreadId must be a non-empty string when provided",
+      }),
+    });
+
+    expect(
+      validateSessionProtocolParams("session.ephemeral.submit", {
+        sessionId: "session-1",
+        contextId: "ephemeral-1",
+        threadId: "thread-1",
+        message: "review this",
+        reasoning: "extreme",
+      }),
+    ).toEqual({
+      ok: false,
+      error: expect.objectContaining({
+        code: SESSION_PROTOCOL_ERROR_CODES.invalidParams,
+        message:
+          "session.ephemeral.submit params.reasoning must be one of none, minimal, low, medium, high, xhigh, or max when provided",
       }),
     });
   });

--- a/test/session_protocol_handler.test.js
+++ b/test/session_protocol_handler.test.js
@@ -740,7 +740,13 @@ describe("SessionProtocolHandler", () => {
   });
 
   it("creates, uses, and closes ephemeral contexts during an active main turn", async () => {
-    const harness = createHarness();
+    const submissions = [];
+    const harness = createHarness({
+      submitEphemeralThread: async (options) => {
+        submissions.push(options);
+        return { threadId: options.threadId, response: "done" };
+      },
+    });
     const submit = harness.connection.handleRequest(
       request("submit", "session.submit", {
         sessionId: "session-1",
@@ -754,6 +760,7 @@ describe("SessionProtocolHandler", () => {
         sessionId: "session-1",
         instructions: "review this",
         tools: ["bash"],
+        reasoning: "high",
       }),
     );
     await harness.connection.handleRequest(
@@ -762,6 +769,7 @@ describe("SessionProtocolHandler", () => {
         contextId: "context-1",
         threadId: "thread-1",
         message: "review",
+        reasoning: "low",
       }),
     );
     await harness.connection.handleRequest(
@@ -772,6 +780,19 @@ describe("SessionProtocolHandler", () => {
     );
 
     expect(harness.seededSession.isTurnRunning).toBe(true);
+    expect(harness.seededSession.createEphemeralContext).toHaveBeenCalledWith({
+      instructions: "review this",
+      tools: ["bash"],
+      reasoning: "high",
+    });
+    expect(submissions).toEqual([
+      {
+        contextId: "context-1",
+        threadId: "thread-1",
+        message: "review",
+        reasoning: "low",
+      },
+    ]);
     expect(harness.lines.find((line) => line.id === "ephemeral-create")).toEqual(
       expect.objectContaining({ ok: true, result: { contextId: "context-1" } }),
     );


### PR DESCRIPTION
## why

Ephemeral contexts currently resolve reasoning only from their persona defaults. Clients need to choose an initial effort and update an individual thread's effort as part of a submission, including a fork's first turn.

## what

- add optional `reasoning` fields to ephemeral context creation and thread submission across the protocol and Node SDK
- capture the parent agent's effective reasoning when context creation omits an override
- retain reasoning as thread spec state, copy it into forks, and apply submission overrides before the submitted turn
- document the lifecycle and cover protocol validation, host routing, SDK forwarding, inheritance, retention, and fork behavior

## details

The implementation treats context reasoning as the initial value for newly created threads, not as mutable shared context state. An omitted creation value captures the parent agent spec at context creation, so later parent setting changes do not alter that context. A submission override updates only the target thread; a fork copies the source thread spec first and then applies its own override without mutating the source.

There are no remaining questions.

fixes #463
