### PR TITLE
reduce long-session tui rendering work

### DIFF
--- a/src/protocol/session_protocol.ts
+++ b/src/protocol/session_protocol.ts
@@ -3771,10 +3771,10 @@ export function applySessionProtocolDelta(
     return contentAppendSnapshot;
   }
 
-  const keyedPatchSnapshot = applyKeyedRecordDelta(snapshot, message);
-  if (keyedPatchSnapshot) {
-    validateAppliedSnapshotChanges(snapshot, keyedPatchSnapshot, message.delta.changes);
-    return keyedPatchSnapshot;
+  const structurallySharedSnapshot = applyStructurallySharedPatch(snapshot, message);
+  if (structurallySharedSnapshot) {
+    validateAppliedSnapshotChanges(snapshot, structurallySharedSnapshot, message.delta.changes);
+    return structurallySharedSnapshot;
   }
 
   const next = structuredClone(snapshot);
@@ -3974,7 +3974,7 @@ function setSessionProtocolTurn(
   });
 }
 
-function applyKeyedRecordDelta(
+function applyStructurallySharedPatch(
   snapshot: SessionProtocolSnapshot,
   message: SessionProtocolDeltaMessage,
 ): SessionProtocolSnapshot | undefined {
@@ -3982,6 +3982,9 @@ function applyKeyedRecordDelta(
     return undefined;
   }
 
+  const topLevelChanges: Partial<
+    Pick<SessionProtocolSnapshot, "agentState" | "lifecycle" | "goal" | "costTotal" | "settings">
+  > = {};
   let nextTurns: SessionProtocolSnapshot["turns"] | undefined;
   let nextTools: SessionProtocolSnapshot["tools"] | undefined;
   let nextOperations: SessionProtocolSnapshot["operations"] | undefined;
@@ -4011,6 +4014,21 @@ function applyKeyedRecordDelta(
 
   for (const change of message.delta.changes) {
     switch (change.type) {
+      case "agent-state.set":
+        topLevelChanges.agentState = structuredClone(change.agentState);
+        break;
+      case "lifecycle.set":
+        topLevelChanges.lifecycle = change.lifecycle;
+        break;
+      case "goal.set":
+        topLevelChanges.goal = structuredClone(change.goal);
+        break;
+      case "cost.set":
+        topLevelChanges.costTotal = change.costTotal;
+        break;
+      case "settings.set":
+        topLevelChanges.settings = structuredClone(change.settings);
+        break;
       case "turn.set":
         setSessionProtocolTurn(cloneTurns(), change.turn);
         break;
@@ -4045,6 +4063,7 @@ function applyKeyedRecordDelta(
 
   return {
     ...snapshot,
+    ...topLevelChanges,
     revision: message.toRevision,
     ...(nextTurns ? { turns: nextTurns } : {}),
     ...(nextTools ? { tools: nextTools } : {}),

--- a/src/tui/session_chat_controller.ts
+++ b/src/tui/session_chat_controller.ts
@@ -1356,6 +1356,9 @@ export class SessionChatController {
     }
 
     try {
+      if (this.tryApplyFastSnapshotStateDelta(delta)) {
+        return true;
+      }
       if (this.tryApplyFastContentAppendDelta(delta)) {
         return true;
       }
@@ -1388,6 +1391,36 @@ export class SessionChatController {
       ]);
       return false;
     }
+    return true;
+  }
+
+  private tryApplyFastSnapshotStateDelta(delta: SessionProtocolDeltaMessage): boolean {
+    if (
+      delta.delta.type !== "snapshot.patch" ||
+      delta.delta.changes.length === 0 ||
+      delta.delta.changes.some((change) => {
+        switch (change.type) {
+          case "agent-state.set":
+          case "lifecycle.set":
+          case "goal.set":
+          case "cost.set":
+          case "settings.set":
+          case "turn.set":
+          case "operation.set":
+          case "operation.remove":
+            return false;
+          default:
+            return true;
+        }
+      })
+    ) {
+      return false;
+    }
+
+    this.snapshot = applySessionProtocolDelta(this.snapshot, delta);
+    this.observedSessionRevision = Math.max(this.observedSessionRevision, this.snapshot.revision);
+    this.updateStreamingStateFromSnapshot(this.snapshot);
+    this.refreshStatus();
     return true;
   }
 
@@ -1481,7 +1514,35 @@ export class SessionChatController {
     }
 
     const nextSnapshot = applySessionProtocolDelta(this.snapshot, delta);
-    this.syncRenderedHistory(nextSnapshot);
+    this.snapshot = nextSnapshot;
+    this.observedSessionRevision = Math.max(this.observedSessionRevision, nextSnapshot.revision);
+
+    const toolIds = new Set<string>();
+    for (const change of delta.delta.changes) {
+      if (change.type === "tool.set") {
+        toolIds.add(change.tool.id);
+      } else if (change.type === "facet.set" && change.facet.subject.type === "tool") {
+        toolIds.add(change.facet.subject.id);
+      }
+    }
+
+    for (const item of [...nextSnapshot.timeline.items, ...this.ephemeralTimelineItems.values()]) {
+      if (item.type !== "tool" || !toolIds.has(item.toolId)) {
+        continue;
+      }
+      const tool = nextSnapshot.tools[item.toolId];
+      if (!tool) {
+        continue;
+      }
+      const model = { type: "tool" as const, tool: buildToolUiModel(nextSnapshot, tool) };
+      const viewMessageId = this.getViewMessageId(item.id);
+      if (this.renderedMessageIds.includes(viewMessageId)) {
+        this.view.updateMessage(viewMessageId, model);
+      } else {
+        this.renderedMessageIds.push(this.view.addMessage(model, viewMessageId));
+      }
+    }
+
     this.refreshStatus();
     return true;
   }

--- a/src/tui/ui/footer.ts
+++ b/src/tui/ui/footer.ts
@@ -51,7 +51,7 @@ const WORKING_ANIMATIONS = [
   ],
 ] as const;
 
-const WORKING_FRAME_INTERVALS = [120, 120, 120, 120, 80] as const;
+const WORKING_FRAME_INTERVALS = [240, 240, 240, 240, 160] as const;
 export const DEFAULT_FOOTER_NOTICE_DURATION_MS = 3000;
 const COMPLETION_DURATION_MS = 3000;
 const IDLE_ICON = "○";

--- a/test/session_chat_controller.test.js
+++ b/test/session_chat_controller.test.js
@@ -3049,6 +3049,61 @@ describe("SessionChatController", () => {
     expect(session.submit).not.toHaveBeenCalled();
   });
 
+  it("applies snapshot state deltas without reconciling transcript messages", async () => {
+    const snapshot = createSnapshot([
+      {
+        id: "user-1",
+        message: { role: "user", content: [{ type: "text", text: "hello" }] },
+      },
+      {
+        id: "assistant-1",
+        message: createAssistantMessage("hi"),
+      },
+    ]);
+    const session = new FakeSession(snapshot);
+    const view = new FakeView();
+    const controller = new SessionChatController({
+      view,
+      session,
+      snapshot: await session.snapshot(),
+      targetLabel: "local",
+    });
+
+    controller.start();
+    const addMessageSpy = vi.spyOn(view, "addMessage");
+    const updateMessageSpy = vi.spyOn(view, "updateMessage");
+    const updateAssistantMessageSpy = vi.spyOn(view, "updateAssistantMessage");
+    const delta = {
+      version: SESSION_PROTOCOL_VERSION,
+      type: "session.delta",
+      sessionId: session.id,
+      fromRevision: snapshot.revision,
+      toRevision: snapshot.revision + 1,
+      cause: { type: "configuration" },
+      delta: {
+        type: "snapshot.patch",
+        changes: [
+          {
+            type: "settings.set",
+            settings: { ...snapshot.settings, reasoning: "high" },
+          },
+        ],
+      },
+    };
+    session.snapshotValue = applySessionProtocolDelta(session.snapshotValue, delta);
+
+    for (const listener of session.listeners) {
+      listener(delta);
+    }
+
+    expect(addMessageSpy).not.toHaveBeenCalled();
+    expect(updateMessageSpy).not.toHaveBeenCalled();
+    expect(updateAssistantMessageSpy).not.toHaveBeenCalled();
+    expect(view.status.editor.reasoning).toBe("high");
+    expect(controller.snapshot.messages).toBe(snapshot.messages);
+    await controller.dispose();
+  });
+
   it("applies assistant content append deltas without full snapshot reconciliation", async () => {
     const baseSnapshot = createSnapshot();
     const snapshot = updateSnapshot(baseSnapshot, {
@@ -3850,6 +3905,8 @@ describe("SessionChatController", () => {
 
     controller.start();
     const resetCount = view.resetToolUiSession.mock.calls.length;
+    const updateMessageSpy = vi.spyOn(view, "updateMessage");
+    const updateAssistantMessageSpy = vi.spyOn(view, "updateAssistantMessage");
     const delta = {
       version: SESSION_PROTOCOL_VERSION,
       type: "session.delta",
@@ -3888,6 +3945,10 @@ describe("SessionChatController", () => {
         presentation: expect.objectContaining({ subject: "echo a" }),
       }),
     ]);
+    expect(updateMessageSpy).toHaveBeenCalledTimes(1);
+    expect(updateMessageSpy.mock.calls[0]?.[1].type).toBe("tool");
+    expect(updateAssistantMessageSpy).not.toHaveBeenCalled();
+    updateMessageSpy.mockClear();
 
     const facetDelta = {
       version: SESSION_PROTOCOL_VERSION,
@@ -3925,6 +3986,9 @@ describe("SessionChatController", () => {
         presentation: expect.objectContaining({ subject: "echo a\necho b" }),
       }),
     ]);
+    expect(updateMessageSpy).toHaveBeenCalledTimes(1);
+    expect(updateMessageSpy.mock.calls[0]?.[1].type).toBe("tool");
+    expect(updateAssistantMessageSpy).not.toHaveBeenCalled();
     expect(view.status.footer.sessionCost).toBe("$0.42");
     expect(controller.snapshot.tools["tool-a"].status).toBe("running");
     await controller.dispose();

--- a/test/session_protocol.test.js
+++ b/test/session_protocol.test.js
@@ -2453,18 +2453,19 @@ describe("session_protocol", () => {
         ],
       },
     });
-    const settingsPatchedSnapshot = applySessionProtocolDelta(
-      createProtocolSnapshot({
-        sessionId: "session-1",
-        revision: 2,
-      }),
-      settingsDelta,
-    );
+    const settingsSnapshot = createProtocolSnapshot({
+      sessionId: "session-1",
+      revision: 2,
+    });
+    const settingsPatchedSnapshot = applySessionProtocolDelta(settingsSnapshot, settingsDelta);
     expect(settingsPatchedSnapshot.revision).toBe(3);
     expect(settingsPatchedSnapshot.settings).toEqual({
       personaId: "default",
       reasoning: "high",
     });
+    expect(settingsPatchedSnapshot.settings).not.toBe(settingsSnapshot.settings);
+    expect(settingsPatchedSnapshot.messages).toBe(settingsSnapshot.messages);
+    expect(settingsPatchedSnapshot.timeline).toBe(settingsSnapshot.timeline);
 
     const goalDelta = createSessionProtocolDeltaMessage({
       sessionId: "session-1",

--- a/test/ui_components.test.js
+++ b/test/ui_components.test.js
@@ -537,7 +537,7 @@ test("FooterComponent renders activity instead of regular status", () => {
     expect(text).toContain("<feedback>compacting context</feedback>");
     expect(text).not.toContain("tau-one");
 
-    vi.advanceTimersByTime(120);
+    vi.advanceTimersByTime(240);
     expect(renderText(footer, 120)).toContain("<feedback>⠙</feedback>");
 
     footer.setStatus({
@@ -685,11 +685,11 @@ test("FooterComponent uses distinct standard and sand cadences", () => {
     expect(renderLines(dots, 20)[0]).toContain("<brandAccent>⠋</brandAccent>");
     expect(renderLines(sand, 20)[0]).toContain("<brandAccent>⠀</brandAccent>");
 
-    vi.advanceTimersByTime(120);
+    vi.advanceTimersByTime(240);
     expect(renderLines(dots, 20)[0]).toContain("<brandAccent>⠙</brandAccent>");
     expect(renderLines(sand, 20)[0]).toContain("<brandAccent>⠀</brandAccent>");
 
-    vi.advanceTimersByTime(40);
+    vi.advanceTimersByTime(80);
     expect(renderLines(sand, 20)[0]).toContain("<brandAccent>⠁</brandAccent>");
   } finally {
     dots.dispose();


### PR DESCRIPTION
## why

Long-lived TUI sessions do avoidable work for small session updates. Settings and tool status deltas can rebuild the full active transcript, while the animated working indicator repeatedly pays the growing main-screen render cost.

This addresses the low-risk first batch from #481 without changing compaction or transcript retention behavior.

## what

State-only protocol patches now preserve unchanged snapshot collections, and the TUI applies them without reconciling transcript messages. Tool and presentation-facet patches update only the affected tool cards instead of replaying the active timeline.

The working indicator remains animated with all existing animation variants, but its dedicated frame cadence is reduced by half to lower background rendering pressure. Regression coverage verifies structural sharing, targeted delta updates, and the retained animation cadence.
