### PR TITLE
add saved prompt selection to Telegram

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,7 @@ Every Bash invocation runs in a fresh, noninteractive login Bash in the executio
 - Tool producers own bounded `ToolRunPresentation`. Preserve the canonical lifecycle from `preparing` to `queued` to `running` to a terminal protocol status. Keep one generic tool-card renderer, with no tool-specific renderers or expanded mode. Exact preview policies belong in `src/core/tools/presentation.ts` and their tests, not in the TUI.
 - Tool presentation facets have an independent version. Missing or historical presentation degrades from canonical tool name, status, and textual result without revealing stored arguments. Malformed current-version presentation fails validation.
 - Use semantic palette tokens for TUI colors. Add a dedicated token for a new semantic state; never repurpose an unrelated token. See `src/tui/ui/theme/` and terminal appearance tests.
-- Programmatic Telegram replies and notices must be natural-language sentences. Integrate project and session identifiers into prose and translate internal states instead of emitting metadata-style labels.
+- Programmatic Telegram replies and notices must be natural-language sentences with lowercase prose, including sentence beginnings. Use lowercase for Tau-authored button labels too. Preserve proper nouns and identifiers, and do not change the casing of user content, saved prompts, or model responses. Integrate project and session identifiers into prose and translate internal states instead of emitting metadata-style labels.
 
 ## Codebase map
 

--- a/docs/prompts-and-project-context.md
+++ b/docs/prompts-and-project-context.md
@@ -56,6 +56,14 @@ The session catalog stores only prompt metadata. Tau loads the body lazily from 
 
 If the file is missing or invalid when Tau resolves it, invocation fails instead of using a stale body. Remote clients ask the host to resolve the prompt from the session's execution environment; they do not read a same-named file on the client machine.
 
+### Telegram prompt picker
+
+In [Telegram](telegram.md), `/prompt` lists the active session’s saved prompts, with pages for larger catalogs. Selecting a prompt resolves its current body through the session and records it as a committed user message. Selection is allowed only while the session is idle; otherwise wait for Tau to finish or use `/interrupt` first.
+
+After recording succeeds, the picker becomes non-actionable and shows the prompt text, continued in additional messages when needed. Send a normal message (for example, details or “go”) to start the next turn with the prompt in context. In groups, that message must mention the bot as usual. Selecting another prompt appends another message rather than replacing the previous one. Recorded prompts survive session recovery.
+
+Only the newest picker in a chat is active. Pickers are bound to the session that opened them and expire after selection, session replacement, or runner restart. Duplicate taps do not record the same picker twice. Prompt selection does not consume pending attachments or group context.
+
 ### Install starter prompts
 
 Use `tau install` to copy Tau's starter content:

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -83,7 +83,7 @@ Use both lists for a private bot. `allowedUserIds` controls who can trigger work
 
 A bot sees only `allowedProjectIds`. If that field is omitted, it sees every configured project. A sole allowed project is selected automatically; otherwise a chat needs `defaultProjectId` or an explicit `/use_<project>` preference before `/new`.
 
-Tau registers ten built-in commands plus one `/use_<projectId>` command per visible project. A bot may expose at most 90 projects under Telegram's 100-command limit.
+Telegram’s 100-command limit permits eleven built-ins and up to 89 `/use_<projectId>` commands.
 
 ## Project IDs and common fields
 
@@ -237,12 +237,13 @@ The runner's speech-to-text provider is loaded from normal Tau config at runner 
 | `/effort_medium` | Selects medium reasoning for later independent turns. |
 | `/effort_high` | Selects high reasoning for later independent turns. |
 | `/effort_xhigh` | Selects xhigh reasoning for later independent turns. |
+| `/prompt` | [Records a saved prompt](prompts-and-project-context.md#telegram-prompt-picker) while idle, without starting a turn. |
 | `/compact` | Runs summary-only manual compaction while the session is idle. |
 | `/interrupt` | Interrupts the active Tau turn. |
 | `/tts_on` | Enables a Gemini-generated voice note after each final assistant response. |
 | `/tts_off` | Disables voice responses. |
 
-Preferences are scoped to one bot and chat and survive restarts, projects, and sessions. A new project choice does not switch the active session; `/status` reports the difference.
+Preferences persist per bot and chat across restarts, projects, and sessions. Project changes apply to `/new`, not the active session.
 
 In groups, commands must explicitly mention the bot. Accepted forms include:
 
@@ -252,7 +253,7 @@ In groups, commands must explicitly mention the bot. Accepted forms include:
 @tau_engineering_bot /status
 ```
 
-A command addressed to another bot does not trigger this one.
+Commands addressed to other bots are ignored.
 
 ## DMs, groups, and active work
 

--- a/src/core/telegram/adapter.ts
+++ b/src/core/telegram/adapter.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, extname, join } from "node:path";
@@ -120,6 +121,12 @@ export type TelegramApi = {
     allowedUpdates: TelegramAllowedUpdates;
   }): Promise<TelegramUpdate[]>;
   sendMessage(chatId: number, text: string, options: TelegramSendOptions): Promise<void>;
+  editMessage(
+    chatId: number,
+    messageId: number,
+    text: string,
+    options: TelegramSendOptions,
+  ): Promise<void>;
   sendRichMessage(chatId: number, markdown: string, options: TelegramSendOptions): Promise<void>;
   sendVoice(chatId: number, voice: Buffer, options: TelegramSendOptions): Promise<void>;
   sendChatAction(chatId: number, action: string): Promise<void>;
@@ -1185,6 +1192,19 @@ function createTelegramApi(botToken: string): TelegramApi {
         options.signal,
       );
     },
+    async editMessage(chatId, messageId, text, options) {
+      await callTelegramMethod(
+        "editMessageText",
+        {
+          chat_id: chatId,
+          message_id: messageId,
+          text,
+          reply_markup: options.replyMarkup ?? { inline_keyboard: [] },
+        },
+        z.unknown(),
+        options.signal,
+      );
+    },
     async sendRichMessage(chatId, markdown, options) {
       await callTelegramMethod(
         "sendRichMessage",
@@ -1299,6 +1319,14 @@ class TelegramAdapterImpl {
   private readonly commandHandlers: Map<string, TelegramCommandHandler>;
   private readonly callbackActionHandlers: Map<QuickAction, TelegramCommandHandler>;
   private readonly abortController = new AbortController();
+  private readonly promptPickers = new Map<
+    number,
+    {
+      token: string;
+      sessionId: string;
+      prompts: SessionProtocolSnapshot["catalog"]["prompts"];
+    }
+  >();
   private readonly activeSessionsByChat = new Map<number, string>();
   private readonly sessionsByChat = new Map<number, Set<string>>();
   private readonly chatsBySession = new Map<string, Set<number>>();
@@ -1435,6 +1463,11 @@ class TelegramAdapterImpl {
         description: "show active session status",
         callbackAction: "status",
         handler: async (chatId) => this.handleStatus(chatId),
+      },
+      {
+        command: "/prompt",
+        description: "add a saved prompt without starting a turn",
+        handler: async (chatId, args) => this.handlePrompt(chatId, args),
       },
       {
         command: "/compact",
@@ -1804,7 +1837,11 @@ class TelegramAdapterImpl {
       return;
     }
 
-    const callbackHandled = await this.handleCallback(chat.id, callbackData);
+    const callbackHandled = await this.handleCallback(
+      chat.id,
+      callbackData,
+      callbackQuery.message?.message_id,
+    );
     await this.answerCallbackQuery(callbackQuery.id, callbackHandled ? "done" : undefined);
   }
 
@@ -2259,7 +2296,15 @@ class TelegramAdapterImpl {
     await handler(chatId, args, sourceMessageId);
   }
 
-  private async handleCallback(chatId: number, callbackData: string): Promise<boolean> {
+  private async handleCallback(
+    chatId: number,
+    callbackData: string,
+    messageId?: number,
+  ): Promise<boolean> {
+    if (callbackData.startsWith("prompt:")) {
+      await this.handlePromptCallback(chatId, callbackData, messageId);
+      return true;
+    }
     if (!callbackData.startsWith(CALLBACK_ACTION_PREFIX)) {
       return false;
     }
@@ -2343,6 +2388,108 @@ class TelegramAdapterImpl {
         chatId,
         `failed to save voice response preference: ${error instanceof Error ? error.message : String(error)}`,
       );
+    }
+  }
+
+  private async handlePrompt(chatId: number, args: string[]): Promise<void> {
+    if (args.length > 0) {
+      await this.reply(chatId, "Use /prompt to choose a saved prompt.");
+      return;
+    }
+    const session = await this.requireActiveSession(chatId);
+    if (!session) return;
+    try {
+      const snapshot = await this.getSessionManagerForChat(chatId).getSessionSnapshot(session.id);
+      if (!snapshot) {
+        await this.reply(chatId, "The session is still preparing.");
+        return;
+      }
+      const prompts = snapshot.catalog.prompts;
+      if (prompts.length === 0) {
+        await this.reply(chatId, "This session has no saved prompts.");
+        return;
+      }
+      this.promptPickers.set(chatId, { token: randomUUID(), sessionId: session.id, prompts });
+      await this.showPromptPage(chatId, 0);
+    } catch (error) {
+      await this.reply(chatId, this.formatManagerError(error));
+    }
+  }
+
+  private async showPromptPage(chatId: number, page: number, messageId?: number): Promise<void> {
+    const picker = this.promptPickers.get(chatId);
+    if (!picker) return;
+    const start = page * 20;
+    const keyboard = picker.prompts.slice(start, start + 20).map((prompt, index) => [
+      {
+        text: prompt.label ?? prompt.id,
+        callback_data: `prompt:${picker.token}:select:${start + index}`,
+      },
+    ]);
+    const navigation: TelegramInlineKeyboardButton[] = [];
+    if (page > 0)
+      navigation.push({
+        text: "Previous",
+        callback_data: `prompt:${picker.token}:page:${page - 1}`,
+      });
+    if (start + 20 < picker.prompts.length)
+      navigation.push({ text: "Next", callback_data: `prompt:${picker.token}:page:${page + 1}` });
+    if (navigation.length > 0) keyboard.push(navigation);
+    const text =
+      "Choose a saved prompt to add to the conversation without starting a turn. Selection is available only while Tau is idle.";
+    const replyMarkup = { inline_keyboard: keyboard };
+    if (messageId !== undefined) {
+      await this.sendWithRetry((signal) =>
+        this.api.editMessage(chatId, messageId, text, { replyMarkup, signal }),
+      );
+    } else {
+      await this.reply(chatId, text, { replyMarkup });
+    }
+  }
+
+  private async handlePromptCallback(
+    chatId: number,
+    data: string,
+    messageId?: number,
+  ): Promise<void> {
+    const match = /^prompt:([^:]+):(select|page):(0|[1-9][0-9]*)$/.exec(data);
+    const picker = this.promptPickers.get(chatId);
+    if (
+      !match ||
+      !picker ||
+      picker.token !== match[1] ||
+      this.getActiveSession(chatId)?.id !== picker.sessionId ||
+      messageId === undefined
+    ) {
+      await this.reply(chatId, "This prompt picker has expired. Use /prompt to open a new one.");
+      return;
+    }
+    const index = Number(match[3]);
+    if (match[2] === "page") {
+      if (index * 20 < picker.prompts.length) await this.showPromptPage(chatId, index, messageId);
+      return;
+    }
+    const prompt = picker.prompts[index];
+    if (!prompt) return;
+    let text: string;
+    try {
+      text = await this.getSessionManagerForChat(chatId).recordPrompt(picker.sessionId, prompt.id);
+    } catch (error) {
+      await this.reply(chatId, this.formatManagerError(error));
+      return;
+    }
+    this.promptPickers.delete(chatId);
+    const chunks = splitTelegramMessage(
+      `Added this prompt to the conversation. Send a message when you’re ready for Tau to respond.\n\n${text}`,
+    );
+    for (const [index, chunk] of chunks.entries()) {
+      if (index === 0) {
+        await this.sendWithRetry((signal) =>
+          this.api.editMessage(chatId, messageId, chunk, { signal }),
+        );
+      } else {
+        await this.reply(chatId, chunk);
+      }
     }
   }
 

--- a/src/core/telegram/adapter.ts
+++ b/src/core/telegram/adapter.ts
@@ -2393,7 +2393,7 @@ class TelegramAdapterImpl {
 
   private async handlePrompt(chatId: number, args: string[]): Promise<void> {
     if (args.length > 0) {
-      await this.reply(chatId, "Use /prompt to choose a saved prompt.");
+      await this.reply(chatId, "use /prompt to choose a saved prompt.");
       return;
     }
     const session = await this.requireActiveSession(chatId);
@@ -2401,12 +2401,12 @@ class TelegramAdapterImpl {
     try {
       const snapshot = await this.getSessionManagerForChat(chatId).getSessionSnapshot(session.id);
       if (!snapshot) {
-        await this.reply(chatId, "The session is still preparing.");
+        await this.reply(chatId, "the session is still preparing.");
         return;
       }
       const prompts = snapshot.catalog.prompts;
       if (prompts.length === 0) {
-        await this.reply(chatId, "This session has no saved prompts.");
+        await this.reply(chatId, "this session has no saved prompts.");
         return;
       }
       this.promptPickers.set(chatId, { token: randomUUID(), sessionId: session.id, prompts });
@@ -2429,14 +2429,14 @@ class TelegramAdapterImpl {
     const navigation: TelegramInlineKeyboardButton[] = [];
     if (page > 0)
       navigation.push({
-        text: "Previous",
+        text: "previous",
         callback_data: `prompt:${picker.token}:page:${page - 1}`,
       });
     if (start + 20 < picker.prompts.length)
-      navigation.push({ text: "Next", callback_data: `prompt:${picker.token}:page:${page + 1}` });
+      navigation.push({ text: "next", callback_data: `prompt:${picker.token}:page:${page + 1}` });
     if (navigation.length > 0) keyboard.push(navigation);
     const text =
-      "Choose a saved prompt to add to the conversation without starting a turn. Selection is available only while Tau is idle.";
+      "choose a saved prompt to add to the conversation without starting a turn. selection is available only while Tau is idle.";
     const replyMarkup = { inline_keyboard: keyboard };
     if (messageId !== undefined) {
       await this.sendWithRetry((signal) =>
@@ -2461,7 +2461,7 @@ class TelegramAdapterImpl {
       this.getActiveSession(chatId)?.id !== picker.sessionId ||
       messageId === undefined
     ) {
-      await this.reply(chatId, "This prompt picker has expired. Use /prompt to open a new one.");
+      await this.reply(chatId, "this prompt picker has expired. use /prompt to open a new one.");
       return;
     }
     const index = Number(match[3]);
@@ -2480,7 +2480,7 @@ class TelegramAdapterImpl {
     }
     this.promptPickers.delete(chatId);
     const chunks = splitTelegramMessage(
-      `Added this prompt to the conversation. Send a message when you’re ready for Tau to respond.\n\n${text}`,
+      `added this prompt to the conversation. send a message when you’re ready for Tau to respond.\n\n${text}`,
     );
     for (const [index, chunk] of chunks.entries()) {
       if (index === 0) {

--- a/src/core/telegram/adapter.ts
+++ b/src/core/telegram/adapter.ts
@@ -929,7 +929,7 @@ const TelegramCallbackQuerySchema = telegramPartialObject({
   id: z.string(),
   from: TelegramUserSchema,
   data: z.string(),
-  message: telegramPartialObject({ chat: TelegramChatSchema }),
+  message: telegramPartialObject({ message_id: z.number(), chat: TelegramChatSchema }),
 });
 
 const TelegramUpdateSchema = telegramPartialObject({

--- a/src/core/telegram/config.ts
+++ b/src/core/telegram/config.ts
@@ -26,7 +26,7 @@ export class TelegramConfigError extends Error {
   }
 }
 
-const TELEGRAM_BUILTIN_COMMAND_COUNT = 10;
+const TELEGRAM_BUILTIN_COMMAND_COUNT = 11;
 const TELEGRAM_MAX_COMMAND_COUNT = 100;
 const TELEGRAM_PROJECT_COMMAND_PREFIX = "use_";
 const TELEGRAM_MAX_COMMAND_LENGTH = 32;

--- a/src/core/telegram/session_manager.ts
+++ b/src/core/telegram/session_manager.ts
@@ -12,6 +12,8 @@ import type {
   SessionProtocolInterruptResult,
   SessionProtocolMessage,
   SessionProtocolReasoningEffort,
+  SessionProtocolRecordResult,
+  SessionProtocolResolvePromptResult,
   SessionProtocolSettingsUpdateResult,
   SessionProtocolSnapshot,
   SessionProtocolSteerResult,
@@ -462,6 +464,8 @@ export type TelegramTauSession = {
   submit(text: string, options?: { historyEntryId?: string }): Promise<SessionProtocolSubmitResult>;
   steer(text: string): Promise<SessionProtocolSteerResult>;
   interrupt(): Promise<SessionProtocolInterruptResult>;
+  record(text: string): Promise<SessionProtocolRecordResult>;
+  resolvePrompt(promptId: string): Promise<SessionProtocolResolvePromptResult>;
   compact(mode: "summary-only" | "summary-and-last"): Promise<SessionProtocolCompactResult>;
   setReasoning(
     reasoning: SessionProtocolReasoningEffort,
@@ -504,6 +508,7 @@ export type TelegramSessionManager = {
     options?: TelegramSessionSubmitOptions,
   ): Promise<TelegramSessionRecord>;
   interruptSession(sessionId: string): Promise<TelegramSessionInterruptResult>;
+  recordPrompt(sessionId: string, promptId: string): Promise<string>;
   compactSession(sessionId: string): Promise<SessionProtocolCompactResult>;
   setReasoning(
     sessionId: string,
@@ -765,6 +770,37 @@ class TelegramSessionManagerImpl implements TelegramSessionManager {
       interrupted: result.interrupted,
       isTurnRunning: result.isTurnRunning,
     };
+  }
+
+  async recordPrompt(sessionId: string, promptId: string): Promise<string> {
+    const requireIdleSession = () => {
+      const entry = this.requireSession(sessionId);
+      if (!entry.tauSession) {
+        throw new TelegramSessionManagerError("not_ready", "The session is still preparing.");
+      }
+      if (entry.record.state !== "waiting-input" || entry.activeSubmit) {
+        throw new TelegramSessionManagerError(
+          "busy",
+          "Wait for Tau to finish, or use /interrupt first.",
+        );
+      }
+      return entry.tauSession;
+    };
+    const session = requireIdleSession();
+    const prompt = await session.resolvePrompt(promptId);
+    const snapshot = await session.snapshot();
+    if (
+      snapshot.lifecycle !== "idle" ||
+      Object.values(snapshot.operations).some((operation) => operation.status === "running")
+    ) {
+      throw new TelegramSessionManagerError(
+        "busy",
+        "Wait for Tau to finish, or use /interrupt first.",
+      );
+    }
+    requireIdleSession();
+    await session.record(prompt.text);
+    return prompt.text;
   }
 
   async compactSession(sessionId: string): Promise<SessionProtocolCompactResult> {
@@ -2361,6 +2397,11 @@ class ScopedTelegramSessionManager implements TelegramSessionManager {
   async interruptSession(sessionId: string): Promise<TelegramSessionInterruptResult> {
     this.requireSession(sessionId);
     return await this.sessionManager.interruptSession(sessionId);
+  }
+
+  async recordPrompt(sessionId: string, promptId: string): Promise<string> {
+    this.requireSession(sessionId);
+    return await this.sessionManager.recordPrompt(sessionId, promptId);
   }
 
   async compactSession(sessionId: string): Promise<SessionProtocolCompactResult> {

--- a/src/core/telegram/session_manager.ts
+++ b/src/core/telegram/session_manager.ts
@@ -776,12 +776,12 @@ class TelegramSessionManagerImpl implements TelegramSessionManager {
     const requireIdleSession = () => {
       const entry = this.requireSession(sessionId);
       if (!entry.tauSession) {
-        throw new TelegramSessionManagerError("not_ready", "The session is still preparing.");
+        throw new TelegramSessionManagerError("not_ready", "the session is still preparing.");
       }
       if (entry.record.state !== "waiting-input" || entry.activeSubmit) {
         throw new TelegramSessionManagerError(
           "busy",
-          "Wait for Tau to finish, or use /interrupt first.",
+          "wait for Tau to finish, or use /interrupt first.",
         );
       }
       return entry.tauSession;
@@ -795,7 +795,7 @@ class TelegramSessionManagerImpl implements TelegramSessionManager {
     ) {
       throw new TelegramSessionManagerError(
         "busy",
-        "Wait for Tau to finish, or use /interrupt first.",
+        "wait for Tau to finish, or use /interrupt first.",
       );
     }
     requireIdleSession();

--- a/test/telegram_adapter.test.js
+++ b/test/telegram_adapter.test.js
@@ -2670,9 +2670,20 @@ describe("telegram adapter", () => {
       expect(managerHarness.manager.sendMessage).not.toHaveBeenCalled();
       expect(edits).toHaveLength(2);
       expect(edits.every((edit) => edit.chat_id === chat.id && edit.message_id === 42)).toBe(true);
-      expect(edits[1].text).toContain("Saved prompt body");
+      const pickerMessage = sendMessages.find((message) => message.reply_markup);
+      expect(pickerMessage.text).toBe(
+        "choose a saved prompt to add to the conversation without starting a turn. selection is available only while Tau is idle.",
+      );
+      expect(pickerMessage.reply_markup.inline_keyboard.at(-1)[0].text).toBe("next");
+      expect(edits[0].text).toBe(pickerMessage.text);
+      expect(edits[0].reply_markup.inline_keyboard.at(-1)[0].text).toBe("previous");
+      expect(edits[1].text).toBe(
+        "added this prompt to the conversation. send a message when you’re ready for Tau to respond.\n\nSaved prompt body",
+      );
       expect(edits[1].reply_markup.inline_keyboard).toEqual([]);
-      expect(sendMessages.at(-1).text).toContain("expired");
+      expect(sendMessages.at(-1).text).toBe(
+        "this prompt picker has expired. use /prompt to open a new one.",
+      );
     } finally {
       await adapter.close();
       vi.unstubAllGlobals();

--- a/test/telegram_adapter.test.js
+++ b/test/telegram_adapter.test.js
@@ -139,6 +139,7 @@ function createApiHarness(updateBatches, options = {}) {
     sendMessage: vi.fn(async (chatId, text, options) => {
       sendMessages.push({ chatId, text, options, sentAt: Date.now() });
     }),
+    editMessage: vi.fn(async () => {}),
     sendRichMessage: vi.fn(async (chatId, markdown, options) => {
       sendRichMessages.push({ chatId, markdown, options, sentAt: Date.now() });
     }),
@@ -332,6 +333,7 @@ function createSessionManagerHarness(initialSessions = [], options = {}) {
         isTurnRunning: false,
       };
     }),
+    recordPrompt: vi.fn(async () => "Saved prompt body"),
     compactSession: vi.fn(async (sessionId) => {
       const session = sessions.get(sessionId);
       if (!session) throw new Error("missing session");
@@ -440,6 +442,7 @@ describe("telegram adapter", () => {
       expect(apiHarness.setCommandsCalls[0]).toEqual([
         { command: "new", description: "start a new session" },
         { command: "status", description: "show active session status" },
+        { command: "prompt", description: "add a saved prompt without starting a turn" },
         { command: "compact", description: "compact session context" },
         { command: "interrupt", description: "interrupt active run" },
         { command: "tts_on", description: "enable voice responses" },
@@ -2588,6 +2591,114 @@ describe("telegram adapter", () => {
     }
   });
 
+  it("records a selected prompt once, rejects stale pickers, and waits for the next message", async () => {
+    const chat = { id: 329, type: "private" };
+    const from = { id: 7 };
+    const apiHarness = createApiHarness([]);
+    const managerHarness = createSessionManagerHarness([], {
+      createSnapshot: () => ({
+        catalog: { prompts: Array.from({ length: 21 }, (_, i) => ({ id: `prompt-${i}` })) },
+      }),
+    });
+    let poll = 0;
+    apiHarness.api.getUpdates.mockImplementation(async () => {
+      poll++;
+      if (poll === 1)
+        return [
+          { update_id: 1, message: { chat, from, text: "/new" } },
+          { update_id: 2, message: { chat, from, text: "/prompt" } },
+        ];
+      if (poll === 2) {
+        await waitFor(() => apiHarness.sendMessages.some((m) => m.options.replyMarkup));
+        const keyboard = apiHarness.sendMessages.at(-1).options.replyMarkup.inline_keyboard;
+        const callback = (id, data) => ({
+          update_id: id,
+          callback_query: { id: `${id}`, from, message: { chat, message_id: 42 }, data },
+        });
+        const data = keyboard[0][0].callback_data;
+        expect(keyboard).toHaveLength(21);
+        expect(Buffer.byteLength(data)).toBeLessThanOrEqual(64);
+        return [callback(3, keyboard.at(-1)[0].callback_data)];
+      }
+      if (poll === 3) {
+        await waitFor(() => apiHarness.api.editMessage.mock.calls.length === 1);
+        const keyboard = apiHarness.api.editMessage.mock.calls[0][3].replyMarkup.inline_keyboard;
+        const data = keyboard[0][0].callback_data;
+        return [4, 5].map((id) => ({
+          update_id: id,
+          callback_query: { id: `${id}`, from, message: { chat, message_id: 42 }, data },
+        }));
+      }
+      return await new Promise(() => {});
+    });
+    const adapter = await startAdapter({
+      botToken: "token",
+      projects: { demo: { repo: "git@example.com:demo.git" } },
+      sessionManager: managerHarness.manager,
+      api: apiHarness.api,
+      pollIntervalMs: 1,
+      requestTimeoutSeconds: 1,
+    });
+    try {
+      await waitFor(() => apiHarness.answerCallbackQueryCalls.length === 3);
+      expect(managerHarness.manager.recordPrompt).toHaveBeenCalledExactlyOnceWith(
+        "s1",
+        "prompt-20",
+      );
+      expect(managerHarness.manager.sendMessage).not.toHaveBeenCalled();
+      expect(apiHarness.api.editMessage.mock.calls[1][2]).toContain("Saved prompt body");
+      expect(apiHarness.api.editMessage.mock.calls[1][3].replyMarkup).toBeUndefined();
+      expect(apiHarness.sendMessages.at(-1).text).toContain("expired");
+    } finally {
+      await adapter.close();
+    }
+  });
+
+  it("does not let an old picker record a prompt into a replacement session", async () => {
+    const chat = { id: 329, type: "private" };
+    const from = { id: 7 };
+    const apiHarness = createApiHarness([]);
+    const managerHarness = createSessionManagerHarness([], {
+      createSnapshot: () => ({ catalog: { prompts: [{ id: "review" }] } }),
+    });
+    apiHarness.api.getUpdates
+      .mockImplementationOnce(async () => [
+        { update_id: 1, message: { chat, from, text: "/new" } },
+        { update_id: 2, message: { chat, from, text: "/prompt" } },
+      ])
+      .mockImplementationOnce(async () => {
+        await waitFor(() => apiHarness.sendMessages.some((message) => message.options.replyMarkup));
+        return [
+          { update_id: 3, message: { chat, from, text: "/new" } },
+          {
+            update_id: 4,
+            callback_query: {
+              id: "old-picker",
+              from,
+              message: { chat, message_id: 42 },
+              data: apiHarness.sendMessages.at(-1).options.replyMarkup.inline_keyboard[0][0]
+                .callback_data,
+            },
+          },
+        ];
+      })
+      .mockImplementation(async () => await new Promise(() => {}));
+    const adapter = await startAdapter({
+      botToken: "token",
+      projects: { demo: { repo: "git@example.com:demo.git" } },
+      sessionManager: managerHarness.manager,
+      api: apiHarness.api,
+    });
+    try {
+      await waitFor(() => apiHarness.answerCallbackQueryCalls.length === 1);
+      expect(managerHarness.manager.createSession).toHaveBeenCalledTimes(2);
+      expect(managerHarness.manager.recordPrompt).not.toHaveBeenCalled();
+      expect(apiHarness.sendMessages.at(-1).text).toContain("expired");
+    } finally {
+      await adapter.close();
+    }
+  });
+
   it("compacts the active session", async () => {
     const apiHarness = createApiHarness([
       [
@@ -2709,7 +2820,7 @@ describe("telegram adapter", () => {
     try {
       await waitFor(() => apiHarness.sendMessages.length === 1);
       expect(apiHarness.sendMessages[0].text).toBe(
-        "unsupported command. supported commands: /new, /status, /compact, /interrupt, /tts_on, /tts_off, /effort_low, /effort_medium, /effort_high, /effort_xhigh, /use_demo",
+        "unsupported command. supported commands: /new, /status, /prompt, /compact, /interrupt, /tts_on, /tts_off, /effort_low, /effort_medium, /effort_high, /effort_xhigh, /use_demo",
       );
       expect(managerHarness.manager.closeSession).not.toHaveBeenCalled();
     } finally {

--- a/test/telegram_adapter.test.js
+++ b/test/telegram_adapter.test.js
@@ -2591,66 +2591,91 @@ describe("telegram adapter", () => {
     }
   });
 
-  it("records a selected prompt once, rejects stale pickers, and waits for the next message", async () => {
+  it("parses picker callbacks, paginates, and records a selected prompt only once without starting a turn", async () => {
     const chat = { id: 329, type: "private" };
     const from = { id: 7 };
-    const apiHarness = createApiHarness([]);
+    const sendMessages = [];
+    const edits = [];
+    const answers = [];
     const managerHarness = createSessionManagerHarness([], {
       createSnapshot: () => ({
         catalog: { prompts: Array.from({ length: 21 }, (_, i) => ({ id: `prompt-${i}` })) },
       }),
     });
-    let poll = 0;
-    apiHarness.api.getUpdates.mockImplementation(async () => {
-      poll++;
-      if (poll === 1)
-        return [
-          { update_id: 1, message: { chat, from, text: "/new" } },
-          { update_id: 2, message: { chat, from, text: "/prompt" } },
-        ];
-      if (poll === 2) {
-        await waitFor(() => apiHarness.sendMessages.some((m) => m.options.replyMarkup));
-        const keyboard = apiHarness.sendMessages.at(-1).options.replyMarkup.inline_keyboard;
-        const callback = (id, data) => ({
-          update_id: id,
-          callback_query: { id: `${id}`, from, message: { chat, message_id: 42 }, data },
-        });
-        const data = keyboard[0][0].callback_data;
-        expect(keyboard).toHaveLength(21);
-        expect(Buffer.byteLength(data)).toBeLessThanOrEqual(64);
-        return [callback(3, keyboard.at(-1)[0].callback_data)];
-      }
-      if (poll === 3) {
-        await waitFor(() => apiHarness.api.editMessage.mock.calls.length === 1);
-        const keyboard = apiHarness.api.editMessage.mock.calls[0][3].replyMarkup.inline_keyboard;
-        const data = keyboard[0][0].callback_data;
-        return [4, 5].map((id) => ({
-          update_id: id,
-          callback_query: { id: `${id}`, from, message: { chat, message_id: 42 }, data },
-        }));
-      }
-      return await new Promise(() => {});
+    const callback = (id, data) => ({
+      update_id: id,
+      callback_query: { id: `${id}`, from, message: { chat, message_id: 42 }, data },
     });
+    vi.stubGlobal(
+      "fetch",
+      createTelegramFetchStub({
+        setMyCommands: async () => createJsonResponse({ ok: true, result: true }),
+        sendMessage: async ({ init }) => {
+          sendMessages.push(JSON.parse(init.body));
+          return createJsonResponse({ ok: true, result: { message_id: 42 } });
+        },
+        editMessageText: async ({ init }) => {
+          edits.push(JSON.parse(init.body));
+          return createJsonResponse({ ok: true, result: true });
+        },
+        answerCallbackQuery: async ({ init }) => {
+          answers.push(JSON.parse(init.body));
+          return createJsonResponse({ ok: true, result: true });
+        },
+        getUpdates: async ({ call }) => {
+          if (call === 1) {
+            return createJsonResponse({
+              ok: true,
+              result: [
+                { update_id: 1, message: { chat, from, text: "/new" } },
+                { update_id: 2, message: { chat, from, text: "/prompt" } },
+              ],
+            });
+          }
+          if (call === 2) {
+            await waitFor(() => sendMessages.some((m) => m.reply_markup));
+            const keyboard = sendMessages.at(-1).reply_markup.inline_keyboard;
+            expect(keyboard).toHaveLength(21);
+            expect(Buffer.byteLength(keyboard[0][0].callback_data)).toBeLessThanOrEqual(64);
+            return createJsonResponse({
+              ok: true,
+              result: [callback(3, keyboard.at(-1)[0].callback_data)],
+            });
+          }
+          if (call === 3) {
+            await waitFor(() => edits.length === 1);
+            const keyboard = edits[0].reply_markup.inline_keyboard;
+            return createJsonResponse({
+              ok: true,
+              result: [4, 5].map((id) => callback(id, keyboard[0][0].callback_data)),
+            });
+          }
+          return pendingTelegramCall();
+        },
+      }),
+    );
     const adapter = await startAdapter({
       botToken: "token",
       projects: { demo: { repo: "git@example.com:demo.git" } },
       sessionManager: managerHarness.manager,
-      api: apiHarness.api,
       pollIntervalMs: 1,
       requestTimeoutSeconds: 1,
     });
     try {
-      await waitFor(() => apiHarness.answerCallbackQueryCalls.length === 3);
+      await waitFor(() => answers.length === 3);
       expect(managerHarness.manager.recordPrompt).toHaveBeenCalledExactlyOnceWith(
         "s1",
         "prompt-20",
       );
       expect(managerHarness.manager.sendMessage).not.toHaveBeenCalled();
-      expect(apiHarness.api.editMessage.mock.calls[1][2]).toContain("Saved prompt body");
-      expect(apiHarness.api.editMessage.mock.calls[1][3].replyMarkup).toBeUndefined();
-      expect(apiHarness.sendMessages.at(-1).text).toContain("expired");
+      expect(edits).toHaveLength(2);
+      expect(edits.every((edit) => edit.chat_id === chat.id && edit.message_id === 42)).toBe(true);
+      expect(edits[1].text).toContain("Saved prompt body");
+      expect(edits[1].reply_markup.inline_keyboard).toEqual([]);
+      expect(sendMessages.at(-1).text).toContain("expired");
     } finally {
       await adapter.close();
+      vi.unstubAllGlobals();
     }
   });
 

--- a/test/telegram_cli.test.js
+++ b/test/telegram_cli.test.js
@@ -168,27 +168,27 @@ describe("telegram cli", () => {
     );
   });
 
-  it("reserves ten Telegram commands when validating the project command limit", () => {
+  it("reserves eleven Telegram commands when validating the project command limit", () => {
     const projects = Object.fromEntries(
-      Array.from({ length: 91 }, (_, index) => [`project_${index}`, { repo: "owner/repo" }]),
+      Array.from({ length: 90 }, (_, index) => [`project_${index}`, { repo: "owner/repo" }]),
     );
     const accepted = writeConfig({
       bots: {
         ops: {
           botToken: "token",
-          allowedProjectIds: Object.keys(projects).slice(0, 90),
+          allowedProjectIds: Object.keys(projects).slice(0, 89),
         },
       },
       projects,
     });
-    expect(loadTelegramConfig(accepted.path).bots.ops.allowedProjectIds).toHaveLength(90);
+    expect(loadTelegramConfig(accepted.path).bots.ops.allowedProjectIds).toHaveLength(89);
 
     const rejected = writeConfig({
       bots: { ops: { botToken: "token" } },
       projects,
     });
     expect(() => loadTelegramConfig(rejected.path)).toThrow(
-      "bots.ops exposes 91 projects, exceeding Telegram's 100-command limit with built-in commands",
+      "bots.ops exposes 90 projects, exceeding Telegram's 100-command limit with built-in commands",
     );
   });
 

--- a/test/telegram_session_manager.test.js
+++ b/test/telegram_session_manager.test.js
@@ -63,6 +63,8 @@ function createClientHarness() {
   const session = {
     id: "session-1",
     submit: submit,
+    resolvePrompt: vi.fn(async (promptId) => ({ promptId, text: "Saved prompt body" })),
+    record: vi.fn(async () => ({})),
     steer: vi.fn(async () => {
       return await submitDeferred.promise;
     }),
@@ -207,6 +209,43 @@ function assistantProgressTexts(events) {
 }
 
 describe("telegram session manager", () => {
+  it("records prompts only while idle, including after lazy resolution", async () => {
+    const harness = createClientHarness();
+    const manager = createDemoSessionManager(harness);
+    const created = await manager.createSession({ projectId: "demo" });
+    await waitFor(() => manager.getSession(created.id)?.state === "waiting-input");
+    try {
+      await expect(manager.recordPrompt(created.id, "review")).resolves.toBe("Saved prompt body");
+      expect(harness.session.record).toHaveBeenCalledExactlyOnceWith("Saved prompt body");
+      expect(harness.session.submit).not.toHaveBeenCalled();
+      expect(manager.getSession(created.id).state).toBe("waiting-input");
+      harness.session.snapshot.mockResolvedValueOnce(
+        createProtocolSnapshot({ lifecycle: "running" }),
+      );
+      await expect(manager.recordPrompt(created.id, "review")).rejects.toThrow(
+        "Wait for Tau to finish",
+      );
+      harness.session.resolvePrompt.mockRejectedValueOnce(new Error("Prompt file is missing"));
+      await expect(manager.recordPrompt(created.id, "review")).rejects.toThrow(
+        "Prompt file is missing",
+      );
+      const resolution = deferred();
+      harness.session.resolvePrompt.mockReturnValueOnce(resolution.promise);
+      const recording = manager.recordPrompt(created.id, "review");
+      await manager.sendMessage(created.id, "go");
+      resolution.resolve({ promptId: "review", text: "Another body" });
+      await expect(recording).rejects.toThrow("Wait for Tau to finish");
+      await expect(manager.recordPrompt(created.id, "review")).rejects.toThrow(
+        "Wait for Tau to finish",
+      );
+      expect(harness.session.record).toHaveBeenCalledTimes(1);
+      expect(harness.session.interrupt).not.toHaveBeenCalled();
+    } finally {
+      harness.submitDeferred.resolve({ status: "completed" });
+      await manager.close();
+    }
+  });
+
   it("creates a session and transitions to waiting-input after workspace/client setup", async () => {
     const workspaceDeferred = deferred();
     const clientHarness = createClientHarness();

--- a/test/telegram_session_manager.test.js
+++ b/test/telegram_session_manager.test.js
@@ -223,7 +223,7 @@ describe("telegram session manager", () => {
         createProtocolSnapshot({ lifecycle: "running" }),
       );
       await expect(manager.recordPrompt(created.id, "review")).rejects.toThrow(
-        "Wait for Tau to finish",
+        "wait for Tau to finish",
       );
       harness.session.resolvePrompt.mockRejectedValueOnce(new Error("Prompt file is missing"));
       await expect(manager.recordPrompt(created.id, "review")).rejects.toThrow(
@@ -234,9 +234,9 @@ describe("telegram session manager", () => {
       const recording = manager.recordPrompt(created.id, "review");
       await manager.sendMessage(created.id, "go");
       resolution.resolve({ promptId: "review", text: "Another body" });
-      await expect(recording).rejects.toThrow("Wait for Tau to finish");
+      await expect(recording).rejects.toThrow("wait for Tau to finish");
       await expect(manager.recordPrompt(created.id, "review")).rejects.toThrow(
-        "Wait for Tau to finish",
+        "wait for Tau to finish",
       );
       expect(harness.session.record).toHaveBeenCalledTimes(1);
       expect(harness.session.interrupt).not.toHaveBeenCalled();


### PR DESCRIPTION
## why

Saved prompts are available to Telegram sessions but previously had no Telegram interaction. The agreed flow in #491 adds a prompt to the conversation without immediately starting or interrupting an agent turn.

## what

Add `/prompt` with a paginated inline picker backed by the active session’s prompt catalog. Selection lazily resolves the current body and records it through the existing SDK operation, only while idle. After recording succeeds, the picker is replaced with the prompt and an instruction to send another message when ready; long text continues in additional messages.

Pickers are chat- and session-bound and become non-actionable after success. Duplicate taps and pickers from replaced sessions cannot append another message. Regression coverage exercises pagination, single-use selection, stale sessions, resolution failures, and work starting during lazy resolution.

## details

The interaction uses `/prompt` without an ID argument, matching the agreed button-selection flow. Only the newest picker per chat remains active, pages contain up to 20 prompts, and runner restarts expire pickers. Recorded prompts remain ordinary durable user messages, not drafts. Selection leaves pending attachments and group context for the next normal submission.

The manager checks both runner activity and host snapshot lifecycle/maintenance state before recording. This reuses the existing session protocol rather than introducing a new recording mode.

Registering the eleventh built-in command reduces the maximum visible projects per bot from 90 to 89 under Telegram’s 100-command limit. Configuration validation and documentation reflect that change. The detailed interaction documentation lives on the existing prompts page, with a link from the Telegram command table, to stay within the packaged documentation size limit.

fixes #491
