### PR TITLE
add default Telegram turn guidance

### DIFF
--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -220,7 +220,9 @@ After preparation, Tau creates an ordinary local session at the workspace `cwd`.
 
 A project `persona` overrides the normal default for that session. `noAgentContextFiles: true` suppresses `AGENTS.md` injection for repository or persistent-directory sessions. Composite root context is generated deliberately and uses its required persona.
 
-The top-level and per-bot `systemMessage` values are different from project context. Tau prepends them as a hidden `<system>` block to every Telegram-submitted turn, with the top-level message first and the bot message second. They are persisted as part of the user turn and can appear in history, so never put credentials in them.
+Every Telegram turn starts with hidden `<system>` guidance identifying Telegram as the source and reply destination. It favors direct simple answers and brief acknowledgements or meaningful progress updates for tool-driven or multi-step work, since users cannot see tool activity.
+
+Top-level and per-bot `systemMessage` values share a second hidden block after the default, in that order. Audio transcripts receive another warning that they may contain noise or errors. Unlike project context, hidden guidance is persisted with user turns and can appear in history, so never put credentials in configured messages.
 
 The runner's speech-to-text provider is loaded from normal Tau config at runner startup, based on the runner process's startup `cwd`. Restart the runner after changing that provider or its environment.
 

--- a/src/core/telegram/adapter.ts
+++ b/src/core/telegram/adapter.ts
@@ -228,6 +228,8 @@ type TelegramNotificationOptions = { rich?: false } | { rich: true; messageId: s
 
 const DEFAULT_POLL_INTERVAL_MS = 1000;
 const DEFAULT_REQUEST_TIMEOUT_SECONDS = 30;
+const TELEGRAM_AUDIO_TRANSCRIPTION_SYSTEM_MESSAGE =
+  "This text was transcribed from Telegram audio and may contain noise, misheard words, or transcription errors.";
 const MAX_COMMAND_PREVIEW_CHARS = 128;
 const MAX_PROVISION_DIAGNOSTIC_CHARS = 2_000;
 const DEFAULT_TELEGRAM_VOICE_MIME_TYPE = "audio/ogg";
@@ -2621,7 +2623,15 @@ class TelegramAdapterImpl {
     this.pushIndentedAttachmentLines(lines, triggerAttachments, "");
     lines.push("</telegram-trigger-message>");
 
-    return formatTauUserText({ text: lines.join("\n"), hiddenSystemMessages: [system] });
+    const hasAudioTranscript =
+      Boolean(triggerAudioTranscript) || pending.some((message) => message.audioTranscript);
+    return formatTauUserText({
+      text: lines.join("\n"),
+      hiddenSystemMessages: [
+        system,
+        ...(hasAudioTranscript ? [TELEGRAM_AUDIO_TRANSCRIPTION_SYSTEM_MESSAGE] : []),
+      ],
+    });
   }
 
   private pushIndentedErrorLines(
@@ -2759,7 +2769,11 @@ class TelegramAdapterImpl {
 
     try {
       await this.reply(chatId, `transcribed: ${result.transcript}`);
-      await this.submitSessionMessage(chatId, session.id, result.transcript, sourceMessageId);
+      const text = formatTauUserText({
+        text: result.transcript,
+        hiddenSystemMessages: [TELEGRAM_AUDIO_TRANSCRIPTION_SYSTEM_MESSAGE],
+      });
+      await this.submitSessionMessage(chatId, session.id, text, sourceMessageId);
     } catch (error) {
       await this.reply(chatId, this.formatManagerError(error));
     }

--- a/src/core/telegram/session_manager.ts
+++ b/src/core/telegram/session_manager.ts
@@ -218,6 +218,8 @@ const NANOSECONDS_PER_MILLISECOND = 1_000_000n;
 const PROVISION_SCRIPT_PATH = ".tau/scripts/provision";
 const MAX_PROVISION_DIAGNOSTIC_CHARS = 2_000;
 const TURN_RECOVERY_POLL_INTERVAL_MS = 1_000;
+const DEFAULT_TELEGRAM_SYSTEM_MESSAGE =
+  "This user message came from Telegram, and your assistant messages will be sent back to the Telegram chat. Adapt your communication style to this context. Answer straightforward requests directly. For work that involves tools or multiple steps, send a brief acknowledgement before starting and concise progress updates at meaningful points, since the user cannot see tool activity.";
 
 const ACTIVE_STATES: Set<TelegramSessionState> = new Set([
   "queued",
@@ -533,7 +535,7 @@ class TelegramSessionManagerImpl implements TelegramSessionManager {
   private readonly projects: Record<string, TelegramProjectConfig>;
   private readonly workspaceRoot: string;
   private readonly maxSessions?: number;
-  private readonly systemMessage?: string;
+  private readonly configuredSystemMessage?: string;
   private readonly persistencePath?: string;
   private readonly now: () => Date;
   private readonly onLog?: (entry: WorkspaceLogEntry) => void;
@@ -554,7 +556,7 @@ class TelegramSessionManagerImpl implements TelegramSessionManager {
       options.workspaceRoot ?? resolve(process.cwd(), ".tau/telegram-workspaces"),
     );
     this.maxSessions = options.maxSessions;
-    this.systemMessage = options.systemMessage?.trim() || undefined;
+    this.configuredSystemMessage = options.systemMessage?.trim() || undefined;
     this.persistencePath = options.persistencePath ? resolve(options.persistencePath) : undefined;
     this.now = options.now ?? (() => new Date());
     this.onLog = options.onLog;
@@ -1928,15 +1930,17 @@ class TelegramSessionManagerImpl implements TelegramSessionManager {
   }
 
   private buildSubmitPayload(text: string, additionalSystemMessage?: string): string {
-    const messages = [this.systemMessage, additionalSystemMessage?.trim() || undefined].filter(
-      (message): message is string => Boolean(message),
-    );
-
-    if (messages.length === 0) {
-      return text;
-    }
-
-    return formatTauUserText({ text, hiddenSystemMessages: [messages.join("\n")] });
+    const configuredMessages = [
+      this.configuredSystemMessage,
+      additionalSystemMessage?.trim() || undefined,
+    ].filter((message): message is string => Boolean(message));
+    return formatTauUserText({
+      text,
+      hiddenSystemMessages: [
+        DEFAULT_TELEGRAM_SYSTEM_MESSAGE,
+        ...(configuredMessages.length > 0 ? [configuredMessages.join("\n")] : []),
+      ],
+    });
   }
 
   private countActiveSessions(): number {

--- a/test/telegram_adapter.test.js
+++ b/test/telegram_adapter.test.js
@@ -5,6 +5,13 @@ import { describe, expect, it, vi } from "vitest";
 import { startTelegramAdapter, TelegramRequestError } from "../dist/core/telegram/adapter.js";
 import { TauSessionProtocolResponseError } from "../dist/transport/errors.js";
 
+const TELEGRAM_AUDIO_TRANSCRIPTION_SYSTEM_MESSAGE =
+  "This text was transcribed from Telegram audio and may contain noise, misheard words, or transcription errors.";
+
+function transcribedTelegramUserText(text) {
+  return `<system>${TELEGRAM_AUDIO_TRANSCRIPTION_SYSTEM_MESSAGE}</system>\n${text}`;
+}
+
 async function startAdapter(options) {
   const preferences = new Map();
   const ttsPreferences = new Map();
@@ -1770,6 +1777,9 @@ describe("telegram adapter", () => {
       expect(text).toContain('caption: "second image"');
       expect(text).toContain("3. sender: Katherine (@kat, id 9)");
       expect(text).toContain('   audio_transcript: "transcribed audio"');
+      expect(text).toContain(
+        `</system>\n<system>${TELEGRAM_AUDIO_TRANSCRIPTION_SYSTEM_MESSAGE}</system>\n<telegram-group-context>`,
+      );
       expect(text).toContain("4. sender: Margaret (@margaret, id 10)");
       expect(text).toContain('   text: "normal context"');
       expect(text).toContain("5. sender: Edsger (@edsger, id 12)");
@@ -2348,9 +2358,11 @@ describe("telegram adapter", () => {
     try {
       await waitFor(() => managerHarness.manager.sendMessage.mock.calls.length === 1);
       expect(apiHarness.downloadFileCalls).toEqual(["voice-123"]);
-      expect(managerHarness.manager.sendMessage).toHaveBeenCalledWith("s21", "ship the fix", {
-        mode: "auto",
-      });
+      expect(managerHarness.manager.sendMessage).toHaveBeenCalledWith(
+        "s21",
+        transcribedTelegramUserText("ship the fix"),
+        { mode: "auto" },
+      );
       expect(apiHarness.sendMessages).toEqual([
         expect.objectContaining({ chatId: 210, text: "transcribed: ship the fix" }),
       ]);
@@ -2416,7 +2428,7 @@ describe("telegram adapter", () => {
       expect(apiHarness.downloadFileCalls).toEqual(["voice-456"]);
       expect(managerHarness.manager.sendMessage).toHaveBeenCalledWith(
         "s22",
-        "use google transcription",
+        transcribedTelegramUserText("use google transcription"),
         { mode: "auto" },
       );
       const interactionCall = geminiFetch.mock.calls.find(
@@ -2497,7 +2509,7 @@ describe("telegram adapter", () => {
       await waitFor(() => managerHarness.manager.sendMessage.mock.calls.length === 1);
       expect(managerHarness.manager.sendMessage).toHaveBeenCalledWith(
         "s23",
-        "use file transcription",
+        transcribedTelegramUserText("use file transcription"),
         { mode: "auto" },
       );
       expect(spawnImpl).toHaveBeenCalledWith(

--- a/test/telegram_session_manager.test.js
+++ b/test/telegram_session_manager.test.js
@@ -15,6 +15,17 @@ import { SESSION_PROTOCOL_VERSION } from "../dist/protocol/session_protocol.js";
 import { TauSessionProtocolResponseError } from "../dist/transport/errors.js";
 import { createProtocolSnapshot } from "./helpers/session_protocol_fixtures.js";
 
+const DEFAULT_TELEGRAM_SYSTEM_MESSAGE =
+  "This user message came from Telegram, and your assistant messages will be sent back to the Telegram chat. Adapt your communication style to this context. Answer straightforward requests directly. For work that involves tools or multiple steps, send a brief acknowledgement before starting and concise progress updates at meaningful points, since the user cannot see tool activity.";
+
+function telegramUserText(text, ...configuredSystemMessages) {
+  const configuredText =
+    configuredSystemMessages.length > 0
+      ? `<system>${configuredSystemMessages.join("\n")}</system>\n`
+      : "";
+  return `<system>${DEFAULT_TELEGRAM_SYSTEM_MESSAGE}</system>\n${configuredText}${text}`;
+}
+
 function deferred() {
   let resolve;
   let reject;
@@ -633,7 +644,7 @@ describe("telegram session manager", () => {
     );
   });
 
-  it("prepends configured system message to submitted user text", async () => {
+  it("prepends default and configured system messages to submitted user text", async () => {
     const clientHarness = createClientHarness();
     const manager = createTelegramSessionManager({
       projects: {
@@ -655,7 +666,7 @@ describe("telegram session manager", () => {
 
     await manager.sendMessage(created.id, "write issue about X");
     expect(clientHarness.session.submit).toHaveBeenCalledWith(
-      "<system>follow project conventions</system>\nwrite issue about X",
+      telegramUserText("write issue about X", "follow project conventions"),
       { historyEntryId: expect.stringMatching(/^telegram-turn-/) },
     );
 
@@ -691,7 +702,11 @@ describe("telegram session manager", () => {
       additionalSystemMessage: "this message came from telegram",
     });
     expect(clientHarness.session.submit).toHaveBeenCalledWith(
-      "<system>follow project conventions\nthis message came from telegram</system>\nwrite issue about X",
+      telegramUserText(
+        "write issue about X",
+        "follow project conventions",
+        "this message came from telegram",
+      ),
       { historyEntryId: expect.stringMatching(/^telegram-turn-/) },
     );
 
@@ -732,10 +747,10 @@ describe("telegram session manager", () => {
     await manager.sendMessage(created.id, "start work");
     await manager.sendMessage(created.id, "steer it", { mode: "steer" });
 
-    expect(clientHarness.session.submit).toHaveBeenCalledWith("start work", {
+    expect(clientHarness.session.submit).toHaveBeenCalledWith(telegramUserText("start work"), {
       historyEntryId: expect.stringMatching(/^telegram-turn-/),
     });
-    expect(clientHarness.session.steer).toHaveBeenCalledWith("steer it");
+    expect(clientHarness.session.steer).toHaveBeenCalledWith(telegramUserText("steer it"));
     expect(manager.getSession(created.id)?.state).toBe("running");
 
     firstSubmit.resolve({


### PR DESCRIPTION
## why

Telegram users cannot see tool activity, so agents need enough channel context to adapt their replies and provide useful progress signals. Audio transcripts also need an explicit warning that their text may be imperfect.

## what

Every Telegram turn now receives built-in hidden guidance describing the Telegram source and reply destination, favoring direct simple answers while encouraging acknowledgements and meaningful progress updates for tool-driven work. Configured top-level and per-bot guidance remains in a separate following system block, group guidance remains conditional, and turns containing audio transcripts receive their own transcription-quality warning.
