### PR TITLE
raise diff review snapshot limit

### DIFF
--- a/docs/sdk-diff-review.md
+++ b/docs/sdk-diff-review.md
@@ -23,7 +23,7 @@ try {
 }
 ```
 
-The source may instead be `{ kind: "patch_files", patchFiles, scopeLabel }`. Paths and Git arguments belong to the session execution environment. Optional `host`, `port`, and `signal` fields control the client-owned HTTP process and startup cancellation.
+The source may instead be `{ kind: "patch_files", patchFiles, scopeLabel }`. Paths and Git arguments belong to the session execution environment. Captured snapshot patches are limited to 16 MiB; narrow the Git arguments or patch-file selection when a larger scope is rejected. A plain working-tree snapshot includes non-binary untracked files up to 4 MiB each within that aggregate limit. Optional `host`, `port`, and `signal` fields control the client-owned HTTP process and startup cancellation.
 
 ## Routing and lifecycle
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -176,6 +176,8 @@ Theme ids are exact and case-sensitive. `/theme` does not persist the selection.
 /diff --staged
 ```
 
+Captured snapshot patches are limited to 16 MiB. Narrow the Git arguments when a larger scope is rejected. A plain working-tree snapshot includes non-binary untracked files up to 4 MiB each within that aggregate limit.
+
 A `diffTool` entry in the attaching client’s configuration replaces the launcher. Relative commands resolve from the configuration level that defines them:
 
 ```json

--- a/src/core/diff_review/snapshot.ts
+++ b/src/core/diff_review/snapshot.ts
@@ -57,8 +57,8 @@ type DiffSnapshotDeps = Pick<CoreDeps, "spawn"> & {
 };
 
 const GIT_TIMEOUT_MS = 30_000;
-const GIT_MAX_CAPTURE_BYTES = 2 * 1024 * 1024;
-const MAX_UNTRACKED_TEXT_BYTES = 512 * 1024;
+const MAX_SNAPSHOT_PATCH_BYTES = 16 * 1024 * 1024;
+const MAX_UNTRACKED_TEXT_BYTES = 4 * 1024 * 1024;
 const WORKING_TREE_SCOPE_LABEL = "current working tree";
 
 export class DiffReviewSnapshot {
@@ -155,6 +155,7 @@ export async function captureDiffReviewSnapshot(
       : source.diffArgs.length > 0
         ? await captureExplicitDiffSnapshot(cwd, source.diffArgs, deps, signal)
         : await captureWorkingTreeSnapshot(repoRoot, deps, signal);
+  assertSnapshotPatchBytesWithinLimit(Buffer.byteLength(captured.patch, "utf-8"));
   const diffArgs = source.kind === "git_diff" ? [...source.diffArgs] : [];
 
   return new DiffReviewSnapshot({
@@ -178,6 +179,14 @@ type CapturedSnapshotData = {
 function throwIfSnapshotAborted(signal?: AbortSignal): void {
   if (signal?.aborted) {
     throw new Error("diff review start aborted");
+  }
+}
+
+function assertSnapshotPatchBytesWithinLimit(bytes: number): void {
+  if (bytes > MAX_SNAPSHOT_PATCH_BYTES) {
+    throw new Error(
+      `diff review snapshot patch exceeds the ${MAX_SNAPSHOT_PATCH_BYTES}-byte limit; narrow the review scope`,
+    );
   }
 }
 
@@ -224,11 +233,7 @@ async function capturePatchFilesSnapshot(
     const patchPath = resolve(cwd, patchFile);
     const patch = await deps.fs.readFile(patchPath);
     totalBytes += Buffer.byteLength(patch, "utf-8");
-    if (totalBytes > GIT_MAX_CAPTURE_BYTES) {
-      throw new Error(
-        `patch files exceeded ${GIT_MAX_CAPTURE_BYTES} bytes while capturing diff review snapshot`,
-      );
-    }
+    assertSnapshotPatchBytesWithinLimit(totalBytes);
 
     const patchSections = splitPatchSections(patch);
     if (patchSections.length === 0 && patch.trim().length > 0) {
@@ -517,13 +522,13 @@ async function gitRefExists(
     timeoutMs: GIT_TIMEOUT_MS,
     signal,
     captureOutput: "combined",
-    maxCaptureBytes: GIT_MAX_CAPTURE_BYTES,
+    maxCaptureBytes: MAX_SNAPSHOT_PATCH_BYTES,
     maxCaptureMode: "ignore",
   });
 
   if (result.captureLimitExceeded) {
     throw new Error(
-      `git rev-parse --verify ${ref} output exceeded ${GIT_MAX_CAPTURE_BYTES} bytes while capturing diff review snapshot`,
+      `git rev-parse --verify ${ref} output exceeded ${MAX_SNAPSHOT_PATCH_BYTES} bytes while capturing diff review snapshot`,
     );
   }
 
@@ -556,13 +561,13 @@ async function runGitCommand(
     timeoutMs: GIT_TIMEOUT_MS,
     signal,
     captureOutput: "combined-and-split",
-    maxCaptureBytes: GIT_MAX_CAPTURE_BYTES,
+    maxCaptureBytes: MAX_SNAPSHOT_PATCH_BYTES,
     maxCaptureMode: "ignore",
   });
 
   if (result.captureLimitExceeded) {
     throw new Error(
-      `git ${args.join(" ")} output exceeded ${GIT_MAX_CAPTURE_BYTES} bytes while capturing diff review snapshot`,
+      `git ${args.join(" ")} output exceeded ${MAX_SNAPSHOT_PATCH_BYTES} bytes while capturing diff review snapshot`,
     );
   }
 

--- a/test/diff_review_snapshot.test.js
+++ b/test/diff_review_snapshot.test.js
@@ -167,6 +167,45 @@ describe("diff_review snapshot", () => {
     }
   });
 
+  it("enforces the aggregate patch limit after adding large untracked files", async () => {
+    const trackedContent = "x".repeat(6 * 1024 * 1024);
+    const trackedPatch = [
+      "diff --git a/src/tracked.ts b/src/tracked.ts",
+      "--- a/src/tracked.ts",
+      "+++ b/src/tracked.ts",
+      "@@ -1 +1 @@",
+      `-${trackedContent}`,
+      `+${trackedContent}`,
+    ].join("\n");
+    const untrackedContent = "y".repeat(4 * 1024 * 1024);
+    const spawn = async (_cmd, args) => {
+      if (args[0] === "rev-parse") {
+        return createSpawnResult(args[1] === "--show-toplevel" ? "/repo\n" : "deadbeef\n");
+      }
+      if (args[0] === "ls-files") {
+        return createSpawnResult("src/untracked.ts\0");
+      }
+      if (args[0] === "diff" && args[1] === "--name-status") {
+        return createSpawnResult("M\0src/tracked.ts\0");
+      }
+      return createSpawnResult(trackedPatch);
+    };
+
+    await expect(
+      captureDiffReviewSnapshot({
+        cwd: "/repo",
+        source: { kind: "git_diff", diffArgs: [] },
+        deps: {
+          spawn,
+          env: { env: () => ({}) },
+          fs: { readFile: async () => untrackedContent },
+        },
+      }),
+    ).rejects.toThrow(
+      "diff review snapshot patch exceeds the 16777216-byte limit; narrow the review scope",
+    );
+  });
+
   it("fails fast when any git command output is truncated", async () => {
     const spawn = async (_cmd, args) => {
       if (args[0] === "rev-parse") {
@@ -188,8 +227,43 @@ describe("diff_review snapshot", () => {
         },
       }),
     ).rejects.toThrow(
-      "git diff --name-status -z HEAD output exceeded 2097152 bytes while capturing diff review snapshot",
+      "git diff --name-status -z HEAD output exceeded 16777216 bytes while capturing diff review snapshot",
     );
+  });
+
+  it("captures explicit Git diffs larger than the previous 2 MiB limit", async () => {
+    const content = `export const value = "${"x".repeat(2 * 1024 * 1024)}";`;
+    const patch = [
+      "diff --git a/src/large.ts b/src/large.ts",
+      "new file mode 100644",
+      "--- /dev/null",
+      "+++ b/src/large.ts",
+      "@@ -0,0 +1 @@",
+      `+${content}`,
+    ].join("\n");
+    const spawn = async (_cmd, args) => {
+      if (args[0] === "rev-parse") {
+        return createSpawnResult("/repo\n");
+      }
+      if (args[0] === "diff" && args[1] === "--name-status") {
+        return createSpawnResult("A\0src/large.ts\0");
+      }
+      return createSpawnResult(patch);
+    };
+
+    const snapshot = await captureDiffReviewSnapshot({
+      cwd: "/repo",
+      source: { kind: "git_diff", diffArgs: ["main...HEAD"] },
+      deps: {
+        spawn,
+        env: { env: () => ({}) },
+      },
+    });
+
+    expect(Buffer.byteLength(snapshot.patch, "utf-8")).toBeGreaterThan(2 * 1024 * 1024);
+    expect(snapshot.files).toEqual([
+      { path: "src/large.ts", status: "added", newPath: "src/large.ts" },
+    ]);
   });
 
   it("stops snapshot capture when diff review startup is aborted", async () => {
@@ -303,18 +377,20 @@ describe("diff_review snapshot", () => {
     }
   });
 
-  it("rejects patch files that exceed the snapshot capture limit", async () => {
+  it("rejects patch files that exceed the snapshot patch limit", async () => {
     const fx = createRepoFixture();
 
     try {
-      writeFileSync(join(fx.repo, "large.patch"), "x".repeat(2 * 1024 * 1024 + 1), "utf-8");
+      writeFileSync(join(fx.repo, "large.patch"), "x".repeat(16 * 1024 * 1024 + 1), "utf-8");
 
       await expect(
         captureDiffReviewSnapshot({
           cwd: fx.repo,
           source: { kind: "patch_files", patchFiles: ["large.patch"], scopeLabel: "large.patch" },
         }),
-      ).rejects.toThrow(/patch files exceeded/);
+      ).rejects.toThrow(
+        "diff review snapshot patch exceeds the 16777216-byte limit; narrow the review scope",
+      );
     } finally {
       fx.cleanup();
     }


### PR DESCRIPTION
## why

Diff review snapshot capture used a generic 2 MiB Git output ceiling, which rejects otherwise reviewable repository changes such as the 2,109,009-byte patch reported in #472.

## what

- raise the diff-review snapshot patch limit to 16 MiB for Git diffs and patch-file sources
- enforce the limit again on the final assembled snapshot so combined tracked and untracked patches cannot bypass it
- raise the per-file untracked text limit to 4 MiB while retaining the aggregate snapshot backstop
- return an actionable size-limit message and document the limits for TUI and SDK reviews
- cover explicit diffs above the old ceiling, aggregate working-tree enforcement, and patch-file rejection

## details

The limit is measured in UTF-8 bytes and permits a patch exactly at the ceiling. Patch-file input is bounded cumulatively while reading and the canonical assembled patch is checked before constructing the snapshot.

The existing 30-second Git timeout, 24 MiB SDK execution-capture ceiling, diff-tool request-body limit, and persisted review-state limit remain unchanged because they protect separate paths. There are no remaining implementation questions.

fixes #472
