### PR TITLE
add Claude Fable 5.1 personas

### DIFF
--- a/src/core/personas.ts
+++ b/src/core/personas.ts
@@ -205,6 +205,7 @@ type PersonaSpec = {
   description: string;
   provider: string;
   modelId: string;
+  catalogOnly?: boolean;
   allowedReasoningLevels: NonNullable<Persona["allowedReasoningLevels"]>;
   settings: Persona["settings"];
   skills: string[] | "*";
@@ -302,6 +303,16 @@ const PERSONA_SPECS: PersonaSpec[] = [
     skills: "*",
   },
   {
+    id: "fable-5.1",
+    description: "Claude Fable 5.1",
+    provider: "anthropic",
+    modelId: "claude-fable-5-1",
+    catalogOnly: true,
+    allowedReasoningLevels: ["low", "medium", "high", "xhigh", "max"],
+    settings: { reasoning: "medium" },
+    skills: "*",
+  },
+  {
     id: "opus-5",
     description: "Claude Opus 5",
     provider: "anthropic",
@@ -379,6 +390,10 @@ function buildPersona(spec: PersonaSpec, variant: Variant, modelResolver: ModelR
 
 export function createBuiltinPersonas(modelResolver: ModelResolver = resolveModel): Persona[] {
   return PERSONA_SPECS.flatMap((spec) => {
+    if (spec.catalogOnly && !modelResolver(spec.provider, spec.modelId)) {
+      return [];
+    }
+
     if (spec.id.includes("-codex-")) {
       const coderPersona = buildPersona(spec, "coder", modelResolver);
       return [

--- a/test/persona_extends.test.js
+++ b/test/persona_extends.test.js
@@ -12,7 +12,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { loadAllContent, resolveConfigLevels } from "../dist/core/config/index.js";
-import { loadModelResolver } from "../dist/core/models/catalog.js";
+import { loadModelResolver, resolveModel } from "../dist/core/models/catalog.js";
 
 function setupFixture() {
   const home = mkdtempSync(join(tmpdir(), "tau-personas-home-"));
@@ -33,6 +33,7 @@ async function loadAllContentWithModelResolver(config, options) {
   const modelResolverResult = loadModelResolver({
     deps: options.deps,
     levels,
+    remoteCatalog: options.remoteCatalog,
   });
   return await loadAllContent(config, {
     deps: options.deps,
@@ -150,16 +151,59 @@ describe("custom personas", () => {
     }
   });
 
-  it("loads only the current built-in Anthropic personas", async () => {
+  it("omits catalog-only built-in personas when their model is unavailable", async () => {
     const fx = setupFixture();
 
     try {
       const deps = createConfigDeps({ cwd: fx.cwd, home: fx.home });
       const { personas, errors } = await loadAllContentWithModelResolver({}, { deps, cwd: fx.cwd });
       expect(errors).toEqual([]);
+      expect(personas.find((persona) => persona.id === "fable-5.1-chat")).toBeUndefined();
+      expect(personas.find((persona) => persona.id === "fable-5.1-coder")).toBeUndefined();
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("loads only the current built-in Anthropic personas", async () => {
+    const fx = setupFixture();
+
+    try {
+      const deps = createConfigDeps({ cwd: fx.cwd, home: fx.home });
+      const opus = resolveModel("anthropic", "claude-opus-5");
+      expect(opus).toBeTruthy();
+      const remoteCatalog = new Map([
+        [
+          "anthropic",
+          [
+            {
+              ...structuredClone(opus),
+              id: "claude-fable-5-1",
+              name: "Claude Fable 5.1",
+            },
+          ],
+        ],
+      ]);
+      const { personas, errors } = await loadAllContentWithModelResolver(
+        {},
+        { deps, cwd: fx.cwd, remoteCatalog },
+      );
+      expect(errors).toEqual([]);
 
       expect(personas.find((persona) => persona.id === "opus-4.6-chat")).toBeUndefined();
       expect(personas.find((persona) => persona.id === "opus-4.8-chat")).toBeUndefined();
+      expect(personas.find((persona) => persona.id === "fable-5.1-chat")?.model.id).toBe(
+        "claude-fable-5-1",
+      );
+      expect(personas.find((persona) => persona.id === "fable-5.1-chat")?.settings.reasoning).toBe(
+        "medium",
+      );
+      expect(
+        personas.find((persona) => persona.id === "fable-5.1-chat")?.allowedReasoningLevels,
+      ).toEqual(["low", "medium", "high", "xhigh", "max"]);
+      expect(personas.find((persona) => persona.id === "fable-5.1-coder")?.model.id).toBe(
+        "claude-fable-5-1",
+      );
       expect(personas.find((persona) => persona.id === "opus-5-chat")?.model.id).toBe(
         "claude-opus-5",
       );


### PR DESCRIPTION
## why

The remote model catalog now includes Claude Fable 5.1, but Tau does not expose built-in personas that select it.

## what

Add chat and coder personas for Claude Fable 5.1 with Tau's standard Anthropic reasoning defaults and supported effort levels. Treat the personas as catalog-backed so they appear when the effective model catalog contains Fable 5.1 and remain absent when that model is unavailable.
