### PR TITLE
reduce transcript rendering and snapshot cloning

### DIFF
--- a/src/protocol/session_protocol.ts
+++ b/src/protocol/session_protocol.ts
@@ -3985,12 +3985,22 @@ function applyStructurallySharedPatch(
   const topLevelChanges: Partial<
     Pick<SessionProtocolSnapshot, "agentState" | "lifecycle" | "goal" | "costTotal" | "settings">
   > = {};
+  let nextMessages: SessionProtocolSnapshot["messages"] | undefined;
+  let nextTimeline: SessionProtocolSnapshot["timeline"] | undefined;
   let nextTurns: SessionProtocolSnapshot["turns"] | undefined;
   let nextTools: SessionProtocolSnapshot["tools"] | undefined;
   let nextOperations: SessionProtocolSnapshot["operations"] | undefined;
   let nextAgents: SessionProtocolSnapshot["agents"] | undefined;
   let nextFacets: SessionProtocolSnapshot["facets"] | undefined;
 
+  const cloneMessages = () => {
+    nextMessages ??= [...snapshot.messages];
+    return nextMessages;
+  };
+  const cloneTimeline = () => {
+    nextTimeline ??= { ...snapshot.timeline, items: [...snapshot.timeline.items] };
+    return nextTimeline;
+  };
   const cloneTurns = () => {
     nextTurns ??= { ...snapshot.turns };
     return nextTurns;
@@ -4032,6 +4042,43 @@ function applyStructurallySharedPatch(
       case "turn.set":
         setSessionProtocolTurn(cloneTurns(), change.turn);
         break;
+      case "message.append":
+        cloneMessages().push(structuredClone(change.message));
+        break;
+      case "message.replace": {
+        const messages = cloneMessages();
+        const index = messages.findIndex((entry) => entry.id === change.message.id);
+        if (index === -1) {
+          messages.push(structuredClone(change.message));
+        } else {
+          messages[index] = structuredClone(change.message);
+        }
+        break;
+      }
+      case "timeline.append": {
+        const timeline = cloneTimeline();
+        if (change.item.sequence <= timeline.sequence) {
+          throw new Error(
+            `timeline append sequence ${change.item.sequence} must exceed current timeline sequence ${timeline.sequence}`,
+          );
+        }
+        timeline.items.push(structuredClone(change.item));
+        timeline.sequence = change.item.sequence;
+        break;
+      }
+      case "timeline.advance": {
+        const timeline = cloneTimeline();
+        if (timeline.epoch !== change.epoch) {
+          throw new Error("timeline advance epoch does not match the active epoch");
+        }
+        if (change.sequence <= timeline.sequence) {
+          throw new Error(
+            `timeline advance sequence ${change.sequence} must exceed current timeline sequence ${timeline.sequence}`,
+          );
+        }
+        timeline.sequence = change.sequence;
+        break;
+      }
       case "tool.set":
         cloneTools()[change.tool.id] = structuredClone(change.tool);
         break;
@@ -4065,6 +4112,8 @@ function applyStructurallySharedPatch(
     ...snapshot,
     ...topLevelChanges,
     revision: message.toRevision,
+    ...(nextMessages ? { messages: nextMessages } : {}),
+    ...(nextTimeline ? { timeline: nextTimeline } : {}),
     ...(nextTurns ? { turns: nextTurns } : {}),
     ...(nextTools ? { tools: nextTools } : {}),
     ...(nextOperations ? { operations: nextOperations } : {}),

--- a/src/tui/chat_view.ts
+++ b/src/tui/chat_view.ts
@@ -196,13 +196,13 @@ export class TuiChatView implements ChatView {
   }
 
   updateMessage(id: string, model: ChatMessageModel): void {
-    this.chatContainer.updateMessage(id, model);
-    this.ui.requestRender();
+    if (this.chatContainer.updateMessage(id, model) === "updated") {
+      this.ui.requestRender();
+    }
   }
 
   updateAssistantMessage(id: string, model: AssistantMessageModel): void {
-    this.chatContainer.updateMessage(id, model);
-    this.ui.requestRender();
+    this.updateMessage(id, model);
   }
 
   showFooterNotice(

--- a/src/tui/tool_ui_router.ts
+++ b/src/tui/tool_ui_router.ts
@@ -37,7 +37,7 @@ export class ToolUiRouter {
 
   private upsertToolMessage(model: ToolUiModel): void {
     const message = { type: "tool" as const, tool: model };
-    if (!this.chatContainer.updateMessage(model.toolCallId, message)) {
+    if (this.chatContainer.updateMessage(model.toolCallId, message) === "missing") {
       this.chatContainer.addMessage(message, model.toolCallId);
     }
   }

--- a/src/tui/ui/chat_container.ts
+++ b/src/tui/ui/chat_container.ts
@@ -69,17 +69,26 @@ export class ChatContainerComponent extends Container {
     return true;
   }
 
-  updateMessage(id: string, model: ChatMessageModel): boolean {
+  updateMessage(id: string, model: ChatMessageModel): "missing" | "unchanged" | "updated" {
     const index = this.idToIndex.get(id);
-    if (index === undefined) return false;
+    if (index === undefined) return "missing";
 
     const record = this.allMessages[index];
-    if (!record) return false;
+    if (!record) return "missing";
+    const previousModel = record.model;
     record.model = model;
+
+    if (
+      !this.thoughtsVisible &&
+      previousModel.type === "assistant_partial" &&
+      model.type === "assistant_partial" &&
+      previousModel.text.trim() === model.text.trim()
+    ) {
+      return "unchanged";
+    }
 
     const rendered = record.renderedMessage;
     if (rendered?.update) {
-      const wasVisible = rendered.hasVisibleText ? rendered.hasVisibleText() : true;
       const updated = rendered.update(model, {
         theme: this.theme,
         thoughtsVisible: this.thoughtsVisible,
@@ -87,31 +96,28 @@ export class ChatContainerComponent extends Container {
 
       if (updated) {
         const shouldShow = this.shouldShowMessage(rendered);
-        const isVisibleNow = rendered.hasVisibleText ? rendered.hasVisibleText() : true;
-
-        if (record.rendered && shouldShow) {
-          if (!wasVisible && isVisibleNow) {
-            this.rebuild();
-          }
-          this.invalidateRenderCache();
-          return true;
-        }
-
-        if (!record.rendered && shouldShow) {
-          this.rebuild();
-          return true;
-        }
-
-        if (record.rendered && !shouldShow) {
-          this.rebuild();
+        if (record.rendered !== shouldShow) {
+          this.syncVisibleMessages();
         }
         this.invalidateRenderCache();
-        return true;
+        return "updated";
       }
     }
 
     this.rebuild();
-    return true;
+    return "updated";
+  }
+
+  private syncVisibleMessages(): void {
+    this.chatContainer.clear();
+    for (const record of this.allMessages) {
+      const rendered = record.renderedMessage!;
+      record.rendered = this.shouldShowMessage(rendered);
+      if (record.rendered) {
+        this.addSpacerIfNeeded();
+        this.chatContainer.addChild(rendered.component);
+      }
+    }
   }
 
   setThinkingVisibility(visible: boolean) {

--- a/test/chat_container.test.js
+++ b/test/chat_container.test.js
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { TuiChatView } from "../dist/tui/chat_view.js";
 import { ChatContainerComponent } from "../dist/tui/ui/chat_container.js";
 import { createUiTheme } from "../dist/tui/ui/theme/index.js";
 
@@ -10,6 +11,82 @@ function inspectChatContainer(container) {
 }
 
 describe("ChatContainerComponent", () => {
+  it("retains hidden thinking without invalidating or requesting a render", () => {
+    const container = new ChatContainerComponent(createUiTheme("plain"));
+    container.addMessage({ type: "assistant_partial", text: "answer", thinking: "first" }, "a");
+    const lines = container.render(80);
+    const component = container.allMessages[0].renderedMessage.component;
+    const requestRender = vi.fn();
+    const view = Object.create(TuiChatView.prototype);
+    view.chatContainer = container;
+    view.ui = { requestRender };
+
+    view.updateAssistantMessage("a", {
+      type: "assistant_partial",
+      text: "answer",
+      thinking: "first and second",
+    });
+
+    expect(requestRender).not.toHaveBeenCalled();
+    expect(container.render(80)).toBe(lines);
+    expect(container.allMessages[0].renderedMessage.component).toBe(component);
+    container.setThinkingVisibility(true);
+    expect(container.render(80).join("\n")).toContain("first and second");
+    view.updateAssistantMessage("a", {
+      type: "assistant_partial",
+      text: "answer",
+      thinking: "third",
+    });
+    expect(requestRender).toHaveBeenCalledTimes(1);
+    expect(container.render(80).join("\n")).toContain("third");
+
+    container.setThinkingVisibility(false);
+    view.updateAssistantMessage("a", {
+      type: "assistant",
+      message: { role: "assistant", content: [{ type: "text", text: "final answer" }] },
+    });
+    expect(requestRender).toHaveBeenCalledTimes(2);
+    expect(container.render(80).join("\n")).toContain("final answer");
+  });
+
+  it.each([0, 500, 1000])(
+    "preserves components when visibility changes at position %i",
+    (position) => {
+      const container = new ChatContainerComponent(createUiTheme("plain"));
+      for (let index = 0; index <= 1000; index += 1) {
+        if (index === position) {
+          container.addMessage({ type: "assistant_partial", text: "", thinking: "hidden" }, "a");
+        }
+        if (index < 1000) {
+          container.addMessage(
+            { type: "assistant_partial", text: `message ${index}` },
+            `m${index}`,
+          );
+        }
+      }
+      const lines = container.render(80);
+      const components = container.allMessages.map((record) => record.renderedMessage.component);
+      expect(
+        container.updateMessage("a", {
+          type: "assistant_partial",
+          text: "",
+          thinking: "more hidden",
+        }),
+      ).toBe("unchanged");
+      expect(container.render(80)).toBe(lines);
+
+      for (const text of ["visible", "", "visible again"]) {
+        expect(container.updateMessage("a", { type: "assistant_partial", text })).toBe("updated");
+        container.allMessages.forEach((record, index) => {
+          expect(record.renderedMessage.component).toBe(components[index]);
+        });
+        const expected = new ChatContainerComponent(createUiTheme("plain"));
+        for (const record of container.allMessages) expected.addMessage(record.model, record.id);
+        expect(container.render(80)).toEqual(expected.render(80));
+      }
+    },
+  );
+
   it("replaces an existing message when adding another message with the same id", () => {
     const container = new ChatContainerComponent(createUiTheme("plain"));
 

--- a/test/session_chat_controller.test.js
+++ b/test/session_chat_controller.test.js
@@ -3162,6 +3162,7 @@ describe("SessionChatController", () => {
         timestamp: 1_002,
       },
     };
+    const previousControllerSnapshot = controller.snapshot;
     const appendDelta = {
       version: SESSION_PROTOCOL_VERSION,
       type: "session.delta",
@@ -3197,6 +3198,14 @@ describe("SessionChatController", () => {
 
     expect(addMessageSpy).toHaveBeenCalledTimes(1);
     expect(addMessageSpy).toHaveBeenCalledWith({ type: "user", text: "next" }, "user-next");
+    expect(controller.snapshot.messages[1]).toBe(previousControllerSnapshot.messages[1]);
+    expect(controller.snapshot.timeline.items[0]).toBe(
+      previousControllerSnapshot.timeline.items[0],
+    );
+    expect(controller.snapshot.tools).toBe(previousControllerSnapshot.tools);
+    expect(previousControllerSnapshot.messages.some((message) => message.id === "user-next")).toBe(
+      false,
+    );
     expect(updateMessageSpy).not.toHaveBeenCalled();
     expect(updateAssistantMessageSpy).not.toHaveBeenCalled();
 

--- a/test/session_protocol.test.js
+++ b/test/session_protocol.test.js
@@ -3017,6 +3017,106 @@ describe("session_protocol", () => {
     ).toThrow("session protocol error response is invalid");
   });
 
+  it("shares unaffected snapshot records across ordered message and timeline patches", () => {
+    const snapshot = createProtocolSnapshot({
+      historyEntries: [{ id: "old", message: { role: "user", content: "old", timestamp: 1 } }],
+    });
+    const original = structuredClone(snapshot);
+    const freeze = (value) => {
+      if (!value || typeof value !== "object") return;
+      Object.freeze(value);
+      for (const child of Object.values(value)) freeze(child);
+    };
+    freeze(snapshot);
+    const message = (id, text) => ({
+      id,
+      state: "committed",
+      modelVisible: true,
+      message: { role: "user", content: [{ type: "text", text }], timestamp: 2 },
+    });
+    const item = (id, sequence) => ({
+      type: "message",
+      id: `timeline-${id}`,
+      messageId: id,
+      sequence,
+      createdAt: 2,
+    });
+    const changes = [
+      { type: "message.append", message: message("new", "draft") },
+      { type: "message.replace", message: message("new", "final") },
+      { type: "message.replace", message: message("missing", "inserted") },
+      { type: "timeline.advance", epoch: snapshot.timeline.epoch, sequence: 2 },
+      { type: "timeline.append", item: item("new", 3) },
+      { type: "timeline.append", item: item("missing", 4) },
+      { type: "cost.set", costTotal: 0.1 },
+    ];
+    const delta = (changes) =>
+      createSessionProtocolDeltaMessage({
+        sessionId: snapshot.sessionId,
+        fromRevision: snapshot.revision,
+        toRevision: snapshot.revision + 1,
+        cause: { type: "user-message" },
+        delta: { type: "snapshot.patch", changes },
+      });
+    const patch = delta(changes);
+    const next = applySessionProtocolDelta(snapshot, patch);
+    expect(snapshot).toEqual(original);
+    expect(next.messages).not.toBe(snapshot.messages);
+    expect(next.messages.slice(2)).toEqual([
+      message("new", "final"),
+      message("missing", "inserted"),
+    ]);
+    expect(next.messages[0]).toBe(snapshot.messages[0]);
+    expect(next.messages[1]).toBe(snapshot.messages[1]);
+    expect(next.timeline).not.toBe(snapshot.timeline);
+    expect(next.timeline.items[0]).toBe(snapshot.timeline.items[0]);
+    expect(next.timeline.items.slice(1)).toEqual([item("new", 3), item("missing", 4)]);
+    expect(next.timeline.sequence).toBe(4);
+    expect(next.costTotal).toBe(0.1);
+    for (const key of [
+      "tools",
+      "operations",
+      "agents",
+      "facets",
+      "turns",
+      "bootstrap",
+      "catalog",
+    ]) {
+      expect(next[key]).toBe(snapshot[key]);
+    }
+    patch.delta.changes[1].message.message.content[0].text = "mutated";
+    patch.delta.changes[4].item.id = "mutated";
+    expect(next.messages[2].message.content[0].text).toBe("final");
+    expect(next.timeline.items[1].id).toBe("timeline-new");
+
+    for (const invalid of [
+      { type: "timeline.append", item: item("new", 4) },
+      { type: "timeline.append", item: item("unknown", 5) },
+      { type: "timeline.advance", epoch: snapshot.timeline.epoch + 1, sequence: 5 },
+    ]) {
+      expect(() => applySessionProtocolDelta(snapshot, delta([...changes, invalid]))).toThrow();
+      expect(snapshot).toEqual(original);
+    }
+
+    const replaced = applySessionProtocolDelta(
+      snapshot,
+      delta([{ type: "message.replace", message: message("old", "replaced") }]),
+    );
+    expect(replaced.timeline).toBe(snapshot.timeline);
+    expect(replaced.messages[1]).not.toBe(snapshot.messages[1]);
+    expect(snapshot).toEqual(original);
+
+    const fallback = applySessionProtocolDelta(
+      snapshot,
+      delta([...changes, { type: "timeline.remove", id: "timeline-new" }]),
+    );
+    expect(fallback.timeline.items.map((entry) => entry.id)).toEqual([
+      "timeline-old",
+      "timeline-missing",
+    ]);
+    expect(snapshot).toEqual(original);
+  });
+
   it("validates and applies durable turn record deltas", () => {
     const snapshot = createProtocolSnapshot({ sessionId: "session-1", revision: 1 });
     const running = {

--- a/test/tool_ui_router.test.js
+++ b/test/tool_ui_router.test.js
@@ -16,9 +16,9 @@ function createHarness() {
       return id;
     },
     updateMessage: (id, message) => {
-      if (!messageIds.has(id)) return false;
+      if (!messageIds.has(id)) return "missing";
       updated.push({ id, message });
-      return true;
+      return "updated";
     },
     removeMessages: (ids) => {
       removed.push(...ids);


### PR DESCRIPTION
## why

Long-lived TUI sessions still perform avoidable transcript and snapshot work after the targeted update improvements in #483 and #484. Hidden thinking can trigger unchanged frames, newly visible assistant text recreates retained components, and common timeline patches still clone the complete snapshot.

## what

Skip visual updates for assistant partials whose visible text is unchanged while thoughts are hidden, retaining their latest model for later display. Reassemble visible message placement using existing components when visibility changes, preserving ordering and spacers without reconstructing historical Markdown.

Extend structural sharing to message append/replacement and timeline append/advance patches. Changed payloads remain isolated, prior snapshots are not mutated, and ordered patch validation and the fallback path remain intact. No SDK methods or wire formats change.

## details

Regression coverage checks hidden-thinking display and finalization, visibility transitions at the start, middle, and end of a 1,000-message transcript, immutable previous snapshots, mixed patch ordering, rejected patches, payload isolation, and the TUI delta consumer.

This addresses another batch of #481. The issue remains open for bounded live scrollback, compaction retention, and incremental Markdown rendering.
