### PR TITLE
evict unobserved session runtimes

### DIFF
--- a/docs/remote-sessions.md
+++ b/docs/remote-sessions.md
@@ -186,7 +186,7 @@ Different changes have different owners:
 
 ## Reconnect and observe safely
 
-A WebSocket connection observes a hosted session; it does not own or delete it. If a TUI disconnects while a turn runs, the host keeps working. Reattach with the same session id to obtain the current persisted state and continue receiving updates.
+A WebSocket connection observes a hosted session; it does not own or delete its durable state. After the last observer disconnects, the host unloads an idle live runtime while retaining its persisted snapshot. If a client disconnects while work runs, the host keeps working and unloads the runtime only after that work settles. Reattach with the same session id to recover the current persisted state and continue receiving updates.
 
 A clean `tau serve` shutdown interrupts active work, persists live sessions, and closes clients. On restart, the host lists sessions whose execution environments it can restore. Recovery returns sessions idle, drops pending queued and steering messages, discards live subagents, and changes an active persistent goal to blocked. Use `/goal resume` only after checking why the host stopped.
 

--- a/src/host/hosted_ephemeral_agent_session.ts
+++ b/src/host/hosted_ephemeral_agent_session.ts
@@ -84,6 +84,7 @@ export class HostedEphemeralAgentSession {
 
   async submitThreadMessage(
     options: Omit<SessionProtocolEphemeralSubmitParams, "sessionId">,
+    signal?: AbortSignal,
   ): Promise<SessionProtocolEphemeralSubmitResult> {
     this.assertActive();
     if (options.contextId !== this.options.contextId) {
@@ -105,8 +106,18 @@ export class HostedEphemeralAgentSession {
     this.activeThreadIds.add(options.threadId);
     try {
       const thread = await this.getOrCreateThread(options.threadId, options.forkFromThreadId);
-      if (options.reasoning !== undefined) thread.setReasoning(options.reasoning);
-      return { threadId: options.threadId, response: await thread.submitMessage(options.message) };
+      signal?.throwIfAborted();
+      const interrupt = () => thread.interrupt();
+      signal?.addEventListener("abort", interrupt, { once: true });
+      try {
+        if (options.reasoning !== undefined) thread.setReasoning(options.reasoning);
+        return {
+          threadId: options.threadId,
+          response: await thread.submitMessage(options.message),
+        };
+      } finally {
+        signal?.removeEventListener("abort", interrupt);
+      }
     } finally {
       this.activeThreadIds.delete(options.threadId);
     }
@@ -277,6 +288,10 @@ class EphemeralAgentThread {
     const response = extractAssistantText(assistant).trim();
     if (!response) throw new Error("ephemeral agent thread produced an empty assistant response");
     return response;
+  }
+
+  interrupt(): boolean {
+    return this.runtime.interrupt();
   }
 
   dispose(): void {

--- a/src/host/local_session_host.ts
+++ b/src/host/local_session_host.ts
@@ -162,9 +162,11 @@ export type LocalHostedSession = TauHostedSession & {
 
 export class LocalSessionHost implements TauSessionHost {
   private readonly sessions = new Set<LocalHostedSessionHandle>();
+  private readonly sessionReferences = new Map<LocalHostedSessionHandle, number>();
+  private readonly sessionEvictions = new Set<Promise<void>>();
   private readonly sessionRecoveryPromises = new Map<
     string,
-    Promise<LocalHostedSession | undefined>
+    Promise<LocalHostedSessionHandle | undefined>
   >();
   private readonly store: SessionStore;
   private readonly history: HistoryManager;
@@ -232,13 +234,13 @@ export class LocalSessionHost implements TauSessionHost {
       throw new Error("local session host is shut down");
     }
 
-    return hostedSession;
+    return this.retainSession(hostedSession);
   }
 
   private async createRecoveredSession(
     snapshot: SessionProtocolSnapshot,
     executionEnvironment: ExecutionEnvironment,
-  ): Promise<LocalHostedSession> {
+  ): Promise<LocalHostedSessionHandle> {
     let hostedSession: LocalHostedSessionHandle | undefined;
     try {
       const recovered = normalizeRecoveredSnapshot(snapshot);
@@ -371,7 +373,10 @@ export class LocalSessionHost implements TauSessionHost {
       committedSnapshot,
       forceNextSnapshotRevision,
       this.sessionOptions.recordUsage ?? appendUsageLogEntry,
-      (session) => this.sessions.delete(session),
+      (session) => {
+        this.sessions.delete(session);
+        this.sessionReferences.delete(session);
+      },
     );
     const historyFailure = this.history.registerSession(
       {
@@ -449,24 +454,26 @@ export class LocalSessionHost implements TauSessionHost {
     this.assertHostActive();
     const liveSession = this.findLiveSession(sessionId);
     if (liveSession) {
-      return liveSession;
+      return this.retainSession(liveSession);
     }
 
     await this.refreshStore();
     const refreshedLiveSession = this.findLiveSession(sessionId);
     if (refreshedLiveSession) {
-      return refreshedLiveSession;
+      return this.retainSession(refreshedLiveSession);
     }
 
     const existingRecovery = this.sessionRecoveryPromises.get(sessionId);
     if (existingRecovery) {
-      return await existingRecovery;
+      const recovered = await existingRecovery;
+      return recovered ? this.retainSession(recovered) : undefined;
     }
 
     const recovery = this.recoverSession(sessionId);
     this.sessionRecoveryPromises.set(sessionId, recovery);
     try {
-      return await recovery;
+      const recovered = await recovery;
+      return recovered ? this.retainSession(recovered) : undefined;
     } finally {
       if (this.sessionRecoveryPromises.get(sessionId) === recovery) {
         this.sessionRecoveryPromises.delete(sessionId);
@@ -474,7 +481,7 @@ export class LocalSessionHost implements TauSessionHost {
     }
   }
 
-  private async recoverSession(sessionId: string): Promise<LocalHostedSession | undefined> {
+  private async recoverSession(sessionId: string): Promise<LocalHostedSessionHandle | undefined> {
     if (this.shuttingDown) {
       return undefined;
     }
@@ -520,6 +527,45 @@ export class LocalSessionHost implements TauSessionHost {
       }
     }
     return undefined;
+  }
+
+  private retainSession(session: LocalHostedSessionHandle): LocalHostedSessionHandle {
+    this.sessionReferences.set(session, (this.sessionReferences.get(session) ?? 0) + 1);
+    return session;
+  }
+
+  releaseSession(session: TauHostedSession): void {
+    const hostedSession = [...this.sessions].find((candidate) => candidate === session);
+    if (!hostedSession) return;
+
+    const references = this.sessionReferences.get(hostedSession);
+    if (references === undefined) return;
+    if (references > 1) {
+      this.sessionReferences.set(hostedSession, references - 1);
+      return;
+    }
+
+    this.sessionReferences.delete(hostedSession);
+    const eviction = this.evictReleasedSession(hostedSession);
+    this.sessionEvictions.add(eviction);
+    void eviction.then(
+      () => this.sessionEvictions.delete(eviction),
+      () => this.sessionEvictions.delete(eviction),
+    );
+  }
+
+  private async evictReleasedSession(session: LocalHostedSessionHandle): Promise<void> {
+    await session.waitForActiveWork().catch(() => undefined);
+    if (this.shuttingDown || session.isDisposed || (this.sessionReferences.get(session) ?? 0) > 0) {
+      return;
+    }
+
+    await session.snapshot();
+    if (this.shuttingDown || (this.sessionReferences.get(session) ?? 0) > 0) return;
+
+    this.sessions.delete(session);
+    this.sessionReferences.delete(session);
+    await session.dispose();
   }
 
   async listSessions(): Promise<SessionProtocolSessionSummary[]> {
@@ -588,6 +634,15 @@ export class LocalSessionHost implements TauSessionHost {
       }
     }
     this.sessions.clear();
+    this.sessionReferences.clear();
+
+    const evictionResults = await Promise.allSettled(this.sessionEvictions);
+    for (const result of evictionResults) {
+      if (result.status === "rejected") {
+        errors.push(result.reason);
+      }
+    }
+    this.sessionEvictions.clear();
 
     try {
       await this.history.flush();

--- a/src/host/local_session_host.ts
+++ b/src/host/local_session_host.ts
@@ -1641,7 +1641,7 @@ class LocalHostedSessionHandle implements LocalHostedSession {
     if (!session) {
       throw new Error(`unknown ephemeral context '${options.contextId}'`);
     }
-    return await session.submitThreadMessage(options);
+    return await this.runActiveWork((signal) => session.submitThreadMessage(options, signal));
   }
 
   async closeEphemeralContext(contextId: string): Promise<SessionProtocolEphemeralCloseResult> {

--- a/src/host/session_host.ts
+++ b/src/host/session_host.ts
@@ -142,6 +142,7 @@ export type TauHostedSession = {
 export type TauSessionHost = {
   createSession(input: SessionProtocolCreateParams): Promise<TauHostedSession>;
   observeSession(sessionId: string): Promise<TauHostedSession | undefined>;
+  releaseSession?(session: TauHostedSession): void;
   listSessions(): Promise<SessionProtocolSessionSummary[]>;
   registerClientTools?(options: {
     tools: SessionProtocolClientToolDefinition[];

--- a/src/host/session_host.ts
+++ b/src/host/session_host.ts
@@ -142,7 +142,7 @@ export type TauHostedSession = {
 export type TauSessionHost = {
   createSession(input: SessionProtocolCreateParams): Promise<TauHostedSession>;
   observeSession(sessionId: string): Promise<TauHostedSession | undefined>;
-  releaseSession?(session: TauHostedSession): void;
+  releaseSession(session: TauHostedSession): void;
   listSessions(): Promise<SessionProtocolSessionSummary[]>;
   registerClientTools?(options: {
     tools: SessionProtocolClientToolDefinition[];

--- a/src/host/session_protocol_handler.ts
+++ b/src/host/session_protocol_handler.ts
@@ -191,6 +191,7 @@ export class SessionProtocolHandler {
   private readonly host: TauSessionHost;
   private readonly send: (message: SessionProtocolOutgoingMessage) => void;
   private readonly sessionStates = new Map<string, SessionProtocolHandlerSessionState>();
+  private readonly sessionObservationQueues = new Map<string, Promise<void>>();
   private readonly connectionAbortController = new AbortController();
   private readonly activeSideChannels = new Set<Promise<void>>();
   private readonly activeExecAbortControllers = new Map<string, AbortController>();
@@ -768,6 +769,22 @@ export class SessionProtocolHandler {
   }
 
   private async handleAttach(
+    request: Extract<SessionProtocolRequestMessage, { method: "session.observe" }>,
+  ): Promise<void> {
+    const sessionId = request.params.sessionId;
+    const previous = this.sessionObservationQueues.get(sessionId) ?? Promise.resolve();
+    const observation = previous.catch(() => undefined).then(() => this.handleAttachNow(request));
+    this.sessionObservationQueues.set(sessionId, observation);
+    try {
+      await observation;
+    } finally {
+      if (this.sessionObservationQueues.get(sessionId) === observation) {
+        this.sessionObservationQueues.delete(sessionId);
+      }
+    }
+  }
+
+  private async handleAttachNow(
     request: Extract<SessionProtocolRequestMessage, { method: "session.observe" }>,
   ): Promise<void> {
     const wasObserved = this.sessionStates.get(request.params.sessionId)?.observed ?? false;
@@ -1584,6 +1601,7 @@ export class SessionProtocolHandler {
   private registerSession(session: TauHostedSession): SessionProtocolHandlerSessionState {
     const existing = this.sessionStates.get(session.sessionId);
     if (existing) {
+      this.host.releaseSession(session);
       return existing;
     }
 
@@ -1666,7 +1684,7 @@ export class SessionProtocolHandler {
     const session = await this.host.observeSession(sessionId);
     if (!session) return undefined;
     if (this.closed) {
-      this.host.releaseSession?.(session);
+      this.host.releaseSession(session);
       return undefined;
     }
     return this.registerSession(session);
@@ -1802,7 +1820,7 @@ export class SessionProtocolHandler {
     this.clientToolRegistration?.detachSession(state.session.sessionId);
     if (!state.released) {
       state.released = true;
-      this.host.releaseSession?.(state.session);
+      this.host.releaseSession(state.session);
     }
 
     state.unsubscribeDelta?.();

--- a/src/host/session_protocol_handler.ts
+++ b/src/host/session_protocol_handler.ts
@@ -93,6 +93,8 @@ type SessionProtocolHandlerSessionState = {
   bufferedDeltas?: SessionProtocolDeltaMessage[];
   bufferedPendingUserMessages?: SessionProtocolPendingUserMessagesMessage[];
   bufferedSubagentActivities?: SessionProtocolSubagentActivitiesMessage[];
+  observed: boolean;
+  released: boolean;
 };
 
 type SessionMutationQueueState = {
@@ -747,6 +749,7 @@ export class SessionProtocolHandler {
       await session.dispose();
       return;
     }
+    this.registerSession(session);
     this.sendMessage(
       createSessionProtocolSuccessResponse(request.id, "session.create", {
         sessionId: session.sessionId,
@@ -767,7 +770,7 @@ export class SessionProtocolHandler {
   private async handleAttach(
     request: Extract<SessionProtocolRequestMessage, { method: "session.observe" }>,
   ): Promise<void> {
-    const wasObserved = this.sessionStates.has(request.params.sessionId);
+    const wasObserved = this.sessionStates.get(request.params.sessionId)?.observed ?? false;
     const state = await this.getSessionState(request.params.sessionId);
     if (!state) {
       this.sendMessage(
@@ -797,6 +800,7 @@ export class SessionProtocolHandler {
         }),
       );
       observed = true;
+      state.observed = true;
       this.flushBufferedDeltasAfterSnapshot(state, snapshot.revision);
       this.flushBufferedPendingUserMessagesAfter(state, pendingUserMessages.revision);
       this.flushBufferedSubagentActivitiesAfter(state, subagentActivities.revision);
@@ -1586,6 +1590,8 @@ export class SessionProtocolHandler {
     const state: SessionProtocolHandlerSessionState = {
       session,
       live: getSessionLiveState(session),
+      observed: false,
+      released: false,
     };
 
     state.unsubscribeDelta = session.onDelta((delta) => {
@@ -1658,7 +1664,9 @@ export class SessionProtocolHandler {
     }
 
     const session = await this.host.observeSession(sessionId);
-    if (!session || this.closed) {
+    if (!session) return undefined;
+    if (this.closed) {
+      this.host.releaseSession?.(session);
       return undefined;
     }
     return this.registerSession(session);
@@ -1792,6 +1800,10 @@ export class SessionProtocolHandler {
 
   private unsubscribeSessionListeners(state: SessionProtocolHandlerSessionState): void {
     this.clientToolRegistration?.detachSession(state.session.sessionId);
+    if (!state.released) {
+      state.released = true;
+      this.host.releaseSession?.(state.session);
+    }
 
     state.unsubscribeDelta?.();
     state.unsubscribeDelta = undefined;

--- a/test/in_process_session_transport.test.js
+++ b/test/in_process_session_transport.test.js
@@ -211,6 +211,7 @@ function createHost() {
       async observeSession(sessionId) {
         return sessions.get(sessionId);
       },
+      releaseSession() {},
       async listSessions() {
         return [...sessions.values()].map((session) => ({
           sessionId: session.sessionId,

--- a/test/local_session_host.test.js
+++ b/test/local_session_host.test.js
@@ -5098,6 +5098,64 @@ describe("LocalSessionHost", () => {
     expect(executionEnvironment.dispose).toHaveBeenCalledTimes(1);
   });
 
+  it("evicts an idle live session after its final observer releases it", async () => {
+    const store = new MemorySessionStore();
+    const host = createHost(store);
+    const session = await host.createSession(localCreateInput);
+    await session.record({ text: "recover after observer release" });
+    const storedSnapshot = await session.snapshot();
+    const secondObserver = await host.observeSession(session.sessionId);
+    expect(secondObserver).toBe(session);
+
+    host.releaseSession(session);
+    await Promise.resolve();
+    expect(session.isDisposed).toBe(false);
+
+    host.releaseSession(secondObserver);
+    await vi.waitFor(() => expect(session.isDisposed).toBe(true));
+
+    const recoveredSession = await host.observeSession(storedSnapshot.sessionId);
+    expect(recoveredSession).toBeDefined();
+    expect(recoveredSession).not.toBe(session);
+    await expect(recoveredSession.snapshot()).resolves.toEqual(storedSnapshot);
+    host.releaseSession(recoveredSession);
+    await host.shutdown();
+  });
+
+  it("keeps an unobserved live session until active work settles", async () => {
+    const store = new MemorySessionStore();
+    const host = createHost(store);
+    const session = await host.createSession(localCreateInput);
+    let markModelStarted;
+    const modelStarted = new Promise((resolve) => {
+      markModelStarted = resolve;
+    });
+    let releaseModel;
+    const modelReleased = new Promise((resolve) => {
+      releaseModel = resolve;
+    });
+    session.runtime.agent.spec.model.stream = () => ({
+      async *[Symbol.asyncIterator]() {},
+      async result() {
+        markModelStarted();
+        await modelReleased;
+        return fauxAssistantMessage("finished while detached");
+      },
+    });
+
+    await session.record({ text: "finish without an observer" });
+    const turn = session.runTurn();
+    await modelStarted;
+    host.releaseSession(session);
+    await Promise.resolve();
+    expect(session.isDisposed).toBe(false);
+
+    releaseModel();
+    await expect(turn).resolves.toEqual({ status: "completed", stopReason: "stop" });
+    await vi.waitFor(() => expect(session.isDisposed).toBe(true));
+    await host.shutdown();
+  });
+
   it("removes directly disposed live handles from host recovery bookkeeping", async () => {
     const store = new MemorySessionStore();
     const host = createHost(store);

--- a/test/local_session_host.test.js
+++ b/test/local_session_host.test.js
@@ -5156,6 +5156,52 @@ describe("LocalSessionHost", () => {
     await host.shutdown();
   });
 
+  it("keeps an unobserved live session until an ephemeral submission settles", async () => {
+    const store = new MemorySessionStore();
+    const host = createHost(store);
+    const session = await host.createSession(localCreateInput);
+    const { contextId } = await session.createEphemeralContext({
+      instructions: "review instructions",
+      tools: [],
+    });
+    const hostedContext = session.ephemeralAgentSessions.get(contextId);
+    const thread = await hostedContext.getOrCreateThread("thread-1");
+    let markModelStarted;
+    const modelStarted = new Promise((resolve) => {
+      markModelStarted = resolve;
+    });
+    let releaseModel;
+    const modelReleased = new Promise((resolve) => {
+      releaseModel = resolve;
+    });
+    thread.runtime.spec.model.stream = () => ({
+      async *[Symbol.asyncIterator]() {},
+      async result() {
+        markModelStarted();
+        await modelReleased;
+        return fauxAssistantMessage("finished ephemeral work while detached");
+      },
+    });
+
+    const submission = session.submitEphemeralThread({
+      contextId,
+      threadId: "thread-1",
+      message: "finish without an observer",
+    });
+    await modelStarted;
+    host.releaseSession(session);
+    await Promise.resolve();
+    expect(session.isDisposed).toBe(false);
+
+    releaseModel();
+    await expect(submission).resolves.toEqual({
+      threadId: "thread-1",
+      response: "finished ephemeral work while detached",
+    });
+    await vi.waitFor(() => expect(session.isDisposed).toBe(true));
+    await host.shutdown();
+  });
+
   it("removes directly disposed live handles from host recovery bookkeeping", async () => {
     const store = new MemorySessionStore();
     const host = createHost(store);

--- a/test/session_protocol_handler.test.js
+++ b/test/session_protocol_handler.test.js
@@ -687,6 +687,45 @@ describe("SessionProtocolHandler", () => {
     expect(harness.releaseSession).toHaveBeenCalledWith(session);
   });
 
+  it("releases redundant handles acquired by concurrent session lookups", async () => {
+    const harness = createHarness();
+    let started = 0;
+    let markLookupsStarted;
+    const lookupsStarted = new Promise((resolve) => {
+      markLookupsStarted = resolve;
+    });
+    let releaseLookups;
+    const lookupBlocker = new Promise((resolve) => {
+      releaseLookups = resolve;
+    });
+    const observeSession = vi.fn(async (sessionId) => {
+      started += 1;
+      if (started === 2) markLookupsStarted();
+      await lookupBlocker;
+      return await harness.host.observeSession(sessionId);
+    });
+    const connection = new TestSessionProtocolConnection({
+      host: { ...harness.host, observeSession },
+      send: () => {},
+    });
+
+    const first = connection.handleRequest(
+      request("snapshot-1", "session.snapshot", { sessionId: "session-1" }),
+    );
+    const second = connection.handleRequest(
+      request("snapshot-2", "session.snapshot", { sessionId: "session-1" }),
+    );
+    await lookupsStarted;
+    releaseLookups();
+    await Promise.all([first, second]);
+
+    expect(observeSession).toHaveBeenCalledTimes(2);
+    expect(harness.releaseSession).toHaveBeenCalledTimes(1);
+
+    await connection.close();
+    expect(harness.releaseSession).toHaveBeenCalledTimes(2);
+  });
+
   it("returns busy for concurrent ephemeral thread submissions", async () => {
     const harness = createHarness({
       submitEphemeralThread: async ({ threadId }) => {
@@ -1391,6 +1430,56 @@ describe("SessionProtocolHandler", () => {
     await Promise.resolve();
 
     expect(observerLines.some((line) => deltaHasNotice(line, "after failed observe"))).toBe(false);
+    await observer.close();
+  });
+
+  it("preserves a successful observer when an overlapping observe fails", async () => {
+    let markSnapshotStarted;
+    const snapshotStarted = new Promise((resolve) => {
+      markSnapshotStarted = resolve;
+    });
+    let releaseSnapshot;
+    const snapshotBlocker = new Promise((resolve) => {
+      releaseSnapshot = resolve;
+    });
+    const harness = createHarness({
+      snapshotDelays: [
+        async () => {
+          markSnapshotStarted();
+          await snapshotBlocker;
+          throw new Error("snapshot unavailable");
+        },
+        0,
+      ],
+    });
+    const observerLines = [];
+    const observer = new TestSessionProtocolConnection({
+      host: harness.host,
+      send: (message) => observerLines.push(message),
+    });
+
+    const failed = observer.handleRequest(
+      request("attach-failed", "session.observe", { sessionId: "session-1" }),
+    );
+    await snapshotStarted;
+    const succeeded = observer.handleRequest(
+      request("attach-succeeded", "session.observe", { sessionId: "session-1" }),
+    );
+    releaseSnapshot();
+    await Promise.all([failed, succeeded]);
+
+    expect(observerLines.find((line) => line.id === "attach-failed")).toEqual(
+      expect.objectContaining({ ok: false }),
+    );
+    expect(observerLines.find((line) => line.id === "attach-succeeded")).toEqual(
+      expect.objectContaining({ ok: true }),
+    );
+
+    harness.emitNotice("after overlapping observe", 1);
+    expect(observerLines.some((line) => deltaHasNotice(line, "after overlapping observe"))).toBe(
+      true,
+    );
+
     await observer.close();
   });
 

--- a/test/session_protocol_handler.test.js
+++ b/test/session_protocol_handler.test.js
@@ -560,6 +560,7 @@ function createHarness(options = {}) {
   const hostShutdown = vi.fn(() => {
     sessions.clear();
   });
+  const releaseSession = vi.fn();
   const host = {
     async createSession() {
       return createHostedSession();
@@ -567,6 +568,7 @@ function createHarness(options = {}) {
     async observeSession(sessionId) {
       return sessions.get(sessionId);
     },
+    releaseSession,
     async listSessions() {
       return [...sessions.values()].map((session) => ({
         sessionId: session.sessionId,
@@ -588,6 +590,7 @@ function createHarness(options = {}) {
     connection,
     host,
     hostShutdown,
+    releaseSession,
     seededSession,
     releaseTurn: () => seededSession?.releaseTurn(),
     emitNotice: (text, revision) => seededSession?.emitNotice(text, revision),
@@ -669,6 +672,21 @@ describe("SessionProtocolHandler", () => {
     expect(list.result).toEqual({ sessions: [] });
   });
 
+  it("releases a created session when its protocol connection closes", async () => {
+    const harness = createHarness({ precreate: false });
+
+    await harness.connection.handleRequest(request("create", "session.create", localCreateParams));
+    const response = harness.lines.find(
+      (line) => line.type === "response" && line.id === "create" && line.ok,
+    );
+    const session = await harness.host.observeSession(response.result.sessionId);
+
+    await harness.connection.close();
+
+    expect(harness.releaseSession).toHaveBeenCalledTimes(1);
+    expect(harness.releaseSession).toHaveBeenCalledWith(session);
+  });
+
   it("returns busy for concurrent ephemeral thread submissions", async () => {
     const harness = createHarness({
       submitEphemeralThread: async ({ threadId }) => {
@@ -736,6 +754,7 @@ describe("SessionProtocolHandler", () => {
     await create;
 
     expect(harness.seededSession.createEphemeralContext).not.toHaveBeenCalled();
+    expect(harness.releaseSession).toHaveBeenCalledWith(harness.seededSession);
     expect(lines.some((line) => line.id === "ephemeral-create")).toBe(false);
   });
 

--- a/test/websocket_session_transport.test.js
+++ b/test/websocket_session_transport.test.js
@@ -200,6 +200,7 @@ function createHost(options = {}) {
       async observeSession(sessionId) {
         return sessions.get(sessionId);
       },
+      releaseSession() {},
       async listSessions() {
         return [...sessions.values()].map((session) => ({
           sessionId: session.sessionId,


### PR DESCRIPTION
## why

Tau Serve retained every live session runtime after its WebSocket client disconnected. Durable session snapshots remained useful for recovery, but keeping histories, runtime state, prompts, and execution environments resident indefinitely caused memory use to grow with every Cowork workflow.

## what

Track observer references for hosted sessions and release them when protocol connections close. After the final observer disconnects, idle runtimes are snapshotted and disposed while their durable session remains recoverable. Active detached work is allowed to settle before eviction, and recovery races and multiple observers preserve the runtime until it is genuinely unused.

The remote-session documentation and host and protocol regression coverage now reflect these lifecycle semantics.
