### PR TITLE
adapt Cowork review comments for GitHub

### DIFF
--- a/.cowork/prompts/pull-request-review.append.md
+++ b/.cowork/prompts/pull-request-review.append.md
@@ -1,3 +1,3 @@
-Inspect @@skill:code-review for additional guidance on finding, validating, and prioritizing actionable issues. Apply relevant review principles, but follow the built-in workflow's scope, materiality threshold, inline-comment format, and GitHub publication contract instead of the skill's aggregate output format.
+Inspect @@skill:code-review and follow its guidance for finding qualification, prioritization, ordering, explanation, and fix recommendations. Cowork remains authoritative for the complete pull request snapshot, orchestration and trust rules, and GitHub publication contract. Adapt the skill's aggregate output to the GitHub review interface by publishing each finding as a separate unnumbered inline comment. Omit aggregate section headings, location fields, gaps sections, and finding numbers while preserving each finding's priority, title, and substantive content.
 
 Use review subagents with launch model `openai-codex/gpt-5.6-luna:high`.

--- a/.cowork/prompts/pull-request-review.append.md
+++ b/.cowork/prompts/pull-request-review.append.md
@@ -1,3 +1,19 @@
-Inspect @@skill:code-review and follow its guidance for finding qualification, prioritization, ordering, explanation, and fix recommendations. Cowork remains authoritative for the complete pull request snapshot, orchestration and trust rules, and GitHub publication contract. Adapt the skill's aggregate output to the GitHub review interface by publishing each finding as a separate unnumbered inline comment. Omit aggregate section headings, location fields, gaps sections, and finding numbers while preserving each finding's priority, title, and substantive content.
+Use @@skill:code-review for the complete code review. Follow its guidance for investigation, finding qualification, prioritization, ordering, explanation, and suggested fixes.
+
+Translate each qualifying finding into a separate inline GitHub review comment using this format:
+
+```markdown
+**[P#] <plain-language consequence>**
+
+<the complete finding explanation>
+
+**Suggested fix:** <the recommended correction or meaningful alternatives>
+```
+
+Each inline comment must stand on its own. Preserve the skill's substantive explanation and use as many paragraphs as the finding needs. Do not shorten a finding merely to make it look compact in GitHub.
+
+Do not include aggregate finding numbers, `Location` fields, verdicts, findings or gaps headings, or other report-level wrappers in inline comments. GitHub already supplies the location and thread identity. Do not turn an unverifiable gap into an inline finding; mention a genuinely material gap only in the top-level review body.
+
+Include code only when it makes the correction materially clearer.
 
 Use review subagents with launch model `openai-codex/gpt-5.6-luna:high`.


### PR DESCRIPTION
## why

Repository review guidance should control the substance of findings while Cowork controls the pull request snapshot and GitHub publication mechanics. Aggregate terminal review formatting does not map cleanly to separate inline GitHub threads.

## what

Tell Cowork to follow the repository's code-review skill for finding policy and explanation, then publish each finding as an unnumbered inline comment. Aggregate headings, location fields, gaps sections, and finding numbers are omitted while priority, title, and substantive content are preserved.
