### PR TITLE
target tui timeline updates

### DIFF
--- a/src/tui/session_chat_controller.ts
+++ b/src/tui/session_chat_controller.ts
@@ -1362,7 +1362,7 @@ export class SessionChatController {
       if (this.tryApplyFastContentAppendDelta(delta)) {
         return true;
       }
-      if (this.tryApplyFastToolUiDelta(delta)) {
+      if (this.tryApplyFastTimelineDelta(delta)) {
         return true;
       }
       if (this.tryApplyFastAgentDelta(delta)) {
@@ -1406,6 +1406,7 @@ export class SessionChatController {
           case "cost.set":
           case "settings.set":
           case "turn.set":
+          case "timeline.advance":
           case "operation.set":
           case "operation.remove":
             return false;
@@ -1466,6 +1467,119 @@ export class SessionChatController {
     return true;
   }
 
+  private tryApplyFastTimelineDelta(delta: SessionProtocolDeltaMessage): boolean {
+    if (delta.delta.type !== "snapshot.patch" || delta.delta.changes.length === 0) {
+      return false;
+    }
+
+    const previousSnapshot = this.snapshot;
+    const affectedMessageIds = new Set<string>();
+    const affectedToolIds = new Set<string>();
+    const appendedNotices: Array<Extract<SessionProtocolTimelineItem, { type: "notice" }>> = [];
+    let hasTimelineChange = false;
+
+    for (const change of delta.delta.changes) {
+      switch (change.type) {
+        case "agent-state.set":
+        case "lifecycle.set":
+        case "goal.set":
+        case "cost.set":
+        case "settings.set":
+        case "turn.set":
+        case "timeline.advance":
+        case "operation.set":
+        case "operation.remove":
+          break;
+        case "message.append":
+        case "message.replace":
+          hasTimelineChange = true;
+          affectedMessageIds.add(change.message.id);
+          break;
+        case "message.content.append":
+          hasTimelineChange = true;
+          affectedMessageIds.add(change.messageId);
+          break;
+        case "timeline.append":
+          hasTimelineChange = true;
+          if (change.item.type === "message") {
+            affectedMessageIds.add(change.item.messageId);
+          } else if (change.item.type === "tool") {
+            affectedToolIds.add(change.item.toolId);
+          } else if (change.item.type === "notice") {
+            appendedNotices.push(change.item);
+          }
+          break;
+        case "tool.set":
+          hasTimelineChange = true;
+          affectedToolIds.add(change.tool.id);
+          break;
+        case "facet.set":
+          if (change.facet.kind !== "tau.tool-ui-events" || change.facet.subject.type !== "tool") {
+            return false;
+          }
+          hasTimelineChange = true;
+          affectedToolIds.add(change.facet.subject.id);
+          break;
+        default:
+          return false;
+      }
+    }
+
+    if (!hasTimelineChange) {
+      return false;
+    }
+
+    const nextSnapshot = applySessionProtocolDelta(previousSnapshot, delta);
+    this.snapshot = nextSnapshot;
+    this.observedSessionRevision = Math.max(this.observedSessionRevision, nextSnapshot.revision);
+
+    for (const messageId of affectedMessageIds) {
+      const message = nextSnapshot.messages.find((entry) => entry.id === messageId);
+      if (message) {
+        this.syncProtocolMessage(message);
+      } else {
+        this.removeProtocolMessage(messageId);
+      }
+    }
+
+    if (affectedToolIds.size > 0) {
+      for (const item of [
+        ...nextSnapshot.timeline.items,
+        ...this.ephemeralTimelineItems.values(),
+      ]) {
+        if (item.type !== "tool" || !affectedToolIds.has(item.toolId)) {
+          continue;
+        }
+        const tool = nextSnapshot.tools[item.toolId];
+        if (tool) {
+          this.upsertRenderedMessage(item.id, {
+            type: "tool",
+            tool: buildToolUiModel(nextSnapshot, tool),
+          });
+        }
+      }
+    }
+
+    for (const item of appendedNotices.sort((left, right) => left.sequence - right.sequence)) {
+      const nextItem = nextSnapshot.timeline.items.find((candidate) => candidate.id === item.id);
+      if (nextItem?.type !== "notice") {
+        continue;
+      }
+      this.upsertRenderedMessage(nextItem.id, {
+        type: "transcript_notice",
+        title: nextItem.notice.presentation.title,
+        ...(nextItem.notice.presentation.content
+          ? { content: nextItem.notice.presentation.content }
+          : {}),
+        tone: nextItem.notice.severity === "error" ? "error" : "default",
+      });
+    }
+
+    this.updateStreamingStateFromSnapshot(nextSnapshot);
+    this.refreshStatus();
+    return true;
+  }
+
   private tryApplyFastAgentDelta(delta: SessionProtocolDeltaMessage): boolean {
     if (delta.delta.type !== "snapshot.patch") {
       return false;
@@ -1493,58 +1607,80 @@ export class SessionChatController {
     return true;
   }
 
-  private tryApplyFastToolUiDelta(delta: SessionProtocolDeltaMessage): boolean {
-    if (
-      delta.delta.type !== "snapshot.patch" ||
-      delta.delta.changes.length === 0 ||
-      delta.delta.changes.some(
-        (change) => change.type !== "tool.set" && change.type !== "facet.set",
-      )
-    ) {
-      return false;
+  private syncProtocolMessage(message: SessionProtocolMessage): void {
+    if (this.hiddenHistoryEntryIds.has(message.id) || !this.isMessageProjected(message.id)) {
+      this.removeProtocolMessage(message.id);
+      return;
     }
 
-    const facetChanges = delta.delta.changes.filter((change) => change.type === "facet.set");
-    if (
-      facetChanges.some(
-        ({ facet }) => facet.kind !== "tau.tool-ui-events" || facet.subject.type !== "tool",
-      )
-    ) {
-      return false;
+    const model = this.buildProtocolMessageModel(message);
+    if (model) {
+      this.upsertRenderedMessage(message.id, model);
+    } else {
+      this.removeRenderedProtocolItems([message.id]);
     }
 
-    const nextSnapshot = applySessionProtocolDelta(this.snapshot, delta);
-    this.snapshot = nextSnapshot;
-    this.observedSessionRevision = Math.max(this.observedSessionRevision, nextSnapshot.revision);
-
-    const toolIds = new Set<string>();
-    for (const change of delta.delta.changes) {
-      if (change.type === "tool.set") {
-        toolIds.add(change.tool.id);
-      } else if (change.type === "facet.set" && change.facet.subject.type === "tool") {
-        toolIds.add(change.facet.subject.id);
-      }
+    const outcomeNotice = getMessageOutcomeNotice(message);
+    const outcomeNoticeId = `presentation:failure:${message.id}`;
+    const interruptionNoticeId = `presentation:interruption:${message.id}`;
+    if (outcomeNotice) {
+      this.upsertRenderedMessage(outcomeNotice.id, {
+        type: "transcript_notice",
+        title: outcomeNotice.title,
+        ...(outcomeNotice.content ? { content: outcomeNotice.content } : {}),
+        tone: outcomeNotice.severity === "error" ? "error" : "default",
+      });
     }
+    if (outcomeNotice?.id !== outcomeNoticeId) {
+      this.removeRenderedProtocolItems([outcomeNoticeId]);
+    }
+    if (outcomeNotice?.id !== interruptionNoticeId) {
+      this.removeRenderedProtocolItems([interruptionNoticeId]);
+    }
+  }
 
-    for (const item of [...nextSnapshot.timeline.items, ...this.ephemeralTimelineItems.values()]) {
-      if (item.type !== "tool" || !toolIds.has(item.toolId)) {
-        continue;
-      }
-      const tool = nextSnapshot.tools[item.toolId];
-      if (!tool) {
-        continue;
-      }
-      const model = { type: "tool" as const, tool: buildToolUiModel(nextSnapshot, tool) };
-      const viewMessageId = this.getViewMessageId(item.id);
-      if (this.renderedMessageIds.includes(viewMessageId)) {
-        this.view.updateMessage(viewMessageId, model);
+  private removeProtocolMessage(messageId: string): void {
+    this.removeRenderedProtocolItems([
+      messageId,
+      `presentation:failure:${messageId}`,
+      `presentation:interruption:${messageId}`,
+    ]);
+  }
+
+  private upsertRenderedMessage(protocolId: string, model: ChatMessageModel): void {
+    const viewMessageId = this.getViewMessageId(protocolId);
+    if (this.renderedMessageIds.includes(viewMessageId)) {
+      if (model.type === "assistant" || model.type === "assistant_partial") {
+        this.view.updateAssistantMessage(viewMessageId, model);
       } else {
-        this.renderedMessageIds.push(this.view.addMessage(model, viewMessageId));
+        this.view.updateMessage(viewMessageId, model);
       }
+      return;
     }
+    this.renderedMessageIds.push(this.view.addMessage(model, viewMessageId));
+  }
 
-    this.refreshStatus();
-    return true;
+  private removeRenderedProtocolItems(protocolIds: string[]): void {
+    this.removeRenderedMessages(
+      protocolIds.flatMap((id) => {
+        const viewMessageId = this.viewMessageIds.get(id);
+        return viewMessageId ? [viewMessageId] : [];
+      }),
+    );
+  }
+
+  private removeRenderedMessages(ids: string[]): void {
+    const idsToRemove = ids.filter((id) => this.renderedMessageIds.includes(id));
+    if (idsToRemove.length === 0) {
+      return;
+    }
+    const idSet = new Set(idsToRemove);
+    this.renderedMessageIds.splice(
+      0,
+      this.renderedMessageIds.length,
+      ...this.renderedMessageIds.filter((id) => !idSet.has(id)),
+    );
+    this.view.removeMessages(idsToRemove);
   }
 
   private getViewMessageId(protocolId: string): string {

--- a/src/tui/session_chat_controller.ts
+++ b/src/tui/session_chat_controller.ts
@@ -1475,7 +1475,7 @@ export class SessionChatController {
     const previousSnapshot = this.snapshot;
     const affectedMessageIds = new Set<string>();
     const affectedToolIds = new Set<string>();
-    const appendedNotices: Array<Extract<SessionProtocolTimelineItem, { type: "notice" }>> = [];
+    const appendedNoticeIds = new Set<string>();
     let hasTimelineChange = false;
 
     for (const change of delta.delta.changes) {
@@ -1506,7 +1506,7 @@ export class SessionChatController {
           } else if (change.item.type === "tool") {
             affectedToolIds.add(change.item.toolId);
           } else if (change.item.type === "notice") {
-            appendedNotices.push(change.item);
+            appendedNoticeIds.add(change.item.id);
           }
           break;
         case "tool.set":
@@ -1533,23 +1533,33 @@ export class SessionChatController {
     this.snapshot = nextSnapshot;
     this.observedSessionRevision = Math.max(this.observedSessionRevision, nextSnapshot.revision);
 
+    const remainingMessageIds = new Set(affectedMessageIds);
+    const affectedMessages = new Map<string, SessionProtocolMessage>();
     for (const messageId of affectedMessageIds) {
       const message = nextSnapshot.messages.find((entry) => entry.id === messageId);
       if (message) {
-        this.syncProtocolMessage(message);
-      } else {
-        this.removeProtocolMessage(messageId);
+        affectedMessages.set(messageId, message);
       }
     }
-
-    if (affectedToolIds.size > 0) {
-      for (const item of [
-        ...nextSnapshot.timeline.items,
-        ...this.ephemeralTimelineItems.values(),
-      ]) {
-        if (item.type !== "tool" || !affectedToolIds.has(item.toolId)) {
-          continue;
+    const timelineItems = [...nextSnapshot.timeline.items, ...this.ephemeralTimelineItems.values()]
+      .filter((item) => {
+        if (item.type === "message") {
+          return affectedMessageIds.has(item.messageId);
         }
+        if (item.type === "tool") {
+          return affectedToolIds.has(item.toolId);
+        }
+        return item.type === "notice" && appendedNoticeIds.has(item.id);
+      })
+      .sort((left, right) => left.sequence - right.sequence);
+
+    for (const item of timelineItems) {
+      if (item.type === "message" && remainingMessageIds.delete(item.messageId)) {
+        const message = affectedMessages.get(item.messageId);
+        if (message) {
+          this.syncProtocolMessage(message);
+        }
+      } else if (item.type === "tool" && affectedToolIds.has(item.toolId)) {
         const tool = nextSnapshot.tools[item.toolId];
         if (tool) {
           this.upsertRenderedMessage(item.id, {
@@ -1557,22 +1567,25 @@ export class SessionChatController {
             tool: buildToolUiModel(nextSnapshot, tool),
           });
         }
+      } else if (item.type === "notice" && appendedNoticeIds.has(item.id)) {
+        this.upsertRenderedMessage(item.id, {
+          type: "transcript_notice",
+          title: item.notice.presentation.title,
+          ...(item.notice.presentation.content
+            ? { content: item.notice.presentation.content }
+            : {}),
+          tone: item.notice.severity === "error" ? "error" : "default",
+        });
       }
     }
 
-    for (const item of appendedNotices.sort((left, right) => left.sequence - right.sequence)) {
-      const nextItem = nextSnapshot.timeline.items.find((candidate) => candidate.id === item.id);
-      if (nextItem?.type !== "notice") {
-        continue;
+    for (const messageId of remainingMessageIds) {
+      const message = affectedMessages.get(messageId);
+      if (message) {
+        this.syncProtocolMessage(message);
+      } else {
+        this.removeProtocolMessage(messageId);
       }
-      this.upsertRenderedMessage(nextItem.id, {
-        type: "transcript_notice",
-        title: nextItem.notice.presentation.title,
-        ...(nextItem.notice.presentation.content
-          ? { content: nextItem.notice.presentation.content }
-          : {}),
-        tone: nextItem.notice.severity === "error" ? "error" : "default",
-      });
     }
 
     this.updateStreamingStateFromSnapshot(nextSnapshot);

--- a/test/session_chat_controller.test.js
+++ b/test/session_chat_controller.test.js
@@ -3287,6 +3287,196 @@ describe("SessionChatController", () => {
     await controller.dispose();
   });
 
+  it("preserves append order for mixed targeted timeline changes", async () => {
+    const snapshot = updateSnapshot(
+      createSnapshot([
+        {
+          id: "history-1",
+          message: { role: "user", content: [{ type: "text", text: "first" }] },
+        },
+      ]),
+      { revision: 3 },
+    );
+    const session = new FakeSession(snapshot);
+    const view = new FakeView();
+    const controller = new SessionChatController({
+      view,
+      session,
+      snapshot: await session.snapshot(),
+      targetLabel: "local",
+    });
+
+    controller.start();
+    const addMessageSpy = vi.spyOn(view, "addMessage");
+    const nextMessage = {
+      id: "history-2",
+      state: "committed",
+      modelVisible: true,
+      message: {
+        role: "user",
+        content: [{ type: "text", text: "second" }],
+        timestamp: 3,
+      },
+    };
+    const delta = {
+      version: SESSION_PROTOCOL_VERSION,
+      type: "session.delta",
+      sessionId: session.id,
+      fromRevision: 3,
+      toRevision: 4,
+      cause: { type: "maintenance" },
+      delta: {
+        type: "snapshot.patch",
+        changes: [
+          {
+            type: "timeline.append",
+            item: {
+              type: "notice",
+              id: "notice-between",
+              sequence: snapshot.timeline.sequence + 1,
+              createdAt: 2,
+              notice: {
+                kind: "tau.test.notice",
+                version: 1,
+                severity: "info",
+                subject: { type: "session" },
+                presentation: { title: "between" },
+                data: {},
+              },
+            },
+          },
+          { type: "message.append", message: nextMessage },
+          {
+            type: "timeline.append",
+            item: {
+              type: "message",
+              id: "timeline-history-2",
+              sequence: snapshot.timeline.sequence + 2,
+              createdAt: 3,
+              messageId: nextMessage.id,
+            },
+          },
+        ],
+      },
+    };
+    session.snapshotValue = applySessionProtocolDelta(session.snapshotValue, delta);
+    for (const listener of session.listeners) {
+      listener(delta);
+    }
+
+    expect(addMessageSpy.mock.calls).toEqual([
+      [{ type: "transcript_notice", title: "between", tone: "default" }, "notice-between"],
+      [{ type: "user", text: "second" }, "history-2"],
+    ]);
+    expect(view.messages.slice(-2).map((message) => message.id)).toEqual([
+      "notice-between",
+      "history-2",
+    ]);
+    await controller.dispose();
+  });
+
+  it("keeps late assistant outcome notices at the visible tail", async () => {
+    const assistantMessage = createAssistantToolCallMessage([
+      {
+        type: "toolCall",
+        id: "tool-a",
+        name: "bash",
+        arguments: { command: "echo a" },
+      },
+    ]);
+    const baseSnapshot = createSnapshot();
+    const snapshot = updateSnapshot(baseSnapshot, {
+      revision: 3,
+      messages: [
+        ...baseSnapshot.messages,
+        {
+          id: "assistant-active",
+          state: "draft",
+          modelVisible: false,
+          message: assistantMessage,
+        },
+      ],
+      timeline: [
+        ...baseSnapshot.timeline.items,
+        { type: "message", id: "timeline-assistant-active", messageId: "assistant-active" },
+      ],
+      tools: {
+        "tool-a": {
+          id: "tool-a",
+          toolCallId: "tool-a",
+          toolName: "bash",
+          call: { messageId: "assistant-active", contentIndex: 0 },
+          status: "succeeded",
+          startedAt: 1,
+          finishedAt: 2,
+          facetIds: [],
+        },
+      },
+    });
+    const session = new FakeSession(snapshot);
+    const view = new FakeView();
+    const controller = new SessionChatController({
+      view,
+      session,
+      snapshot: await session.snapshot(),
+      targetLabel: "local",
+    });
+
+    controller.start();
+    const failedMessage = {
+      id: "assistant-active",
+      state: "committed",
+      modelVisible: true,
+      message: {
+        ...assistantMessage,
+        stopReason: "error",
+        errorMessage: "provider failed",
+      },
+    };
+    const delta = {
+      version: SESSION_PROTOCOL_VERSION,
+      type: "session.delta",
+      sessionId: session.id,
+      fromRevision: 3,
+      toRevision: 4,
+      cause: { type: "assistant-message" },
+      delta: {
+        type: "snapshot.patch",
+        changes: [{ type: "message.replace", message: failedMessage }],
+      },
+    };
+    session.snapshotValue = applySessionProtocolDelta(session.snapshotValue, delta);
+    for (const listener of session.listeners) {
+      listener(delta);
+    }
+
+    expect(
+      view.messages
+        .map((message) => message.id)
+        .filter((id) =>
+          [
+            "assistant-active",
+            "timeline-tool-tool-a",
+            "presentation:failure:assistant-active",
+          ].includes(id),
+        ),
+    ).toEqual([
+      "assistant-active",
+      "timeline-tool-tool-a",
+      "presentation:failure:assistant-active",
+    ]);
+    expect(view.messages.at(-1)).toEqual({
+      id: "presentation:failure:assistant-active",
+      model: {
+        type: "transcript_notice",
+        title: "model request failed after tool execution",
+        content: ["provider failed"],
+        tone: "error",
+      },
+    });
+    await controller.dispose();
+  });
+
   it("applies assistant content append deltas without full snapshot reconciliation", async () => {
     const baseSnapshot = createSnapshot();
     const snapshot = updateSnapshot(baseSnapshot, {

--- a/test/session_chat_controller.test.js
+++ b/test/session_chat_controller.test.js
@@ -3104,6 +3104,189 @@ describe("SessionChatController", () => {
     await controller.dispose();
   });
 
+  it("targets message and notice updates in a long timeline", async () => {
+    const baseSnapshot = createSnapshot(
+      Array.from({ length: 1_000 }, (_, index) => ({
+        id: `history-${index}`,
+        message: {
+          role: "user",
+          content: [{ type: "text", text: `history ${index}` }],
+          timestamp: index,
+        },
+      })),
+    );
+    const draftMessage = {
+      id: "assistant-active",
+      state: "draft",
+      modelVisible: false,
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "working" }],
+        timestamp: 1_001,
+      },
+    };
+    const snapshot = updateSnapshot(baseSnapshot, {
+      revision: 3,
+      lifecycle: "running",
+      messages: [...baseSnapshot.messages, draftMessage],
+      timeline: [
+        ...baseSnapshot.timeline.items,
+        {
+          type: "message",
+          id: "timeline-assistant-active",
+          messageId: draftMessage.id,
+        },
+      ],
+    });
+    const session = new FakeSession(snapshot);
+    const view = new FakeView();
+    const controller = new SessionChatController({
+      view,
+      session,
+      snapshot: await session.snapshot(),
+      targetLabel: "local",
+    });
+
+    controller.start();
+    const addMessageSpy = vi.spyOn(view, "addMessage");
+    const updateMessageSpy = vi.spyOn(view, "updateMessage");
+    const updateAssistantMessageSpy = vi.spyOn(view, "updateAssistantMessage");
+    const userMessage = {
+      id: "user-next",
+      state: "committed",
+      modelVisible: true,
+      message: {
+        role: "user",
+        content: [{ type: "text", text: "next" }],
+        timestamp: 1_002,
+      },
+    };
+    const appendDelta = {
+      version: SESSION_PROTOCOL_VERSION,
+      type: "session.delta",
+      sessionId: session.id,
+      fromRevision: 3,
+      toRevision: 4,
+      cause: { type: "user-message" },
+      delta: {
+        type: "snapshot.patch",
+        changes: [
+          {
+            type: "agent-state.set",
+            agentState: { ...snapshot.agentState, revision: snapshot.agentState.revision + 1 },
+          },
+          { type: "message.append", message: userMessage },
+          {
+            type: "timeline.append",
+            item: {
+              type: "message",
+              id: "timeline-user-next",
+              sequence: snapshot.timeline.sequence + 1,
+              createdAt: userMessage.message.timestamp,
+              messageId: userMessage.id,
+            },
+          },
+        ],
+      },
+    };
+    session.snapshotValue = applySessionProtocolDelta(session.snapshotValue, appendDelta);
+    for (const listener of session.listeners) {
+      listener(appendDelta);
+    }
+
+    expect(addMessageSpy).toHaveBeenCalledTimes(1);
+    expect(addMessageSpy).toHaveBeenCalledWith({ type: "user", text: "next" }, "user-next");
+    expect(updateMessageSpy).not.toHaveBeenCalled();
+    expect(updateAssistantMessageSpy).not.toHaveBeenCalled();
+
+    addMessageSpy.mockClear();
+    updateMessageSpy.mockClear();
+    updateAssistantMessageSpy.mockClear();
+    const finalMessage = {
+      ...draftMessage,
+      state: "committed",
+      modelVisible: true,
+      message: createAssistantMessage("done"),
+    };
+    const finalDelta = {
+      version: SESSION_PROTOCOL_VERSION,
+      type: "session.delta",
+      sessionId: session.id,
+      fromRevision: 4,
+      toRevision: 5,
+      cause: { type: "assistant-message" },
+      delta: {
+        type: "snapshot.patch",
+        changes: [
+          { type: "cost.set", costTotal: 0.01 },
+          { type: "message.replace", message: finalMessage },
+          { type: "lifecycle.set", lifecycle: "idle" },
+        ],
+      },
+    };
+    session.snapshotValue = applySessionProtocolDelta(session.snapshotValue, finalDelta);
+    for (const listener of session.listeners) {
+      listener(finalDelta);
+    }
+
+    expect(addMessageSpy).not.toHaveBeenCalled();
+    expect(updateAssistantMessageSpy).toHaveBeenCalledTimes(1);
+    expect(updateMessageSpy).toHaveBeenCalledTimes(1);
+    expect(view.messages.find((message) => message.id === draftMessage.id)?.model).toEqual(
+      expect.objectContaining({
+        type: "assistant",
+        message: expect.objectContaining({ content: [{ type: "text", text: "done" }] }),
+      }),
+    );
+
+    addMessageSpy.mockClear();
+    updateMessageSpy.mockClear();
+    updateAssistantMessageSpy.mockClear();
+    const noticeDelta = {
+      version: SESSION_PROTOCOL_VERSION,
+      type: "session.delta",
+      sessionId: session.id,
+      fromRevision: 5,
+      toRevision: 6,
+      cause: { type: "notice" },
+      delta: {
+        type: "snapshot.patch",
+        changes: [
+          {
+            type: "timeline.append",
+            item: {
+              type: "notice",
+              id: "notice-next",
+              sequence: snapshot.timeline.sequence + 2,
+              createdAt: 1_003,
+              notice: {
+                kind: "tau.test.notice",
+                version: 1,
+                severity: "warn",
+                subject: { type: "session" },
+                presentation: { title: "check this" },
+                data: {},
+              },
+            },
+          },
+        ],
+      },
+    };
+    session.snapshotValue = applySessionProtocolDelta(session.snapshotValue, noticeDelta);
+    for (const listener of session.listeners) {
+      listener(noticeDelta);
+    }
+
+    expect(addMessageSpy).toHaveBeenCalledTimes(1);
+    expect(addMessageSpy).toHaveBeenCalledWith(
+      { type: "transcript_notice", title: "check this", tone: "default" },
+      "notice-next",
+    );
+    expect(updateMessageSpy).not.toHaveBeenCalled();
+    expect(updateAssistantMessageSpy).not.toHaveBeenCalled();
+    await controller.dispose();
+  });
+
   it("applies assistant content append deltas without full snapshot reconciliation", async () => {
     const baseSnapshot = createSnapshot();
     const snapshot = updateSnapshot(baseSnapshot, {
@@ -3843,6 +4026,116 @@ describe("SessionChatController", () => {
     } finally {
       await rm(directory, { recursive: true, force: true });
     }
+  });
+
+  it("targets a tool result update in a long timeline", async () => {
+    const baseSnapshot = createSnapshot(
+      Array.from({ length: 1_000 }, (_, index) => ({
+        id: `history-${index}`,
+        message: {
+          role: "user",
+          content: [{ type: "text", text: `history ${index}` }],
+          timestamp: index,
+        },
+      })),
+    );
+    const toolCallMessage = {
+      id: "assistant-tools",
+      state: "committed",
+      modelVisible: true,
+      message: createAssistantToolCallMessage([
+        {
+          type: "toolCall",
+          id: "tool-a",
+          name: "bash",
+          arguments: { command: "echo a" },
+        },
+      ]),
+    };
+    const tool = {
+      id: "tool-a",
+      toolCallId: "tool-a",
+      toolName: "bash",
+      call: { messageId: toolCallMessage.id, contentIndex: 0 },
+      status: "succeeded",
+      startedAt: 1_001,
+      finishedAt: 1_002,
+      facetIds: [],
+    };
+    const snapshot = updateSnapshot(baseSnapshot, {
+      revision: 3,
+      messages: [...baseSnapshot.messages, toolCallMessage],
+      timeline: [
+        ...baseSnapshot.timeline.items,
+        {
+          type: "message",
+          id: "timeline-assistant-tools",
+          messageId: toolCallMessage.id,
+        },
+      ],
+      tools: { "tool-a": tool },
+    });
+    const session = new FakeSession(snapshot);
+    const view = new FakeView();
+    const controller = new SessionChatController({
+      view,
+      session,
+      snapshot: await session.snapshot(),
+      targetLabel: "local",
+    });
+
+    controller.start();
+    const addMessageSpy = vi.spyOn(view, "addMessage");
+    const updateMessageSpy = vi.spyOn(view, "updateMessage");
+    const updateAssistantMessageSpy = vi.spyOn(view, "updateAssistantMessage");
+    const resultMessage = {
+      id: "tool-result-a",
+      state: "committed",
+      modelVisible: true,
+      message: {
+        role: "toolResult",
+        toolCallId: "tool-a",
+        toolName: "bash",
+        content: [{ type: "text", text: "a\n" }],
+        isError: false,
+        timestamp: 1_003,
+      },
+    };
+    const delta = {
+      version: SESSION_PROTOCOL_VERSION,
+      type: "session.delta",
+      sessionId: session.id,
+      fromRevision: 3,
+      toRevision: 4,
+      cause: { type: "tool-result" },
+      delta: {
+        type: "snapshot.patch",
+        changes: [
+          {
+            type: "agent-state.set",
+            agentState: { ...snapshot.agentState, revision: snapshot.agentState.revision + 1 },
+          },
+          { type: "message.append", message: resultMessage },
+          { type: "tool.set", tool: { ...tool, resultMessageId: resultMessage.id } },
+        ],
+      },
+    };
+    session.snapshotValue = applySessionProtocolDelta(session.snapshotValue, delta);
+    for (const listener of session.listeners) {
+      listener(delta);
+    }
+
+    expect(addMessageSpy).not.toHaveBeenCalled();
+    expect(updateMessageSpy).toHaveBeenCalledTimes(1);
+    expect(updateMessageSpy.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        type: "tool",
+        tool: expect.objectContaining({ toolCallId: "tool-a", status: "succeeded" }),
+      }),
+    );
+    expect(updateAssistantMessageSpy).not.toHaveBeenCalled();
+    expect(controller.snapshot.messages.at(-1)).toEqual(resultMessage);
+    await controller.dispose();
   });
 
   it("applies tool status and presentation facet deltas independently", async () => {


### PR DESCRIPTION
## why

Long-lived TUI sessions still rebuild every active transcript entry for common turn transitions. User messages, assistant completion, durable notices, and tool results can therefore pause in proportion to the retained timeline even though each patch changes only a small number of entries.

This continues the low-risk performance work from #481 without changing transcript retention, compaction, or rendering behavior.

## what

The session controller now applies recognized message and timeline patch combinations through a guarded targeted path. It updates only affected messages, derived outcome notices, tool cards, and newly appended notices, while preserving full reconciliation for resets, rewinds, removals, and unfamiliar patch shapes.

Timeline high-water updates also use the presentation-neutral state path. Regression coverage exercises user append, assistant finalization, durable notice, and tool-result patches against a 1,000-message transcript and verifies that unrelated entries are not updated.
