### PR TITLE
upgrade dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@markusylisiurunen/tau",
       "version": "0.3.65",
       "dependencies": {
-        "@earendil-works/pi-ai": "0.84.3",
-        "@earendil-works/pi-tui": "0.84.3",
+        "@earendil-works/pi-ai": "0.84.4",
+        "@earendil-works/pi-tui": "0.84.4",
         "@fly/sprites": "^0.2.1",
         "chalk": "^6.0.0",
         "colorjs.io": "^0.7.1",
@@ -18,17 +18,17 @@
         "ses": "2.3.0",
         "sharp": "^0.35.4",
         "strip-ansi": "^7.2.0",
-        "typebox": "^1.3.20",
+        "typebox": "^1.3.21",
         "ws": "^8.21.3",
         "yaml": "^2.9.0",
-        "zod": "^4.4.3"
+        "zod": "^4.5.2"
       },
       "bin": {
         "tau": "dist/main.js"
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.11",
-        "@cloudflare/workers-types": "^5.20260828.1",
+        "@cloudflare/workers-types": "^5.20260829.1",
         "@types/node": "^24.13.3",
         "@types/ws": "^8.18.1",
         "prettier": "^3.9.6",
@@ -660,21 +660,21 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "5.20260828.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260828.1.tgz",
-      "integrity": "sha512-Ce0QfghuAK9v821gER8rFPR3rMeC+5puTgTzCu4UrG1Zg967Z5Aa+2uZVciIyfCAdGssyh+sLEC6rMjN/YBQwA==",
+      "version": "5.20260829.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260829.1.tgz",
+      "integrity": "sha512-SsH4G9+JePvrBmz+b5Dl67LQ9w2/ycoIpAPcAkfg2aEs2SEisQHk7/AY0TymSXEBbDbWgcBqoLe4hNcuY3CxWA==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.84.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.3.tgz",
-      "integrity": "sha512-M0YUV8vNO3y2WwWSyY8ijKJV5W4gkSUixuvk+Z00ZBjsyMfsdXfITsHEwP1UIf09YRWXT6oGn0GlCamt+P32XQ==",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.4.tgz",
+      "integrity": "sha512-AClAZxf5+c4RRu44NJPS6wyQy+Nmq+Mzyyrdvm4ZVMNuixelO02RZX4G4Aq1F145Yzp43wnM5S+hLlSI7ypfVw==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
-        "@earendil-works/pi-telemetry": "^0.84.3",
+        "@earendil-works/pi-telemetry": "^0.84.4",
         "@google/genai": "1.52.0",
         "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
@@ -697,18 +697,18 @@
       "license": "MIT"
     },
     "node_modules/@earendil-works/pi-telemetry": {
-      "version": "0.84.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.3.tgz",
-      "integrity": "sha512-sgEkWoKrvSGaKn+YfLLFZmn+/A7B/w62eLwTD57nI+C9to8ITlFFVbgC2OtwvPnT3NFGHdCd53qhBEMIlptD1g==",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.4.tgz",
+      "integrity": "sha512-8e2CuxM+ht+hedQXTZmi5JVl6/xDK9RpSDL2+MbITevKYQhMZ/z6lJOTFgox3HQyGxO8mOZEtYGVeQNaD4OzqA==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"
       }
     },
     "node_modules/@earendil-works/pi-tui": {
-      "version": "0.84.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.3.tgz",
-      "integrity": "sha512-fS6OEQKEEALnKa6Uw8LcgZZ+9CWck7f3MQSCETQp6leUgIFwMEDtKmOUnL9nsYm+RIPmy7OmplVxYRbV6hiaFg==",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.4.tgz",
+      "integrity": "sha512-nPUnwDkLtupPXnZQYrCwPFcuTydCDqTY6ZbFqhsL4S4kVq0AT418kPa/6uXwtaCD+MjBNBltb7ScTYX65yeE1w==",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
@@ -3641,9 +3641,9 @@
       "license": "0BSD"
     },
     "node_modules/typebox": {
-      "version": "1.3.20",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.20.tgz",
-      "integrity": "sha512-qAQnoUNakcqjoTqwDzvqcg5e/+i3FHnltXFmKAbc0tpTPKT86bVOUPuevp/vYQguWUMC7YsVTmk1FT5UpjB/wg==",
+      "version": "1.3.21",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.21.tgz",
+      "integrity": "sha512-7W3Yft9Y51urmR3GbuT9C/ymMhs5YKEkrBWGlsckLoOR3CuFK+y8oKaS5c5UUigcWrEx+fo0lFUYFTqJLqpZYA==",
       "license": "MIT"
     },
     "node_modules/typescript": {
@@ -3945,9 +3945,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.2.tgz",
+      "integrity": "sha512-XkYXCol10+ba/6F/cueWV+TezUeOqXW0hdeJt5CdXjTYeAgAQg5N03RQdJ80mhfFE72+pblvYMW4wy2Qp4Qbrg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "0.84.3",
-    "@earendil-works/pi-tui": "0.84.3",
+    "@earendil-works/pi-ai": "0.84.4",
+    "@earendil-works/pi-tui": "0.84.4",
     "@fly/sprites": "^0.2.1",
     "chalk": "^6.0.0",
     "colorjs.io": "^0.7.1",
@@ -41,14 +41,14 @@
     "ses": "2.3.0",
     "sharp": "^0.35.4",
     "strip-ansi": "^7.2.0",
-    "typebox": "^1.3.20",
+    "typebox": "^1.3.21",
     "ws": "^8.21.3",
     "yaml": "^2.9.0",
-    "zod": "^4.4.3"
+    "zod": "^4.5.2"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.11",
-    "@cloudflare/workers-types": "^5.20260828.1",
+    "@cloudflare/workers-types": "^5.20260829.1",
     "@types/node": "^24.13.3",
     "@types/ws": "^8.18.1",
     "prettier": "^3.9.6",

--- a/src/diff_tool/app/package-lock.json
+++ b/src/diff_tool/app/package-lock.json
@@ -7,7 +7,7 @@
       "name": "tau-diff-tool",
       "dependencies": {
         "@pierre/diffs": "^1.3.6",
-        "lucide-react": "^1.35.0",
+        "lucide-react": "^1.37.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "react-markdown": "^10.1.0",
@@ -1650,9 +1650,9 @@
       "license": "MIT"
     },
     "node_modules/lucide-react": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.35.0.tgz",
-      "integrity": "sha512-yXCCWxGFYT6bLIPYC4SY6fPQPRs/d797rRIue+J9XP2Td6vQvD53gaQRBCnIVT1kTQRHtAtxlfOQNWAuIF8ELg==",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.37.0.tgz",
+      "integrity": "sha512-LPsB4rD1TD6wZu1djKOf9vUnS1jTNaHbolXebXDgiTdb6jeA1agIJhJsIybCmjKmQClcOaal1o1OaiYahEftyQ==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/src/diff_tool/app/package.json
+++ b/src/diff_tool/app/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@pierre/diffs": "^1.3.6",
-    "lucide-react": "^1.35.0",
+    "lucide-react": "^1.37.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-markdown": "^10.1.0",

--- a/test/model_catalog.test.js
+++ b/test/model_catalog.test.js
@@ -41,17 +41,17 @@ describe("model catalog", () => {
     expect(sol.provider).toBe("openai");
     expect(sol.api).toBe("openai-responses");
     expect(sol.cost).toEqual({
-      input: 5,
-      output: 30,
-      cacheRead: 0.5,
-      cacheWrite: 6.25,
+      input: 4,
+      output: 20,
+      cacheRead: 0.4,
+      cacheWrite: 5,
       tiers: [
         {
           inputTokensAbove: 272000,
-          input: 10,
-          output: 45,
-          cacheRead: 1,
-          cacheWrite: 12.5,
+          input: 8,
+          output: 30,
+          cacheRead: 0.8,
+          cacheWrite: 10,
         },
       ],
     });


### PR DESCRIPTION
## why

Keep Tau's runtime, tooling, and diff-tool dependencies current and pick up the latest Pi model and TUI fixes.

## what

Upgrade Pi AI and TUI to 0.84.4, refresh TypeBox, Zod, Cloudflare Workers types, and Lucide React, and update both lockfiles.

## details

Align the GPT-5.6 Sol catalog assertion with the pricing shipped by Pi AI 0.84.4. Node types remain on the supported Node 24 LTS major.
