### PR TITLE
allow Escape to cancel manual compaction

### DIFF
--- a/docs/tui.md
+++ b/docs/tui.md
@@ -51,7 +51,7 @@ When Tau is idle, Enter and Ctrl+Enter both start a normal turn. While a turn is
 
 Pending input is session state shared by attached clients while the host remains alive. It is not durable across host restart or session recovery. A queued turn captures the persona, reasoning, tools, and model settings when that turn actually starts. Steering remains part of the active logical turn and keeps the settings captured when that turn began.
 
-Escape interrupts foreground client work or the main session’s active work. If a local diff review, recording, or speech playback task owns the foreground, Escape stops that task first; otherwise it requests main-session interruption from the host, including cancellation of a running manual compaction. It does not stop independently running supervised subagents; select one with Alt+Down and use Ctrl+G. Press Escape twice to clear the current editor text.
+Escape interrupts foreground client work or the main session’s active work. If a local diff review, recording, or speech playback task owns the foreground, Escape stops that task first; otherwise it requests main-session interruption from the host, including cancellation of a running manual compaction. Once compaction has replaced model context, a late interruption does not undo it or turn successful persistence into a failure. It does not stop independently running supervised subagents; select one with Alt+Down and use Ctrl+G. Press Escape twice to clear the current editor text.
 
 Press Enter twice on an empty editor to retry from the current session history. Retry does not rewind or duplicate the last user message. Goal-controlled turns cannot be retried; resume a blocked goal instead.
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -51,7 +51,7 @@ When Tau is idle, Enter and Ctrl+Enter both start a normal turn. While a turn is
 
 Pending input is session state shared by attached clients while the host remains alive. It is not durable across host restart or session recovery. A queued turn captures the persona, reasoning, tools, and model settings when that turn actually starts. Steering remains part of the active logical turn and keeps the settings captured when that turn began.
 
-Escape interrupts foreground client work or the main session’s active work. If a local diff review, recording, or speech playback task owns the foreground, Escape stops that task first; otherwise it requests main-session interruption from the host. It does not stop independently running supervised subagents; select one with Alt+Down and use Ctrl+G. Press Escape twice to clear the current editor text.
+Escape interrupts foreground client work or the main session’s active work. If a local diff review, recording, or speech playback task owns the foreground, Escape stops that task first; otherwise it requests main-session interruption from the host, including cancellation of a running manual compaction. It does not stop independently running supervised subagents; select one with Alt+Down and use Ctrl+G. Press Escape twice to clear the current editor text.
 
 Press Enter twice on an empty editor to retry from the current session history. Retry does not rewind or duplicate the last user message. Goal-controlled turns cannot be retried; resume a blocked goal instead.
 

--- a/src/host/local_session_host.ts
+++ b/src/host/local_session_host.ts
@@ -1513,7 +1513,6 @@ class LocalHostedSessionHandle implements LocalHostedSession {
           signal,
         });
 
-        signal.throwIfAborted();
         return {
           snapshot: await this.snapshot(),
           compactionMessage: result.compactionMessage,

--- a/src/host/session_protocol_handler.ts
+++ b/src/host/session_protocol_handler.ts
@@ -1132,8 +1132,9 @@ export class SessionProtocolHandler {
       return;
     }
 
+    // Cancellation must reach maintenance work while it holds the mutation queue.
+    const interrupted = state.session.interruptActiveWork();
     const result = await this.enqueueMutation(state, async () => {
-      const interrupted = state.session.interruptActiveWork();
       if (interrupted) {
         state.live.interrupting = true;
       }

--- a/src/tui/session_chat_controller.ts
+++ b/src/tui/session_chat_controller.ts
@@ -736,7 +736,10 @@ export class SessionChatController {
       return;
     }
 
-    if (!this.isStreaming || this.assistantInterruptRequested) {
+    if (
+      (!this.isStreaming && !this.manualCompactionInProgress) ||
+      this.assistantInterruptRequested
+    ) {
       return;
     }
 
@@ -2232,6 +2235,7 @@ export class SessionChatController {
       this.view.addTranscriptNotice("failed to compact session", "error", [message]);
     } finally {
       this.manualCompactionInProgress = false;
+      this.assistantInterruptRequested = false;
       this.refreshStatus();
     }
   }

--- a/test/local_session_host.test.js
+++ b/test/local_session_host.test.js
@@ -2144,6 +2144,62 @@ describe("LocalSessionHost", () => {
     await host.shutdown();
   });
 
+  it("keeps the session usable when interrupted during final compaction persistence", async () => {
+    const store = new MemorySessionStore();
+    const host = createHost(store);
+    const hostedSession = await host.createSession(localCreateInput);
+    const responses = [
+      fauxAssistantMessage("first response"),
+      fauxAssistantMessage(
+        "compacted summary\n\n<preserved-user-message-ids>\n[]\n</preserved-user-message-ids>",
+      ),
+      fauxAssistantMessage("response after compaction"),
+    ];
+    hostedSession.runtime.agent.spec.model.stream = () => {
+      const response = responses.shift();
+      if (!response) throw new Error("unexpected model call");
+      return {
+        async *[Symbol.asyncIterator]() {},
+        async result() {
+          return response;
+        },
+      };
+    };
+
+    await hostedSession.record({ text: "compact me" });
+    await expect(hostedSession.runTurn()).resolves.toMatchObject({ status: "completed" });
+    const previousSnapshot = await hostedSession.snapshot();
+    const persistenceReached = deferred();
+    const releasePersistence = deferred();
+    const commitSessionSnapshot = store.commitSessionSnapshot.bind(store);
+    let paused = false;
+    store.commitSessionSnapshot = vi.fn(async (snapshot, options) => {
+      if (!paused && snapshot.timeline.epoch === previousSnapshot.timeline.epoch + 1) {
+        paused = true;
+        persistenceReached.resolve();
+        await releasePersistence.promise;
+      }
+      return await commitSessionSnapshot(snapshot, options);
+    });
+    const deltas = [];
+    hostedSession.onDelta((delta) => deltas.push(delta));
+
+    const compaction = hostedSession.compact({ mode: "summary-only" });
+    await persistenceReached.promise;
+    expect(hostedSession.interruptActiveWork()).toBe(true);
+    releasePersistence.resolve();
+
+    const result = await compaction;
+    expect(result.snapshot.timeline.epoch).toBe(previousSnapshot.timeline.epoch + 1);
+    expect(result.snapshot.messages).toHaveLength(2);
+    expect(deltas.reduce(applySessionProtocolDelta, previousSnapshot)).toEqual(result.snapshot);
+    await expect(hostedSession.snapshot()).resolves.toEqual(result.snapshot);
+    await expect(store.loadSession(hostedSession.sessionId)).resolves.toEqual(result.snapshot);
+    await hostedSession.record({ text: "continue after compaction" });
+    await expect(hostedSession.runTurn()).resolves.toMatchObject({ status: "completed" });
+    await host.shutdown();
+  });
+
   it("emits runtime feedback without adding it to the timeline", async () => {
     const host = createHost(new MemorySessionStore());
     const hostedSession = await host.createSession(localCreateInput);

--- a/test/session_chat_controller.test.js
+++ b/test/session_chat_controller.test.js
@@ -5049,6 +5049,42 @@ describe("SessionChatController", () => {
     );
   });
 
+  it("interrupts manual compaction with Escape and allows later compactions to be interrupted", async () => {
+    const session = new FakeSession();
+    let pendingCompact;
+    session.compact = vi.fn(() => {
+      pendingCompact = deferred();
+      return pendingCompact.promise;
+    });
+    session.interrupt = vi.fn(async () => {
+      pendingCompact.reject(new Error("compaction aborted"));
+      return { interrupted: true, isTurnRunning: false };
+    });
+    const view = new FakeView();
+    const controller = new SessionChatController({
+      view,
+      session,
+      snapshot: await session.snapshot(),
+      targetLabel: "ws://host",
+    });
+    controller.start();
+
+    for (const command of ["/compact-all", "/compact-keep-last"]) {
+      controller.getInputHandlers().onSubmit(command);
+      await flush();
+      expect(view.status.footer).toEqual({ type: "activity", label: "compacting context" });
+
+      controller.getInputHandlers().onEscape();
+      controller.getInputHandlers().onEscape();
+      await flush();
+      expect(view.status.footer.type).toBe("regular");
+    }
+    expect(session.interrupt).toHaveBeenCalledTimes(2);
+    controller.getInputHandlers().onEscape();
+    await flush();
+    expect(session.interrupt).toHaveBeenCalledTimes(2);
+  });
+
   it("shows manual compaction status until the compact request finishes", async () => {
     const session = new FakeSession();
     const pendingCompact = deferred();

--- a/test/session_protocol_handler.test.js
+++ b/test/session_protocol_handler.test.js
@@ -454,6 +454,9 @@ function createHarness(options = {}) {
         return { revision: snapshot.revision, settings: snapshot.settings };
       },
       async compact(compactOptions) {
+        if (options.compact) {
+          return await runActiveWork((signal) => options.compact({ ...compactOptions, signal }));
+        }
         const compactionMessage = `compacted with ${compactOptions.mode}`;
         historyEntries.splice(0, historyEntries.length, {
           id: `history-${nextHistoryId++}`,
@@ -2342,6 +2345,47 @@ describe("SessionProtocolHandler", () => {
         ok: true,
         result: { interrupted: true, isTurnRunning: true },
       }),
+    );
+  });
+
+  it("interrupts manual compaction while it holds the mutation queue", async () => {
+    let compactSignal;
+    const harness = createHarness({
+      compact: ({ signal }) =>
+        new Promise((_resolve, reject) => {
+          compactSignal = signal;
+          signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+        }),
+    });
+    const compact = harness.connection.handleRequest(
+      request("compact", "session.compact", {
+        sessionId: "session-1",
+        mode: "summary-only",
+      }),
+    );
+    await waitFor(() => compactSignal);
+
+    const interrupt = harness.connection.handleRequest(
+      request("interrupt-compact", "session.interrupt", { sessionId: "session-1" }),
+    );
+    await waitFor(() => compactSignal.aborted);
+    await Promise.all([compact, interrupt]);
+
+    expect(harness.lines.find((line) => line.id === "compact")).toEqual(
+      expect.objectContaining({ ok: false }),
+    );
+    expect(harness.lines.find((line) => line.id === "interrupt-compact")).toEqual(
+      expect.objectContaining({
+        ok: true,
+        result: { interrupted: true, isTurnRunning: true },
+      }),
+    );
+
+    await harness.connection.handleRequest(
+      request("snapshot-after-compact", "session.snapshot", { sessionId: "session-1" }),
+    );
+    expect(harness.lines.find((line) => line.id === "snapshot-after-compact")).toEqual(
+      expect.objectContaining({ ok: true }),
     );
   });
 


### PR DESCRIPTION
## why

Escape could not cancel manual compaction: the TUI ignored interruption while only compaction was active, and the protocol handler queued cancellation behind the compaction itself.

## what

Allow Escape during either manual compaction command and reset interruption deduplication when compaction settles. Send the host's active-work abort before waiting for the protocol mutation queue so pending compaction can unwind.

Add controller and protocol regressions covering both commands, repeated Escape presses, subsequent compactions, and cancellation while compaction holds the mutation queue. Add a real hosted-session regression covering interruption during final compaction persistence, snapshot and delta consistency, subsequent turns, and shutdown. Clarify manual compaction cancellation in the TUI documentation.

## details

Keep compaction serialized as a context mutation. Only delivery of the existing abort signal moves outside the queue; pending-input handling, interruption bookkeeping, and the protocol response remain serialized. Cancellation before history replacement retains the existing compaction error and operation-settlement behavior without introducing a new cancellation result contract. Once runtime history has been replaced and persistence succeeds, a late abort no longer converts committed compaction into a failed mutation or invalidates the live session.

fixes #487
